### PR TITLE
Auto-disable vector search when no embedder provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ```swift
 import Wax
 
-// Create a memory file
+// Create a memory file (text search, works out of the box)
 let brain = try await MemoryOrchestrator(
     at: URL(fileURLWithPath: "brain.mv2s")
 )
@@ -44,6 +44,15 @@ try await brain.remember(
 let context = try await brain.recall(query: "user preferences")
 // → "User prefers dark mode and gets headaches from bright screens"
 //   + relevant context, ranked and token-budgeted
+```
+
+Want hybrid vector + text search? Use the built-in MiniLM embedder:
+
+```swift
+// Hybrid search with on-device embeddings (MiniLM, 384-dim)
+let brain = try await MemoryOrchestrator.openMiniLM(
+    at: URL(fileURLWithPath: "brain.mv2s")
+)
 ```
 
 No Docker. No network calls.


### PR DESCRIPTION
## Summary
Changed `MemoryOrchestrator` initialization to automatically disable vector search when no embedder is provided and no pre-existing vector index exists, rather than throwing an error. This allows the simple `MemoryOrchestrator(at:)` initializer to work out-of-the-box with text-only search.

## Key Changes
- **Auto-disable vector search**: When `enableVectorSearch=true` in config but no embedder is provided and no committed vector index exists, the config is automatically adjusted to disable vector search instead of throwing a `WaxError`
- **Config resolution**: Introduced `resolvedConfig` variable to apply this logic before storing the final config
- **Removed error path**: Eliminated the explicit error throw that previously required an embedder when vector search was enabled
- **Updated README**: Added documentation showing the simple text-only usage pattern and introduced the new `openMiniLM()` convenience method for hybrid search

## Implementation Details
- The auto-disable logic checks three conditions: `enableVectorSearch` is true, `embedder` is nil, and no committed vector index manifest exists
- All subsequent config references use `resolvedConfig` to ensure consistency
- This change maintains backward compatibility while improving the default user experience for text-only search scenarios

https://claude.ai/code/session_01X25YygEqmZtSTmeVYxyhRy