### PR TITLE
Harden unsafe unwraps, validate temporal bounds, and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,226 +1,126 @@
 <div align="center">
 
-<br/><img width="2816" height="1536" alt="Gemini_Generated_Image_3m176s3m176s3m17" src="https://github.com/user-attachments/assets/63eadebd-a738-4483-a39f-50b2a0d41f98" />
+# Wax
 
+**On-device long-term memory for Swift AI apps and agents on iOS/macOS.**
 
 <img src="https://img.shields.io/badge/Swift-6.2-F05138?style=flat&logo=swift&logoColor=white" />
-<img src="https://img.shields.io/badge/platform-iOS%20%7C%20macOS-blue?style=flat&logo=apple" />
-<img src="https://img.shields.io/badge/license-MIT-green?style=flat" />
-<img src="https://img.shields.io/github/stars/christopherkarani/Wax?style=flat" />
-
-<br/><br/>
-### On-device memory for iOS & macOS AI agents.
-No server. No cloud. One file.
-<br/>
+<img src="https://img.shields.io/badge/platform-iOS%2018%2B%20%7C%20macOS%2015%2B-blue?style=flat&logo=apple" />
+<img src="https://img.shields.io/badge/license-Apache%202.0-green?style=flat" />
+<img src="https://img.shields.io/github/actions/workflow/status/christopherkarani/Wax/ci.yml?branch=main&style=flat" />
 
 </div>
 
----
+Wax is a Swift-native memory framework that stores text, metadata, and retrieval indexes in one local `.wax` file so agents can remember, search, and recall context without cloud infrastructure.
 
-Most iOS AI apps lose their memory the moment the user closes them. Wax fixes that — giving your agents persistent, searchable, private memory that lives entirely on-device in a single portable file.
+## Quick start
 
 ```swift
 import Wax
 import WaxVectorSearchMiniLM
 
 let memory = try await MemoryOrchestrator.openMiniLM(
-    at: .documentsDirectory.appending(path: "agent.wax")
+    at: .documentsDirectory.appending(path: "assistant.wax")
 )
 
-// Store a memory
-try await memory.remember("User prefers concise answers and hates bullet points.")
-
-// Retrieve the most relevant context — semantically
+try await memory.remember("User prefers concise answers.")
 let context = try await memory.recall(query: "communication preferences")
+
+for item in context.items {
+    print(item.kind, item.score, item.text)
+}
 ```
 
----
-
-## Performance
-
-<div align="center">
-<img src="Resources/website/static/img/benchmarks.svg" width="800" alt="Wax Performance Benchmarks" />
-</div>
-
-<br/>
-
-## Why Wax
-
-Building AI agents on Apple platforms means juggling Core Data for persistence, FAISS or Annoy for vector search, and a tokenizer for context budgets — none of which talk to each other. Or you spin up Chroma or Pinecone and suddenly your app has a server dependency, network calls, and a privacy story you can't tell users.
-
-Wax packages all of it into one self-contained file:
-
-| Capability | Without Wax | With Wax |
-|---|---|---|
-| Document storage | Core Data / SQLite | ✅ Built-in |
-| Semantic search | External FAISS / Annoy | ✅ Built-in (HNSW) |
-| Full-text search | Another index | ✅ Built-in (BM25) |
-| Token budgeting | Manual | ✅ Automatic |
-| Crash safety | You figure it out | ✅ WAL + dual headers |
-| Server required | Often | ✅ Never |
-
----
-
-## Features
-
-- **Hybrid retrieval** — BM25 keyword search fused with HNSW vector similarity. Gets the right memory, even when wording differs.
-- **On-device embeddings** — Powered by MiniLM, running locally. No API calls, no latency, no cost.
-- **Metal acceleration** — Embedding and search use Apple Silicon GPU when available.
-- **Token budgets** — Set a hard limit. Wax automatically trims and compresses context to fit, every time.
-- **Tiered surrogates** — Store full text, a gist, or a micro-summary. Trade recall for speed at query time.
-- **Single portable file** — The whole memory store is one `.wax` file. Back it up, sync it, move it.
-- **Crash-safe by design** — Append-only format with write-ahead logging and dual headers. No corruption on unexpected exits.
-- **Swift 6 concurrency** — Fully `async/await` native with `Sendable` conformances throughout.
-
----
-
-## Installation
-
-**Swift Package Manager**
+## Installation (SPM)
 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/christopherkarani/Wax.git", from: "0.1.8")
+  .package(url: "https://github.com/christopherkarani/Wax.git", from: "0.1.8")
 ],
 targets: [
-    .target(
-        name: "MyApp",
-        dependencies: [
-            .product(name: "Wax", package: "Wax"),
-            .product(name: "WaxVectorSearchMiniLM", package: "Wax")
-        ]
-    )
+  .target(
+    name: "MyApp",
+    dependencies: [
+      .product(name: "Wax", package: "Wax"),
+      .product(name: "WaxVectorSearchMiniLM", package: "Wax")
+    ]
+  )
 ]
 ```
 
-Or in Xcode: **File → Add Package Dependencies** → paste the repo URL.
+## What Wax gives you
 
-## MCP Installer (npm)
+1. **Hybrid retrieval**: BM25 text + vector similarity.
+2. **On-device embeddings**: MiniLM provider with no network calls.
+3. **Crash-safe persistence**: WAL + dual-header file format.
+4. **RAG context building**: token-aware, ranked output for prompts.
+5. **Structured memory**: entity/predicate/fact graph with temporal queries.
+
+## Common usage patterns
+
+### 1) Remember and recall
+
+```swift
+try await memory.remember("Alex is building a SwiftUI habit tracker")
+let rag = try await memory.recall(query: "what project is Alex building?")
+```
+
+### 2) Session-aware memory
+
+```swift
+let sessionID = await memory.startSession()
+try await memory.remember("Discussed onboarding flow", metadata: ["session": sessionID.uuidString])
+await memory.endSession()
+```
+
+### 3) Maintenance and durability
+
+```swift
+try await memory.flush()                // force persisted commit
+let stats = try await memory.runtimeStats()
+print(stats.frameCount, stats.generation)
+```
+
+## When to use Wax
+
+Use Wax when you need:
+- local/private memory for iOS or macOS AI features,
+- hybrid retrieval + RAG context construction,
+- deterministic persistence without managing multiple storage systems.
+
+## When not to use Wax
+
+Wax may not be the right fit when:
+- you require multi-tenant cloud hosting as the primary storage model,
+- your target platform is outside Apple ecosystems,
+- you only need ephemeral in-memory context with no persistence.
+
+## MCP / CLI
+
+Install the MCP launcher:
 
 ```bash
 npx -y waxmcp@latest mcp install --scope user
 ```
 
-## Claude Code Integration
+Run locally:
 
-After installing the MCP server, add this to your `CLAUDE.md` so Claude Code uses Wax as its memory:
-
-<details>
-<summary><strong>CLAUDE.md snippet</strong> (click to expand)</summary>
-
-```markdown
-## Rules
-
-1. **Session start** — call `wax_handoff_latest` to resume prior context
-2. **Before answering** — call `wax_recall` to check what you already know. Always try this first.
-3. **When you learn something durable** — call `wax_remember`. Worth storing: user preferences, project decisions, architectural patterns, conventions, people/roles. Not worth storing: transient debugging, one-off commands.
-4. **When corrected** — call `wax_forget` with what changed (e.g. "we don't use Redux anymore")
-5. **Session end** — call `wax_handoff` with summary + pending tasks
-
-## Tools
-
-| Tool | When |
-|------|------|
-| `wax_remember` | User states a preference, makes a decision, or you learn a stable pattern. `project` to scope. |
-| `wax_recall` | Before answering anything that might have prior context. Use `graph: true` for relationship-aware search. |
-| `wax_forget` | User corrects you or facts become outdated. Natural language or `fact_id`. |
-| `wax_context` | Need the full picture of a specific entity (person, project, library). |
-| `wax_reflect` | Audit what you know — entity counts, top predicates, memory health. |
-| `wax_handoff` | Session ending. Pass `pending_tasks` array for continuity. |
-| `wax_handoff_latest` | Session starting. Loads last handoff. |
+```bash
+swift run wax-mcp --help
+swift run wax-cli --help
 ```
 
-</details>
+## Documentation
 
----
-
-## Quick Start
-
-```swift
-import Wax
-import WaxVectorSearchMiniLM
-
-// 1. Open (or create) a memory store
-let memory = try await MemoryOrchestrator.openMiniLM(
-    at: .documentsDirectory.appending(path: "myagent.wax")
-)
-
-// 2. Store memories
-try await memory.remember("The user's name is Alex and they live in Toronto.")
-try await memory.remember("Alex dislikes formal language. Keep responses casual.")
-try await memory.remember("Alex is building a habit tracker in SwiftUI.")
-
-// 3. Retrieve relevant context for a prompt
-let context = try await memory.recall(query: "how should I address the user?")
-print(context.items.map(\.text))
-```
-
----
-
-## Use Cases
-
-- **Conversational agents** that remember preferences, history, and facts across sessions
-- **Note-taking apps** with semantic search ("find everything I wrote about WWDC")
-- **Photo & video apps** that index captions and transcripts for natural-language lookup
-- **Personal assistants** that learn user habits without sending data off-device
-- **RAG pipelines** built entirely on-device for sensitive or offline-first applications
-
----
-
-## Requirements
-
-| | Minimum |
-|---|---|
-| Swift | 6.2 |
-| iOS | 17.0 |
-| macOS | 14.0 |
-| Xcode | 16.0 |
-
-Apple Silicon recommended for GPU-accelerated embedding. Intel Macs fall back to CPU seamlessly.
-
----
-
-## Comparison
-
-| | Wax | ChromaDB | Pinecone | Core Data + FAISS |
-|---|---|---|---|---|
-| On-device | ✅ | ❌ | ❌ | ✅ |
-| No server | ✅ | ❌ | ❌ | ✅ |
-| Hybrid search | ✅ | ✅ | ✅ | Manual |
-| Token budgeting | ✅ | ❌ | ❌ | ❌ |
-| Single file | ✅ | ❌ | ❌ | ❌ |
-| Swift-native API | ✅ | ❌ | ❌ | Partial |
-| Privacy (data stays on device) | ✅ | ❌ | ❌ | ✅ |
-
----
-
-## Roadmap
-
-- [ ] CloudKit sync (opt-in, encrypted)
-- [ ] iCloud Drive `.wax` document support
-- [ ] Memory clustering and deduplication
-- [ ] Quantized embedding models for smaller footprint
-- [ ] Instruments template for memory profiling
-
----
+- Core docs: `Sources/WaxCore/WaxCore.docc`
+- Orchestrator docs: `Resources/website/docs/orchestrator`
+- MiniLM docs: `Sources/WaxVectorSearchMiniLM/WaxVectorSearchMiniLM.docc`
 
 ## Contributing
 
-Issues and PRs are welcome. If you're building something with Wax, open a Discussion — would love to see what you're working on.
-
----
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=christopherkarani/wax&type=date&legend=top-left)](https://www.star-history.com/#christopherkarani/wax&type=date&legend=top-left)
+Contributions are welcome. Please open an issue/discussion for design changes and include tests with PRs.
 
 ## License
 
-Apache 2.0 © [Christopher Karani](https://github.com/christopherkarani)
-
----
-
-<div align="center">
-<sub>Built for developers who believe user data belongs on the user's device.</sub>
-</div>
+Apache 2.0. See [LICENSE](LICENSE).

--- a/Sources/WaxTextSearch/FTS5SearchEngine.swift
+++ b/Sources/WaxTextSearch/FTS5SearchEngine.swift
@@ -220,10 +220,10 @@ public actor FTS5SearchEngine {
         system: StructuredTimeRange,
         evidence: [StructuredEvidence]
     ) async throws -> FactRowID {
-        guard valid.toMs == nil || valid.toMs! > valid.fromMs else {
+        if let validToMs = valid.toMs, validToMs <= valid.fromMs {
             throw WaxError.encodingError(reason: "valid_to_ms must be greater than valid_from_ms")
         }
-        guard system.toMs == nil || system.toMs! > system.fromMs else {
+        if let systemToMs = system.toMs, systemToMs <= system.fromMs {
             throw WaxError.encodingError(reason: "system_to_ms must be greater than system_from_ms")
         }
 

--- a/Sources/WaxVectorSearch/MetalVectorEngine.swift
+++ b/Sources/WaxVectorSearch/MetalVectorEngine.swift
@@ -470,7 +470,8 @@ public actor MetalVectorEngine {
 
             var currentVectorCount = UInt32(vectorCount)
             withUnsafeBytes(of: &currentVectorCount) { raw in
-                transientCountBuffer.contents().copyMemory(from: raw.baseAddress!, byteCount: raw.count)
+                guard let source = raw.baseAddress else { return }
+                transientCountBuffer.contents().copyMemory(from: source, byteCount: raw.count)
             }
 
             guard let commandBuffer = commandQueue.makeCommandBuffer() else {
@@ -494,7 +495,12 @@ public actor MetalVectorEngine {
             let threadgroupMemorySize = dimensions * MemoryLayout<Float>.stride
             computeEncoder.setThreadgroupMemoryLength(threadgroupMemorySize, index: 0)
 
-            let activePipeline = (useSIMD8 && computePipelineSIMD8 != nil) ? computePipelineSIMD8! : computePipeline
+            let activePipeline: MTLComputePipelineState
+            if useSIMD8, let computePipelineSIMD8 {
+                activePipeline = computePipelineSIMD8
+            } else {
+                activePipeline = computePipeline
+            }
             computeEncoder.setComputePipelineState(activePipeline)
 
             let maxThreads = activePipeline.maxTotalThreadsPerThreadgroup

--- a/Sources/WaxVectorSearchMiniLM/CoreML/all-MiniLM-L6-v2.swift
+++ b/Sources/WaxVectorSearchMiniLM/CoreML/all-MiniLM-L6-v2.swift
@@ -51,7 +51,11 @@ public class all_MiniLM_L6_v2Output : MLFeatureProvider {
 
     /// var_554 as multidimensional array of 16-bit floats
     public var var_554: MLMultiArray {
-        provider.featureValue(for: "var_554")!.multiArrayValue!
+        guard let feature = provider.featureValue(for: "var_554"),
+              let multiArray = feature.multiArrayValue else {
+            fatalError("Model output 'var_554' is missing or has unexpected type")
+        }
+        return multiArray
     }
 
     /// var_554 as multidimensional array of 16-bit floats
@@ -93,7 +97,10 @@ public class all_MiniLM_L6_v2 {
         }
         #endif
         let bundle = Bundle(for: self)
-        return bundle.url(forResource: "all-MiniLM-L6-v2", withExtension: "mlmodelc")!
+        guard let url = bundle.url(forResource: "all-MiniLM-L6-v2", withExtension: "mlmodelc") else {
+            fatalError("Could not find all-MiniLM-L6-v2.mlmodelc in bundle")
+        }
+        return url
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Remove risky force-unwraps and fragile runtime paths that can crash in edge conditions (GPU pipeline setup, generated CoreML wrapper, and temporal validation).
- Improve developer onboarding and first-run experience by surfacing a compact, actionable `README` quick-start.

### Description

- Replaced a force-unwrapped raw pointer copy in `MetalVectorEngine.search` with a guarded `withUnsafeBytes` unwrap and removed a forced pipeline unwrap by selecting the active pipeline with explicit optional binding in `Sources/WaxVectorSearch/MetalVectorEngine.swift`.
- Replaced `guard ... toMs! > ...` style checks with safe `if let` validations for `valid.toMs` and `system.toMs` in `Sources/WaxTextSearch/FTS5SearchEngine.swift` to avoid force-unwrapping temporal bounds.
- Hardened generated CoreML wrapper `Sources/WaxVectorSearchMiniLM/CoreML/all-MiniLM-L6-v2.swift` by guarding the model output lookup and bundle URL lookup and emitting clear `fatalError` messages instead of force-unwrapping optional values.
- Rewrote and trimmed the top-level `README.md` to present a one-line purpose, a visible quick-start example, SPM install snippet, clear capability list, and when-to-use guidance for production onboarding.

### Testing

- Attempted `swift test --filter WaxCoreTests --filter WaxIntegrationTests/READMEExamplesTests`, but the invocation failed early due to an existing package manifest issue: `error: 'wax': invalid custom path 'Tests/WaxTests' for target 'waxTests'` (this is a pre-existing project config problem and blocked running the full test suite).
- Per-file static safety checks were performed (grep/inspection) on the modified files to confirm the removed force-unwrap patterns; those checks passed for the updated files.
- Changes were committed locally: the patch includes edits to `MetalVectorEngine.swift`, `FTS5SearchEngine.swift`, `all-MiniLM-L6-v2.swift`, and `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa92122b4c832ab09d3ebb0def56e9)