### PR TITLE
Lower platform requirements to macOS 14 and iOS 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,8 @@ waxIntegrationLinuxExcludes = []
 let package = Package(
     name: "Wax",
     platforms: [
-        .iOS(.v18),
-        .macOS(.v15),
+        .iOS(.v17),
+        .macOS(.v14),
     ],
     products: [
         .library(
@@ -189,6 +189,7 @@ let package = Package(
             resources: [.process("RAG/Resources")],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
+                .define("MiniLMEmbeddings", .when(traits: ["MiniLMEmbeddings"])),
                 .define("ArcticEmbeddings", .when(traits: ["ArcticEmbeddings"])),
             ]
         ),
@@ -288,7 +289,10 @@ let package = Package(
             ],
             exclude: waxIntegrationLinuxExcludes,
             resources: [.process("Fixtures")],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+                .define("MiniLMEmbeddings", .when(traits: ["MiniLMEmbeddings"])),
+            ]
         ),
         .testTarget(
             name: "WaxArcticTests",

--- a/Sources/Wax/Adapters/MemoryOrchestrator+Arctic.swift
+++ b/Sources/Wax/Adapters/MemoryOrchestrator+Arctic.swift
@@ -2,6 +2,7 @@
 import Foundation
 import WaxVectorSearchArctic
 
+@available(macOS 15.0, iOS 18.0, *)
 package extension MemoryOrchestrator {
     static func openArctic(
         at url: URL,

--- a/Sources/Wax/Adapters/MemoryOrchestrator+MiniLM.swift
+++ b/Sources/Wax/Adapters/MemoryOrchestrator+MiniLM.swift
@@ -1,7 +1,8 @@
-#if canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
+#if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
 import Foundation
 import WaxVectorSearchMiniLM
 
+@available(macOS 15.0, iOS 18.0, *)
 package extension MemoryOrchestrator {
     static func openMiniLM(
         at url: URL,

--- a/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
+++ b/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
@@ -23,7 +23,11 @@ package enum CommandLineEmbedderFactory {
 
         if embedderChoice.lowercased() == "arctic" {
             #if ArcticEmbeddings && canImport(WaxVectorSearchArctic) && canImport(CoreML)
-            return DeferredCommandLineEmbedder(kind: .arctic, tuning: tuning)
+            if #available(macOS 15.0, iOS 18.0, *) {
+                return DeferredCommandLineEmbedder(kind: .arctic, tuning: tuning)
+            }
+            brokerWriteStderr("Warning: Arctic requires macOS 15.0 or iOS 18.0. Falling back to text-only search.")
+            return nil
             #else
             brokerWriteStderr("Warning: Arctic embeddings not available in this build. Falling back to text-only search.")
             return nil
@@ -31,7 +35,11 @@ package enum CommandLineEmbedderFactory {
         }
 
         #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
-        return DeferredCommandLineEmbedder(kind: .minilm, tuning: tuning)
+        if #available(macOS 15.0, iOS 18.0, *) {
+            return DeferredCommandLineEmbedder(kind: .minilm, tuning: tuning)
+        }
+        brokerWriteStderr("Warning: MiniLM requires macOS 15.0 or iOS 18.0. Falling back to text-only search.")
+        return nil
         #else
         return nil
         #endif

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Prewarm.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Prewarm.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
+#if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
 import WaxVectorSearchMiniLM
 #endif
 
@@ -17,7 +17,8 @@ package enum WaxPrewarm {
         }
     }
 
-    #if canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
+    #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
+    @available(macOS 15.0, iOS 18.0, *)
     package static func miniLM(sampleText: String = "hello") async throws {
         let embedder = try MiniLMEmbedder()
         try await embedder.prewarm()

--- a/Sources/WaxCLI/StoreSession.swift
+++ b/Sources/WaxCLI/StoreSession.swift
@@ -162,6 +162,10 @@ enum StoreSession {
         switch embedderChoice {
         case .arctic:
             #if ArcticEmbeddings && canImport(WaxVectorSearchArctic) && canImport(CoreML)
+            guard #available(macOS 15.0, iOS 18.0, *) else {
+                return .unavailable("Arctic requires macOS 15.0 or iOS 18.0")
+            }
+
             if !skipPrewarm {
                 writeStderr("Loading Arctic embedder...")
             }
@@ -205,6 +209,10 @@ enum StoreSession {
             #endif
         case .minilm:
             #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
+            guard #available(macOS 15.0, iOS 18.0, *) else {
+                return .unavailable("MiniLM requires macOS 15.0 or iOS 18.0")
+            }
+
             if !skipPrewarm {
                 writeStderr("Loading MiniLM embedder...")
             }

--- a/Sources/WaxMCPServer/MCPMemoryFactory.swift
+++ b/Sources/WaxMCPServer/MCPMemoryFactory.swift
@@ -164,6 +164,10 @@ enum MCPMemoryFactory {
 
         if embedderChoice.lowercased() == "arctic" {
             #if ArcticEmbeddings && canImport(WaxVectorSearchArctic) && canImport(CoreML)
+           guard #available(macOS 15.0, iOS 18.0, *) else {
+                writeStderr("Warning: Arctic requires macOS 15.0 or iOS 18.0; falling back to text-only search.")
+                return nil
+            }
             return DeferredCommandLineEmbedder(kind: .arctic, timeout: tuning.timeoutDuration, tuning: tuning)
             #else
             writeStderr("Warning: Arctic embeddings not available in this build. Falling back to text-only search.")
@@ -172,6 +176,10 @@ enum MCPMemoryFactory {
         }
 
         #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
+        guard #available(macOS 15.0, iOS 18.0, *) else {
+            writeStderr("Warning: MiniLM requires macOS 15.0 or iOS 18.0; falling back to text-only search.")
+            return nil
+        }
         return DeferredCommandLineEmbedder(kind: .minilm, timeout: tuning.timeoutDuration, tuning: tuning)
         #else
         return nil

--- a/Sources/WaxRepo/Store/RepoStore.swift
+++ b/Sources/WaxRepo/Store/RepoStore.swift
@@ -43,22 +43,28 @@ actor RepoStore {
     init(storeURL: URL, textOnly: Bool = false) async throws {
         self.storeURL = storeURL
 
-        let embedder: (any EmbeddingProvider)? = try await {
-            guard !textOnly else { return nil }
+        let embedder: (any EmbeddingProvider)?
+        if textOnly {
+            embedder = nil
+        } else {
             #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
-            // Some CLI executable contexts are unstable with CoreML batch
-            // prediction APIs. Keep batch size at 1 so MiniLM runs through
-            // the single-prediction path for reliability.
-            let modelConfiguration = MLModelConfiguration()
-            modelConfiguration.computeUnits = .cpuOnly
-            let config = MiniLMEmbedder.Config(batchSize: 1, modelConfiguration: modelConfiguration)
-            let e = try MiniLMEmbedder(config: config)
-            try await e.prewarm(batchSize: 1)
-            return e
+            if #available(macOS 15.0, iOS 18.0, *) {
+                // Some CLI executable contexts are unstable with CoreML batch
+                // prediction APIs. Keep batch size at 1 so MiniLM runs through
+                // the single-prediction path for reliability.
+                let modelConfiguration = MLModelConfiguration()
+                modelConfiguration.computeUnits = .cpuOnly
+                let config = MiniLMEmbedder.Config(batchSize: 1, modelConfiguration: modelConfiguration)
+                let e = try MiniLMEmbedder(config: config)
+                try await e.prewarm(batchSize: 1)
+                embedder = e
+            } else {
+                embedder = nil
+            }
             #else
-            return nil
+            embedder = nil
             #endif
-        }()
+        }
 
         var config = OrchestratorConfig.default
         if embedder == nil {

--- a/Sources/WaxVectorSearchArctic/ArcticEmbedder.swift
+++ b/Sources/WaxVectorSearchArctic/ArcticEmbedder.swift
@@ -8,6 +8,7 @@ import WaxBertTokenizer
 @preconcurrency import OSLog
 #endif
 
+@available(macOS 15.0, iOS 18.0, *)
 extension ArcticEmbeddings: @unchecked Sendable {}
 
 /// High-performance Snowflake Arctic Embed Small embedder with batch and query-aware support.
@@ -237,6 +238,7 @@ extension ArcticEmbedder {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, *)
 private extension ArcticEmbedder {
     static func describe(_ units: MLComputeUnits) -> String {
         switch units {

--- a/Sources/WaxVectorSearchMiniLM/MiniLMEmbedder.swift
+++ b/Sources/WaxVectorSearchMiniLM/MiniLMEmbedder.swift
@@ -7,6 +7,7 @@ import WaxVectorSearch
 @preconcurrency import OSLog
 #endif
 
+@available(macOS 15.0, iOS 18.0, *)
 extension MiniLMEmbeddings: @unchecked Sendable {}
 
 /// High-performance MiniLM embedder with batch support for optimal ANE/GPU utilization.
@@ -239,6 +240,7 @@ extension MiniLMEmbedder {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, *)
 private extension MiniLMEmbedder {
     static func describe(_ units: MLComputeUnits) -> String {
         switch units {

--- a/Tests/WaxArcticTests/ArcticEmbedderTests.swift
+++ b/Tests/WaxArcticTests/ArcticEmbedderTests.swift
@@ -12,6 +12,7 @@ struct ArcticEmbedderTests {
 
     @Test
     func arcticEmbedderProduces384Dimensions() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
         try await embedder.prewarm(batchSize: 1)
         let vector = try await embedder.embed("Hello world")
@@ -22,6 +23,7 @@ struct ArcticEmbedderTests {
 
     @Test
     func arcticEmbedderIdentity() throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
 
         let identity = embedder.identity
@@ -33,6 +35,7 @@ struct ArcticEmbedderTests {
 
     @Test
     func arcticBatchConsistency() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
         try await embedder.prewarm(batchSize: 1)
 
@@ -68,12 +71,14 @@ struct ArcticEmbedderTests {
 
     @Test
     func arcticPrewarmDoesNotThrow() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
         try await embedder.prewarm(batchSize: 4)
     }
 
     @Test
     func arcticEmbedderNormalizesOutput() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
         try await embedder.prewarm(batchSize: 1)
         let vector = try await embedder.embed("Test normalization")

--- a/Tests/WaxArcticTests/ArcticEmbeddingQualityTests.swift
+++ b/Tests/WaxArcticTests/ArcticEmbeddingQualityTests.swift
@@ -24,6 +24,7 @@ struct ArcticEmbeddingQualityTests {
 
     @Test
     func embeddingsProduceMeaningfulSimilarities() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
         try await embedder.prewarm(batchSize: 1)
 
@@ -45,6 +46,7 @@ struct ArcticEmbeddingQualityTests {
 
     @Test
     func queryPrefixImprovesRetrieval() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
         try await embedder.prewarm(batchSize: 1)
 

--- a/Tests/WaxArcticTests/ArcticPerformanceBenchmark.swift
+++ b/Tests/WaxArcticTests/ArcticPerformanceBenchmark.swift
@@ -47,6 +47,7 @@ final class ArcticPerformanceBenchmark: XCTestCase {
 
     func testMiniLMSingleEmbedLatency() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_ARCTIC=1") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
 
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndNeuralEngine
@@ -68,6 +69,7 @@ final class ArcticPerformanceBenchmark: XCTestCase {
 
     func testArcticSingleEmbedLatency() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_ARCTIC=1") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("Arctic requires macOS 15.0 or iOS 18.0") }
 
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndNeuralEngine
@@ -89,6 +91,7 @@ final class ArcticPerformanceBenchmark: XCTestCase {
 
     func testArcticQueryEmbedLatency() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_ARCTIC=1") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("Arctic requires macOS 15.0 or iOS 18.0") }
 
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndNeuralEngine
@@ -112,6 +115,7 @@ final class ArcticPerformanceBenchmark: XCTestCase {
 
     func testMiniLMBatchThroughput() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_ARCTIC=1") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
 
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndNeuralEngine
@@ -132,6 +136,7 @@ final class ArcticPerformanceBenchmark: XCTestCase {
 
     func testArcticBatchThroughput() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_ARCTIC=1") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("Arctic requires macOS 15.0 or iOS 18.0") }
 
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndNeuralEngine

--- a/Tests/WaxArcticTests/QueryAwareEmbeddingTests.swift
+++ b/Tests/WaxArcticTests/QueryAwareEmbeddingTests.swift
@@ -12,12 +12,14 @@ struct QueryAwareEmbeddingTests {
 
     @Test
     func miniLMDoesNotConformToQueryAware() throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         #expect(!(MiniLMEmbedder.self is any QueryAwareEmbeddingProvider.Type),
                 "MiniLM should not conform to QueryAwareEmbeddingProvider")
     }
 
     @Test
     func arcticConformsToQueryAware() {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         func requireQueryAware<T: QueryAwareEmbeddingProvider>(_: T.Type) {}
         requireQueryAware(ArcticEmbedder.self)
     }
@@ -25,6 +27,7 @@ struct QueryAwareEmbeddingTests {
     @Test(.disabled(if: ProcessInfo.processInfo.environment["WAX_TEST_ARCTIC"] != "1",
                     "Set WAX_TEST_ARCTIC=1 to run Arctic tests"))
     func arcticEmbedQueryProducesDifferentVectorThanEmbed() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try ArcticEmbedder()
         try await embedder.prewarm(batchSize: 1)
 
@@ -40,6 +43,7 @@ struct QueryAwareEmbeddingTests {
 
     @Test
     func miniLMEmbedIsConsistentWithoutQueryPrefix() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else { return }
         let embedder = try makeMiniLMEmbedderForTesting()
         try await embedder.prewarm(batchSize: 1)
 
@@ -54,6 +58,7 @@ struct QueryAwareEmbeddingTests {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, *)
 private func makeMiniLMEmbedderForTesting() throws -> MiniLMEmbedder {
     let modelConfiguration = MLModelConfiguration()
     modelConfiguration.computeUnits = .cpuOnly

--- a/Tests/WaxIntegrationTests/BatchEmbeddingBenchmark.swift
+++ b/Tests/WaxIntegrationTests/BatchEmbeddingBenchmark.swift
@@ -32,6 +32,7 @@ final class BatchEmbeddingBenchmark: XCTestCase {
         try await AsyncTimeout.run(timeout: timeoutDuration, operation: operation, body)
     }
 
+    @available(macOS 15.0, iOS 18.0, *)
     private func makeBenchmarkEmbedder() async throws -> MiniLMEmbedder {
         let configuration = MLModelConfiguration()
         // XCTest/CLI contexts are prone to CoreML/ANE compile stalls and GPU crashes; keep this benchmark bounded and deterministic.
@@ -47,6 +48,7 @@ final class BatchEmbeddingBenchmark: XCTestCase {
     /// Test batch embedding vs sequential embedding performance
     func testBatchVsSequentialEmbedding() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run batch embedding benchmark.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
 
         let embedder = try await makeBenchmarkEmbedder()
         let textCount = 32
@@ -122,6 +124,7 @@ final class BatchEmbeddingBenchmark: XCTestCase {
     /// Test batch embedding with varying batch sizes
     func testBatchEmbeddingScaling() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run batch embedding scaling benchmark.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
 
         let embedder = try await makeBenchmarkEmbedder()
         let batchSizes = [8, 16, 32, 64]
@@ -163,6 +166,7 @@ final class BatchEmbeddingBenchmark: XCTestCase {
     /// Test full orchestrator ingest with batch embedding vs sequential fallback
     func testOrchestratorBatchEmbeddingPerformance() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run orchestrator batch embedding benchmark.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
         
         let documentCount = 100
         let iterations = 2

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
@@ -608,11 +608,12 @@ private extension String {
     }
 }
 
-#if canImport(WaxVectorSearchMiniLM)
+#if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM)
 import WaxVectorSearchMiniLM
 
 @Test
 func miniLMAdapterSymbolsExistWhenAvailable() async {
+    guard #available(macOS 15.0, iOS 18.0, *) else { return }
     _ = MiniLMEmbedder.self
     _ = MemoryOrchestrator.openMiniLM
     #expect(Bool(true))

--- a/Tests/WaxIntegrationTests/RAGBenchmarksMiniLM.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarksMiniLM.swift
@@ -12,6 +12,7 @@ final class RAGMiniLMBenchmarks: XCTestCase {
 
     func testMiniLMEmbeddingPerformance() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run MiniLM benchmarks.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
         let factory = BenchmarkTextFactory(sentencesPerDocument: scale.sentencesPerDocument)
         let text = factory.makeDocument(index: 0)
         let embedder = try MiniLMEmbedder()
@@ -26,6 +27,7 @@ final class RAGMiniLMBenchmarks: XCTestCase {
 
     func testMiniLMBatchEmbeddingThroughput() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run MiniLM benchmarks.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
         let scale = self.scale
         let factory = BenchmarkTextFactory(sentencesPerDocument: scale.sentencesPerDocument)
         let embedder = try MiniLMEmbedder()
@@ -46,6 +48,7 @@ final class RAGMiniLMBenchmarks: XCTestCase {
 
     func testMiniLMEmbeddingColdStartPerformance() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run MiniLM benchmarks.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
         let factory = BenchmarkTextFactory(sentencesPerDocument: scale.sentencesPerDocument)
         let text = factory.makeDocument(index: 0)
 
@@ -58,6 +61,7 @@ final class RAGMiniLMBenchmarks: XCTestCase {
 
     func testMiniLMOpenAndFirstRecallOnExistingStoreSamples() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run MiniLM benchmarks.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
         let scale = self.scale
         let factory = BenchmarkTextFactory(sentencesPerDocument: scale.sentencesPerDocument)
 
@@ -90,6 +94,7 @@ final class RAGMiniLMBenchmarks: XCTestCase {
 
     func testMiniLMIngestPerformance() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run MiniLM benchmarks.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
         let scale = self.scale
         let factory = BenchmarkTextFactory(sentencesPerDocument: scale.sentencesPerDocument)
         let timeout = max(scale.timeout, 240)
@@ -117,6 +122,7 @@ final class RAGMiniLMBenchmarks: XCTestCase {
 
     func testMiniLMRecallPerformance() async throws {
         guard isEnabled else { throw XCTSkip("Set WAX_BENCHMARK_MINILM=1 to run MiniLM benchmarks.") }
+        guard #available(macOS 15.0, iOS 18.0, *) else { throw XCTSkip("MiniLM requires macOS 15.0 or iOS 18.0") }
         let scale = self.scale
         let factory = BenchmarkTextFactory(sentencesPerDocument: scale.sentencesPerDocument)
         let timeout = max(scale.timeout, 120)


### PR DESCRIPTION
## Summary

Lower the package platform requirements from macOS 15 / iOS 18 to macOS 14 / iOS 17.

Built-in MiniLM and Arctic Core ML embedding providers still require macOS 15 / iOS 18, so their runtime construction paths are guarded with availability checks. On older systems, Wax falls back to text-only search instead of failing to compile or initialize those providers.

## Why

The previous macOS 15 / iOS 18 requirement was stricter than necessary for Wax's core functionality. On macOS 14 and iOS 17, the core store, text-only search, structured memory, and custom embedding provider paths remain usable.

This makes Wax easier to adopt on current deployed Apple platforms while preserving the higher OS requirement only for the built-in Core ML embedding providers that need it.

## Validation

- `swift build`
- `swift build --disable-default-traits`
- `swift build --traits ArcticEmbeddings`
- `swift test --filter WaxCoreTests`
