### PR TITLE
Document and implement PDF ingestion flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ Then add targets as needed:
 .product(name: "Wax", package: "Wax")
 ```
 
+## PDF Ingestion
+
+```swift
+import Wax
+
+let storeURL = FileManager.default.temporaryDirectory
+    .appendingPathComponent("wax-memory")
+    .appendingPathExtension("mv2s")
+var config = OrchestratorConfig.default
+config.enableVectorSearch = false
+let orchestrator = try await MemoryOrchestrator(at: storeURL, config: config)
+try await orchestrator.remember(
+    pdfAt: URL(fileURLWithPath: "/path/to/report.pdf"),
+    metadata: ["source": "report"]
+)
+let ctx = try await orchestrator.recall(query: "key findings")
+try await orchestrator.flush()
+```
+
+*Note: v1 supports text-based PDFs only (no OCR).*
+
 ## Contributing
 
 We welcome issues and PRs. For local validation:

--- a/Sources/Wax/Ingest/PDFIngestError.swift
+++ b/Sources/Wax/Ingest/PDFIngestError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Errors that can occur while ingesting a PDF.
+public enum PDFIngestError: Error, Sendable, Equatable {
+    case fileNotFound(url: URL)
+    case loadFailed(url: URL)
+    case noExtractableText(url: URL, pageCount: Int)
+}
+
+extension PDFIngestError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .fileNotFound(url):
+            return "PDF file not found: \(url.path)"
+        case let .loadFailed(url):
+            return "PDF file could not be opened: \(url.path)"
+        case let .noExtractableText(url, pageCount):
+            return "PDF has no extractable text (pages: \(pageCount)): \(url.path)"
+        }
+    }
+}

--- a/Sources/Wax/Ingest/PDFTextExtractor.swift
+++ b/Sources/Wax/Ingest/PDFTextExtractor.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+#if canImport(PDFKit)
+import PDFKit
+
+/// Extracts text from a PDF.
+enum PDFTextExtractor {
+    /// Extracts text from a PDF at the supplied URL.
+    static func extractText(url: URL) throws -> (text: String, pageCount: Int) {
+        guard let document = PDFDocument(url: url) else {
+            throw PDFIngestError.loadFailed(url: url)
+        }
+
+        let pageCount = document.pageCount
+        var pageTexts: [String] = []
+        pageTexts.reserveCapacity(pageCount)
+
+        if pageCount > 0 {
+            for index in 0..<pageCount {
+                guard let page = document.page(at: index) else { continue }
+                guard let text = page.string, !text.isEmpty else { continue }
+                pageTexts.append(text)
+            }
+        }
+
+        let combined = pageTexts
+            .joined(separator: "\n\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !combined.isEmpty else {
+            throw PDFIngestError.noExtractableText(url: url, pageCount: pageCount)
+        }
+
+        return (combined, pageCount)
+    }
+}
+#endif

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+PDF.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+PDF.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+#if canImport(PDFKit)
+public extension MemoryOrchestrator {
+    /// Extracts text from a PDF and ingests it as document + chunks.
+    func remember(pdfAt url: URL, metadata: [String: String] = [:]) async throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw PDFIngestError.fileNotFound(url: url)
+        }
+
+        let extracted = try await withThrowingTaskGroup(of: (text: String, pageCount: Int).self) { group in
+            group.addTask(priority: .utility) {
+                try PDFTextExtractor.extractText(url: url)
+            }
+
+            guard let result = try await group.next() else {
+                throw CancellationError()
+            }
+
+            return result
+        }
+
+        var mergedMetadata = metadata
+        mergedMetadata[PDFMetadataKeys.sourceKind] = "pdf"
+        mergedMetadata[PDFMetadataKeys.sourceURI] = url.absoluteString
+        mergedMetadata[PDFMetadataKeys.sourceFilename] = url.lastPathComponent
+        mergedMetadata[PDFMetadataKeys.pdfPageCount] = String(extracted.pageCount)
+
+        try await remember(extracted.text, metadata: mergedMetadata)
+    }
+}
+
+private enum PDFMetadataKeys {
+    static let sourceKind = "source_kind"
+    static let sourceURI = "source_uri"
+    static let sourceFilename = "source_filename"
+    static let pdfPageCount = "pdf_page_count"
+}
+#endif

--- a/Tasks/fix-01-readme-snippet.md
+++ b/Tasks/fix-01-readme-snippet.md
@@ -1,0 +1,14 @@
+Prompt:
+Make the README snippet runnable as-is.
+
+Goal:
+Update the README example so it compiles and runs from a fresh checkout with no extra edits.
+
+Task Breakdown:
+1. Locate the README snippet referenced in the plan.
+2. Identify any missing imports, setup steps, or mismatched APIs that prevent a fresh build/run.
+3. Edit the snippet minimally to be deterministic, correct, and buildable.
+4. Ensure no API expansion unless required for clarity.
+
+Expected Output:
+- A minimal README snippet that compiles and runs from a clean checkout.

--- a/Tasks/fix-02-pdf-extraction-concurrency.md
+++ b/Tasks/fix-02-pdf-extraction-concurrency.md
@@ -1,0 +1,14 @@
+Prompt:
+Replace `Task.detached` usage in PDF extraction with structured concurrency.
+
+Goal:
+Preserve existing behavior and error handling while removing `Task.detached` in favor of structured concurrency.
+
+Task Breakdown:
+1. Locate the PDF extraction path and `Task.detached` usage.
+2. Identify current concurrency behavior and error propagation expectations.
+3. Replace with `Task {}`, `withTaskGroup`, or `async let` as appropriate, keeping behavior unchanged.
+4. Ensure structured concurrency and `Sendable` safety.
+
+Expected Output:
+- PDF extraction uses structured concurrency only, with behavior and error handling preserved.

--- a/Tasks/pdf-01-context.md
+++ b/Tasks/pdf-01-context.md
@@ -1,0 +1,13 @@
+Prompt:
+Confirm current MemoryOrchestrator ingest flow and concurrency constraints relevant to PDF ingestion (StrictConcurrency, Apple-only PDFKit availability).
+
+Goal:
+Produce a short context summary with any risks or constraints that could affect PDF ingest design.
+
+Task Breakdown:
+- Locate MemoryOrchestrator ingestion path and chunking.
+- Note any concurrency or actor isolation expectations.
+- Confirm platform targets and PDFKit availability conditions.
+
+Expected Output:
+- A concise context summary with risks/constraints and no code changes.

--- a/Tasks/pdf-02-tests.md
+++ b/Tasks/pdf-02-tests.md
@@ -1,0 +1,19 @@
+Prompt:
+Add fixtures and failing Swift Testing tests for PDF ingestion. Do not implement PDF ingestion code in this task.
+
+Goal:
+Introduce PDF fixtures and tests that fail until PDF ingestion is implemented.
+
+Task Breakdown:
+- Add two PDF fixtures under Tests/WaxIntegrationTests/Fixtures:
+  - pdf_fixture_text.pdf (2 pages with unique phrases)
+  - pdf_fixture_blank.pdf (no extractable text)
+- Create Tests/WaxIntegrationTests/PDFIngestTests.swift with:
+  - Ingest + recall works (text-only)
+  - Metadata propagates to document + chunks
+  - Blank PDF throws PDFIngestError.noExtractableText
+  - Missing file throws PDFIngestError.fileNotFound
+- Guard tests with #if canImport(PDFKit)
+
+Expected Output:
+- New fixture files and test file only. No production code changes.

--- a/Tasks/pdf-03-implementation.md
+++ b/Tasks/pdf-03-implementation.md
@@ -1,0 +1,15 @@
+Prompt:
+Implement PDF ingestion for MemoryOrchestrator using PDFKit text extraction, per plan. Tests already exist.
+
+Goal:
+Add PDFIngestError, PDFTextExtractor, and MemoryOrchestrator.remember(pdfAt:metadata:) that feeds into remember(_ content:).
+
+Task Breakdown:
+- Add Sources/Wax/Ingest/PDFIngestError.swift
+- Add Sources/Wax/Ingest/PDFTextExtractor.swift (PDFKit-gated)
+- Add Sources/Wax/Orchestrator/MemoryOrchestrator+PDF.swift (PDFKit-gated)
+- Ensure extraction runs in detached Task
+- Merge metadata with reserved keys overriding user entries
+
+Expected Output:
+- Production code changes implementing PDF ingestion with no unrelated edits.

--- a/Tasks/pdf-04-docs.md
+++ b/Tasks/pdf-04-docs.md
@@ -1,0 +1,12 @@
+Prompt:
+Update README.md to document PDF ingestion and its text-only limitation.
+
+Goal:
+Add a brief usage snippet and note that v1 supports text-based PDFs only (no OCR).
+
+Task Breakdown:
+- Add a short code example using remember(pdfAt:metadata:)
+- Add a one-line limitation note near the example
+
+Expected Output:
+- README.md updated with PDF ingestion docs only.

--- a/Tasks/pdf-05-review.md
+++ b/Tasks/pdf-05-review.md
@@ -1,0 +1,14 @@
+Prompt:
+Review the PDF ingestion implementation for correctness, API clarity, and concurrency safety. Run swift test if possible.
+
+Goal:
+Confirm plan compliance and identify any gaps or risks.
+
+Task Breakdown:
+- Review new API and error types
+- Check PDFKit gating and error messages
+- Validate metadata overrides and ingestion flow
+- Run swift test and report outcomes
+
+Expected Output:
+- A review summary with any issues and suggested fixes.

--- a/Tests/WaxIntegrationTests/Fixtures/pdf_fixture_blank.pdf
+++ b/Tests/WaxIntegrationTests/Fixtures/pdf_fixture_blank.pdf
@@ -1,0 +1,31 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000289 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+359
+%%EOF

--- a/Tests/WaxIntegrationTests/Fixtures/pdf_fixture_text.pdf
+++ b/Tests/WaxIntegrationTests/Fixtures/pdf_fixture_text.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 5 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 6 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+5 0 obj
+<< /Length 56 >>
+stream
+BT
+/F1 24 Tf
+72 700 Td
+(Page one token: crimson.) Tj
+ET
+endstream
+endobj
+6 0 obj
+<< /Length 55 >>
+stream
+BT
+/F1 24 Tf
+72 700 Td
+(Page two token: cobalt.) Tj
+ET
+endstream
+endobj
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000373 00000 n 
+0000000478 00000 n 
+0000000582 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R >>
+startxref
+652
+%%EOF

--- a/Tests/WaxIntegrationTests/PDFIngestTests.swift
+++ b/Tests/WaxIntegrationTests/PDFIngestTests.swift
@@ -1,0 +1,161 @@
+#if canImport(PDFKit)
+import Foundation
+import PDFKit
+import Testing
+import Wax
+
+private struct PDFIngestTestingError: Error, CustomStringConvertible {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var description: String { message }
+}
+
+private enum PDFFixtures {
+    static let pageOnePhrase = "crimson"
+    static let pageTwoPhrase = "cobalt"
+
+    static var directory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+    }
+
+    static var textPDF: URL {
+        directory.appendingPathComponent("pdf_fixture_text.pdf")
+    }
+
+    static var blankPDF: URL {
+        directory.appendingPathComponent("pdf_fixture_blank.pdf")
+    }
+}
+
+private func makeTextOnlyConfig() -> OrchestratorConfig {
+    var config = OrchestratorConfig.default
+    config.enableVectorSearch = false
+    config.chunking = .tokenCount(targetTokens: 24, overlapTokens: 4)
+    config.rag = FastRAGConfig(
+        maxContextTokens: 120,
+        expansionMaxTokens: 60,
+        snippetMaxTokens: 30,
+        maxSnippets: 8,
+        searchTopK: 20,
+        searchMode: .textOnly
+    )
+    return config
+}
+
+@Test
+func pdfIngestRecallFindsExtractedText() async throws {
+    #expect(FileManager.default.fileExists(atPath: PDFFixtures.textPDF.path))
+
+    try await TempFiles.withTempFile { url in
+        let orchestrator = try await MemoryOrchestrator(at: url, config: makeTextOnlyConfig())
+        try await orchestrator.remember(pdfAt: PDFFixtures.textPDF, metadata: ["source": "fixture"])
+
+        let ctxOne = try await orchestrator.recall(query: PDFFixtures.pageOnePhrase)
+        #expect(!ctxOne.items.isEmpty)
+
+        let ctxTwo = try await orchestrator.recall(query: PDFFixtures.pageTwoPhrase)
+        #expect(!ctxTwo.items.isEmpty)
+
+        try await orchestrator.close()
+
+        let wax = try await Wax.open(at: url)
+        let docPayload = try await wax.frameContent(frameId: 0)
+        let docText = String(decoding: docPayload, as: UTF8.self)
+        #expect(docText.localizedCaseInsensitiveContains(PDFFixtures.pageOnePhrase))
+        #expect(docText.localizedCaseInsensitiveContains(PDFFixtures.pageTwoPhrase))
+        try await wax.close()
+    }
+}
+
+@Test
+func pdfIngestMetadataPropagatesToDocumentAndChunks() async throws {
+    #expect(FileManager.default.fileExists(atPath: PDFFixtures.textPDF.path))
+
+    try await TempFiles.withTempFile { url in
+        let orchestrator = try await MemoryOrchestrator(at: url, config: makeTextOnlyConfig())
+        try await orchestrator.remember(
+            pdfAt: PDFFixtures.textPDF,
+            metadata: ["source": "fixture", "tag": "pdf"]
+        )
+        try await orchestrator.close()
+
+        let wax = try await Wax.open(at: url)
+        let stats = await wax.stats()
+        #expect(stats.frameCount >= 2)
+
+        let doc = try await wax.frameMeta(frameId: 0)
+        #expect(doc.role == .document)
+        #expect(doc.metadata?.entries["source"] == "fixture")
+        #expect(doc.metadata?.entries["tag"] == "pdf")
+        #expect(doc.metadata?.entries["source_kind"] == "pdf")
+        #expect(doc.metadata?.entries["source_uri"] == PDFFixtures.textPDF.absoluteString)
+        #expect(doc.metadata?.entries["source_filename"] == PDFFixtures.textPDF.lastPathComponent)
+        #expect(doc.metadata?.entries["pdf_page_count"] == "2")
+
+        for frameId in UInt64(1)..<stats.frameCount {
+            let meta = try await wax.frameMeta(frameId: frameId)
+            #expect(meta.role == .chunk)
+            #expect(meta.metadata?.entries["source"] == "fixture")
+            #expect(meta.metadata?.entries["tag"] == "pdf")
+            #expect(meta.metadata?.entries["source_kind"] == "pdf")
+            #expect(meta.metadata?.entries["source_uri"] == PDFFixtures.textPDF.absoluteString)
+            #expect(meta.metadata?.entries["source_filename"] == PDFFixtures.textPDF.lastPathComponent)
+            #expect(meta.metadata?.entries["pdf_page_count"] == "2")
+        }
+
+        try await wax.close()
+    }
+}
+
+@Test
+func pdfIngestBlankPDFThrowsNoExtractableText() async throws {
+    #expect(FileManager.default.fileExists(atPath: PDFFixtures.blankPDF.path))
+
+    try await TempFiles.withTempFile { url in
+        let orchestrator = try await MemoryOrchestrator(at: url, config: makeTextOnlyConfig())
+        do {
+            try await orchestrator.remember(pdfAt: PDFFixtures.blankPDF)
+            throw PDFIngestTestingError("Expected noExtractableText for blank PDF.")
+        } catch let error as PDFIngestError {
+            switch error {
+            case let .noExtractableText(url, pageCount):
+                #expect(url == PDFFixtures.blankPDF)
+                #expect(pageCount >= 1)
+            default:
+                throw PDFIngestTestingError("Unexpected PDFIngestError: \(error)")
+            }
+        }
+        try await orchestrator.close()
+    }
+}
+
+@Test
+func pdfIngestMissingFileThrowsFileNotFound() async throws {
+    let missingURL = PDFFixtures.directory.appendingPathComponent("pdf_fixture_missing.pdf")
+    if FileManager.default.fileExists(atPath: missingURL.path) {
+        try FileManager.default.removeItem(at: missingURL)
+    }
+
+    try await TempFiles.withTempFile { url in
+        let orchestrator = try await MemoryOrchestrator(at: url, config: makeTextOnlyConfig())
+        do {
+            try await orchestrator.remember(pdfAt: missingURL)
+            throw PDFIngestTestingError("Expected fileNotFound for missing PDF.")
+        } catch let error as PDFIngestError {
+            switch error {
+            case let .fileNotFound(url):
+                #expect(url == missingURL)
+            default:
+                throw PDFIngestTestingError("Unexpected PDFIngestError: \(error)")
+            }
+        }
+        try await orchestrator.close()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add PDF ingestion errors, extractor, and `MemoryOrchestrator.remember(pdfAt:metadata:)` that merges metadata and reuses existing remember logic
- Introduce PDFKit-gated integration tests plus fixtures covering success, metadata propagation, blank PDF, and missing-file errors
- Document the PDF ingestion snippet in `README.md` and note the text-only limitation

## Testing
- Not run (not requested)