### PR TITLE
Fix Swift 6.3 CoreML sendability build errors

### DIFF
--- a/Sources/WaxVectorSearchArctic/CoreML/ArcticEmbeddings.swift
+++ b/Sources/WaxVectorSearchArctic/CoreML/ArcticEmbeddings.swift
@@ -135,7 +135,7 @@ package final class ArcticEmbeddings {
         let localModel = model
         return await withCheckedContinuation { continuation in
             Self.predictionQueue.async {
-                let output = try? localModel.prediction(
+                let output: snowflake_arctic_embed_sOutput? = try? localModel.prediction(
                     input_ids: inputIds,
                     attention_mask: attentionMask
                 )
@@ -212,6 +212,15 @@ package final class ArcticEmbeddings {
     }
 
 }
+
+// MARK: - Sendable Conformances for CoreML Types
+// These auto-generated CoreML wrapper types are safe for concurrent prediction
+// and produce immutable output objects. @unchecked Sendable is appropriate here.
+@available(macOS 15.0, iOS 18.0, *)
+extension snowflake_arctic_embed_s: @unchecked Sendable {}
+
+@available(macOS 15.0, iOS 18.0, *)
+extension snowflake_arctic_embed_sOutput: @unchecked Sendable {}
 
 @available(macOS 15.0, iOS 18.0, *)
 private extension ArcticEmbeddings {

--- a/Sources/WaxVectorSearchMiniLM/CoreML/MiniLMEmbeddings.swift
+++ b/Sources/WaxVectorSearchMiniLM/CoreML/MiniLMEmbeddings.swift
@@ -141,7 +141,7 @@ package final class MiniLMEmbeddings {
         let localModel = model
         return await withCheckedContinuation { continuation in
             Self.predictionQueue.async {
-                let output = try? localModel.prediction(
+                let output: all_MiniLM_L6_v2Output? = try? localModel.prediction(
                     input_ids: inputIds,
                     attention_mask: attentionMask
                 )
@@ -218,6 +218,15 @@ package final class MiniLMEmbeddings {
     }
 
 }
+
+// MARK: - Sendable Conformances for CoreML Types
+// These auto-generated CoreML wrapper types are safe for concurrent prediction
+// and produce immutable output objects. @unchecked Sendable is appropriate here.
+@available(macOS 15.0, iOS 18.0, *)
+extension all_MiniLM_L6_v2: @unchecked Sendable {}
+
+@available(macOS 15.0, iOS 18.0, *)
+extension all_MiniLM_L6_v2Output: @unchecked Sendable {}
 
 @available(macOS 15.0, iOS 18.0, *)
 private extension MiniLMEmbeddings {


### PR DESCRIPTION
## Summary
- add explicit CoreML output typing in the off-pool prediction helpers
- mark the generated Arctic and MiniLM CoreML model/output wrapper types as `@unchecked Sendable`
- restore successful builds under Swift 6.3 strict concurrency diagnostics

## Verification
- `swift build`

Closes #58