### PR TITLE
refactor: use opaque `some` types instead of existential `any` in function parameters

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -4,7 +4,7 @@ import WaxCore
 public protocol MaintenableMemory: Sendable {
     func optimizeSurrogates(
         options: MaintenanceOptions,
-        generator: any SurrogateGenerator
+        generator: some SurrogateGenerator
     ) async throws -> MaintenanceReport
 
     func compactIndexes(options: MaintenanceOptions) async throws -> MaintenanceReport
@@ -38,7 +38,7 @@ public extension MemoryOrchestrator {
 
     func optimizeSurrogates(
         options: MaintenanceOptions,
-        generator: any SurrogateGenerator
+        generator: some SurrogateGenerator
     ) async throws -> MaintenanceReport {
         let start = ContinuousClock.now
 

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -277,7 +277,7 @@ public actor MemoryOrchestrator {
     /// Minimizes cache lookups and maximizes batch embedding efficiency.
     private static func prepareEmbeddingsBatchOptimized(
         chunks: [String],
-        embedder: any EmbeddingProvider,
+        embedder: some EmbeddingProvider,
         cache: EmbeddingMemoizer?
     ) async throws -> [[Float]] {
         var results: [[Float]] = Array(repeating: [], count: chunks.count)
@@ -364,7 +364,7 @@ public actor MemoryOrchestrator {
     /// Legacy method for backward compatibility
     private static func prepareEmbeddingsBatch(
         chunks: [String],
-        embedder: any EmbeddingProvider,
+        embedder: some EmbeddingProvider,
         cache: EmbeddingMemoizer?
     ) async throws -> [[Float]] {
         try await prepareEmbeddingsBatchOptimized(chunks: chunks, embedder: embedder, cache: cache)
@@ -532,7 +532,7 @@ public actor MemoryOrchestrator {
 
     private static func embedOne(
         _ text: String,
-        embedder: any EmbeddingProvider,
+        embedder: some EmbeddingProvider,
         cache: EmbeddingMemoizer?
     ) async throws -> [Float] {
         let key = EmbeddingKey.make(
@@ -555,7 +555,7 @@ public actor MemoryOrchestrator {
 
     private static func prepareEmbeddings(
         chunks: [String],
-        embedder: any EmbeddingProvider,
+        embedder: some EmbeddingProvider,
         cache: EmbeddingMemoizer?
     ) async throws -> [Int: [Float]] {
         var out: [Int: [Float]] = [:]

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -414,7 +414,7 @@ public actor WaxSession {
         }
     }
 
-    private func stageVectorForCommit(using engine: any VectorSearchEngine) async throws {
+    private func stageVectorForCommit(using engine: some VectorSearchEngine) async throws {
         let snapshot = await wax.pendingEmbeddingMutations(since: lastPendingEmbeddingSequence)
         if let latest = snapshot.latestSequence,
            let last = lastPendingEmbeddingSequence,


### PR DESCRIPTION
Swift 6.2 generics modernization — replace `any Protocol` with `some Protocol`
in function parameters where the protocol value is consumed but not stored.
This enables static dispatch via implicit generic specialization (SE-0352)
and better communicates that these functions accept a single concrete type
rather than a type-erased existential.

Changes:
- MemoryOrchestrator: 4 private static helpers now use `some EmbeddingProvider`
  (prepareEmbeddingsBatchOptimized, prepareEmbeddingsBatch, embedOne,
   prepareEmbeddings)
- MaintenableMemory protocol: requirement uses `some SurrogateGenerator`
- MemoryOrchestrator+Maintenance: implementation matches protocol with `some`
- WaxSession: stageVectorForCommit uses `some VectorSearchEngine`

Stored properties and return types that require type erasure (returning
different concrete types) correctly retain `any`.

https://claude.ai/code/session_01M5G6dSJa1srXqrTEtGv7n2