### PR TITLE
Fix iOS compilation

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerClient.swift
+++ b/Sources/Wax/Broker/AgentBrokerClient.swift
@@ -80,6 +80,9 @@ package enum AgentBrokerClient {
     }
 
     private static func startBrokerIfNeeded(configuration: AgentBrokerConfiguration) throws -> Bool {
+        #if os(iOS) || os(tvOS) || os(watchOS)
+        throw BrokerClientError("Starting a broker process is not supported on this platform.")
+        #else
         guard FileManager.default.isExecutableFile(atPath: configuration.brokerExecutablePath) else {
             throw BrokerClientError(
                 "Broker executable is not executable at \(configuration.brokerExecutablePath)"
@@ -160,6 +163,7 @@ package enum AgentBrokerClient {
         }
 
         throw BrokerClientError("Timed out waiting for broker startup.")
+        #endif
     }
 
     private static func shutdownStartedBroker(configuration: AgentBrokerConfiguration) throws {

--- a/Sources/Wax/Broker/AgentBrokerProtocol.swift
+++ b/Sources/Wax/Broker/AgentBrokerProtocol.swift
@@ -222,11 +222,19 @@ package enum AgentBrokerPathing {
             return URL(fileURLWithPath: expandPath(raw), isDirectory: true)
         }
 
+        #if os(iOS) || os(tvOS) || os(watchOS)
+        let root = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return root
+            .appendingPathComponent("waxmcp", isDirectory: true)
+            .appendingPathComponent("broker", isDirectory: true)
+        #else
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local", isDirectory: true)
             .appendingPathComponent("share", isDirectory: true)
             .appendingPathComponent("waxmcp", isDirectory: true)
             .appendingPathComponent("broker", isDirectory: true)
+        #endif
     }
 
     package static func resolveBrokerCLIPath(
@@ -317,6 +325,9 @@ package enum AgentBrokerPathing {
     }
 
     private static func resolveExecutableOnPath(_ tool: String) -> String? {
+        #if os(iOS) || os(tvOS) || os(watchOS)
+        nil
+        #else
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = ["which", tool]
@@ -341,5 +352,6 @@ package enum AgentBrokerPathing {
         let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let path, !path.isEmpty else { return nil }
         return path
+        #endif
     }
 }


### PR DESCRIPTION
## Summary
- Avoid Process-based broker startup on iOS, tvOS, and watchOS.
- Use an app-support broker directory on platforms where the home directory path is unavailable.
- Avoid PATH executable lookup on iOS-family platforms.

## Validation
- swift build --target Wax --triple arm64-apple-ios17.0 --sdk "$(xcrun --sdk iphoneos --show-sdk-path)"
