### PR TITLE
Fix force-unwrapped time-range validation in FTS5SearchEngine and add regression test

### DIFF
--- a/Sources/WaxTextSearch/FTS5SearchEngine.swift
+++ b/Sources/WaxTextSearch/FTS5SearchEngine.swift
@@ -220,10 +220,10 @@ public actor FTS5SearchEngine {
         system: StructuredTimeRange,
         evidence: [StructuredEvidence]
     ) async throws -> FactRowID {
-        guard valid.toMs == nil || valid.toMs! > valid.fromMs else {
+        if let validToMs = valid.toMs, validToMs <= valid.fromMs {
             throw WaxError.encodingError(reason: "valid_to_ms must be greater than valid_from_ms")
         }
-        guard system.toMs == nil || system.toMs! > system.fromMs else {
+        if let systemToMs = system.toMs, systemToMs <= system.fromMs {
             throw WaxError.encodingError(reason: "system_to_ms must be greater than system_from_ms")
         }
 

--- a/Tests/WaxIntegrationTests/StructuredMemoryCRUDTests.swift
+++ b/Tests/WaxIntegrationTests/StructuredMemoryCRUDTests.swift
@@ -16,6 +16,33 @@ import Wax
     #expect(matches.map(\.key) == [EntityKey("person:alice")])
 }
 
+
+@Test func assertFactRejectsInvalidTimeRanges() async throws {
+    let engine = try FTS5SearchEngine.inMemory()
+
+    await #expect(throws: WaxError.self) {
+        _ = try await engine.assertFact(
+            subject: EntityKey("person:alice"),
+            predicate: PredicateKey("status"),
+            object: .string("active"),
+            valid: StructuredTimeRange(fromMs: 10, toMs: 10),
+            system: StructuredTimeRange(fromMs: 0, toMs: nil),
+            evidence: []
+        )
+    }
+
+    await #expect(throws: WaxError.self) {
+        _ = try await engine.assertFact(
+            subject: EntityKey("person:alice"),
+            predicate: PredicateKey("status"),
+            object: .string("active"),
+            valid: StructuredTimeRange(fromMs: 0, toMs: nil),
+            system: StructuredTimeRange(fromMs: 50, toMs: 49),
+            evidence: []
+        )
+    }
+}
+
 @Test func assertFactAndQueryAsOfReturnsCurrentFact() async throws {
     let engine = try FTS5SearchEngine.inMemory()
     _ = try await engine.upsertEntity(


### PR DESCRIPTION
### Motivation
- Remove crash-prone force-unwrapping in structured fact validation and make the check safe while keeping existing validation semantics.
- Add a regression test to prevent future regressions around `StructuredTimeRange` bounds for both valid-time and system-time windows.

### Description
- Replaced force-unwrapped comparisons in `FTS5SearchEngine.assertFact(...)` with safe optional binding for `valid.toMs` and `system.toMs` to avoid runtime crashes (`Sources/WaxTextSearch/FTS5SearchEngine.swift`).
- Added `assertFactRejectsInvalidTimeRanges` to `Tests/WaxIntegrationTests/StructuredMemoryCRUDTests.swift` which verifies that assertions with invalid `valid` or `system` ranges throw `WaxError`.

### Testing
- Attempted to run `swift test --filter StructuredMemoryCRUDTests`, but test execution stopped early because the package manifest references a non-existent test path: `invalid custom path 'Tests/WaxTests' for target 'waxTests'`, so the newly added test could not be executed in CI here.
- The change is small and behavior-preserving for valid inputs; the new test was added to the integration suite so it will run once the package manifest issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9170f0c8832aacdd7e560d2d1666)