### PR TITLE
Expose public retrieval controls and built-in embedders

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -206,9 +206,12 @@ private extension AgentBrokerService {
             throw BrokerValidationError.invalid("search_top_k must be between 1 and \(Self.maxTopK)")
         }
         let effectiveTopK = requestedTopK ?? limit
-        let embeddingPolicy: MemoryOrchestrator.QueryEmbeddingPolicy = if case .text? = mode {
+        let embeddingPolicy: MemoryOrchestrator.QueryEmbeddingPolicy = switch mode {
+        case .text?:
             .never
-        } else {
+        case .vector?:
+            .always
+        case .hybrid?, nil:
             .ifAvailable
         }
         let execution = try await memory.recallExecution(
@@ -593,6 +596,7 @@ private extension AgentBrokerService {
         }
         let corpusNoEmbedder: Bool = switch mode {
         case .text: true
+        case .vector: false
         case .hybrid: noEmbedder
         }
         let buildSummary: BrokerCorpusBuildSummary?
@@ -835,10 +839,12 @@ private extension AgentBrokerService {
         switch modeRaw {
         case "text":
             return .text
+        case "vector":
+            return .vector
         case "hybrid":
             return .hybrid(alpha: try validatedHybridAlpha(alpha ?? 0.5))
         default:
-            throw BrokerValidationError.invalid("mode must be one of: text, hybrid")
+            throw BrokerValidationError.invalid("mode must be one of: text, vector, hybrid")
         }
     }
 
@@ -850,10 +856,12 @@ private extension AgentBrokerService {
         switch modeRaw ?? "text" {
         case "text":
             return .text
+        case "vector":
+            return .vector
         case "hybrid":
             return .hybrid(alpha: validatedAlpha)
         default:
-            throw BrokerValidationError.invalid("mode must be one of: text, hybrid")
+            throw BrokerValidationError.invalid("mode must be one of: text, vector, hybrid")
         }
     }
 

--- a/Sources/Wax/BuiltInEmbeddings.swift
+++ b/Sources/Wax/BuiltInEmbeddings.swift
@@ -1,0 +1,106 @@
+import Foundation
+import WaxCore
+import WaxVectorSearch
+
+/// Built-in Wax embedding providers that can be used without going through the CLI or MCP server.
+public enum BuiltInEmbeddingProvider: String, CaseIterable, Sendable, Equatable, Codable {
+    /// The all-MiniLM-L6-v2 CoreML embedding provider.
+    case miniLM = "minilm"
+    /// The Snowflake Arctic Embed Small CoreML embedding provider.
+    case arctic
+
+    package var commandLineChoice: String {
+        rawValue
+    }
+}
+
+/// CoreML compute-unit preference for built-in Wax embedders.
+public enum BuiltInEmbeddingComputeUnit: String, CaseIterable, Sendable, Equatable, Codable {
+    /// Run inference on the CPU only.
+    case cpuOnly
+    /// Prefer CPU and GPU execution.
+    case cpuAndGPU
+    /// Prefer CPU and Apple Neural Engine execution.
+    case cpuAndNeuralEngine
+    /// Allow CoreML to use all available compute units.
+    case all
+
+    package var commandLineValue: CommandLineEmbedderComputeUnit {
+        switch self {
+        case .cpuOnly:
+            .cpuOnly
+        case .cpuAndGPU:
+            .cpuAndGPU
+        case .cpuAndNeuralEngine:
+            .cpuAndNeuralEngine
+        case .all:
+            .all
+        }
+    }
+}
+
+/// Runtime options for constructing built-in Wax embedding providers.
+public struct BuiltInEmbeddingProviderOptions: Sendable, Equatable, Codable {
+    public var batchSize: Int
+    public var prewarmBatchSize: Int
+    public var allowLowPrecisionGPU: Bool
+    public var timeoutSeconds: Double
+    public var computeUnitsOrder: [BuiltInEmbeddingComputeUnit]
+
+    public init(
+        batchSize: Int = 1,
+        prewarmBatchSize: Int = 1,
+        allowLowPrecisionGPU: Bool = true,
+        timeoutSeconds: Double = 30.0,
+        computeUnitsOrder: [BuiltInEmbeddingComputeUnit] = [.cpuOnly]
+    ) {
+        self.batchSize = max(1, batchSize)
+        self.prewarmBatchSize = max(1, prewarmBatchSize)
+        self.allowLowPrecisionGPU = allowLowPrecisionGPU
+        self.timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 30.0
+        self.computeUnitsOrder = computeUnitsOrder.isEmpty ? [.cpuOnly] : computeUnitsOrder
+    }
+
+    public static let `default` = BuiltInEmbeddingProviderOptions()
+
+    package var tuning: CommandLineEmbedderRuntimeTuning {
+        CommandLineEmbedderRuntimeTuning(
+            batchSize: batchSize,
+            prewarmBatchSize: prewarmBatchSize,
+            allowLowPrecisionGPU: allowLowPrecisionGPU,
+            timeoutSeconds: timeoutSeconds,
+            computeUnitsOrder: computeUnitsOrder.map(\.commandLineValue)
+        )
+    }
+}
+
+/// Errors thrown while constructing built-in Wax embedding providers.
+public enum BuiltInEmbeddingProviderError: LocalizedError, Sendable, Equatable {
+    /// The requested provider is unavailable in the current build or platform.
+    case unavailable(BuiltInEmbeddingProvider)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable(let provider):
+            return "\(provider.rawValue) embeddings are unavailable in this Wax build or platform."
+        }
+    }
+}
+
+/// Factory for Wax's built-in embedding providers.
+public enum BuiltInEmbeddings {
+    /// Construct a built-in embedding provider using Wax's on-device CoreML runtime.
+    public static func make(
+        _ provider: BuiltInEmbeddingProvider,
+        options: BuiltInEmbeddingProviderOptions = .default
+    ) async throws -> any EmbeddingProvider {
+        guard let embedder = try await CommandLineEmbedderFactory.buildEmbedder(
+            noEmbedder: false,
+            embedderChoice: provider.commandLineChoice,
+            tuning: options.tuning
+        ) else {
+            throw BuiltInEmbeddingProviderError.unavailable(provider)
+        }
+        return embedder
+    }
+}

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -52,8 +52,15 @@ public actor Memory {
     }
 
     public enum RetrievalMode: Sendable, Equatable {
+        /// Search only the full-text index.
         case textOnly
-        case hybrid
+        /// Search only the vector index. Requires vector search and an embedding provider.
+        case vectorOnly
+        /// Blend full-text and vector results using Reciprocal Rank Fusion.
+        ///
+        /// The alpha value is clamped by Wax's search engine. Higher values favor
+        /// text results; lower values favor vector results.
+        case hybrid(alpha: Float = 0.5)
     }
 
     public struct SearchOptions: Sendable, Equatable {
@@ -66,7 +73,7 @@ public actor Memory {
             topK: Int = 10,
             includeSurrogates: Bool = false,
             timeRange: TimeRange? = nil,
-            mode: RetrievalMode = .hybrid
+            mode: RetrievalMode = .hybrid()
         ) {
             self.topK = topK
             self.includeSurrogates = includeSurrogates
@@ -124,6 +131,21 @@ public actor Memory {
         )
     }
 
+    /// Open memory with one of Wax's built-in embedding providers.
+    public init(
+        at url: URL,
+        config: Config = .default,
+        builtInEmbedding provider: BuiltInEmbeddingProvider,
+        embeddingOptions: BuiltInEmbeddingProviderOptions = .default
+    ) async throws {
+        let embedding = try await BuiltInEmbeddings.make(provider, options: embeddingOptions)
+        self.orchestrator = try await MemoryOrchestrator(
+            at: url,
+            config: Self.makeOrchestratorConfig(config),
+            embedder: embedding
+        )
+    }
+
     /// Persist text into memory.
     public func save(_ text: String, metadata: [String: String] = [:]) async throws {
         try await orchestrator.remember(text, metadata: metadata)
@@ -141,12 +163,16 @@ public actor Memory {
         let directMode: MemoryOrchestrator.DirectSearchMode = switch options.mode {
         case .textOnly:
             .text
-        case .hybrid:
-            .hybrid(alpha: 0.5)
+        case .vectorOnly:
+            .vector
+        case .hybrid(let alpha):
+            .hybrid(alpha: alpha)
         }
         let embeddingPolicy: MemoryOrchestrator.QueryEmbeddingPolicy = switch options.mode {
         case .textOnly:
             .never
+        case .vectorOnly:
+            .always
         case .hybrid:
             .ifAvailable
         }

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -14,6 +14,7 @@ package actor MemoryOrchestrator {
     /// Direct search mode for raw candidate retrieval.
     package enum DirectSearchMode: Sendable, Equatable {
         case text
+        case vector
         case hybrid(alpha: Float)
 
         package static let `default`: DirectSearchMode = .hybrid(alpha: 0.5)
@@ -907,6 +908,8 @@ package actor MemoryOrchestrator {
         let policy: QueryEmbeddingPolicy = switch mode {
         case .text:
             .never
+        case .vector:
+            .always
         case .hybrid:
             .ifAvailable
         }
@@ -1267,6 +1270,8 @@ package actor MemoryOrchestrator {
         switch mode {
         case .text:
             .textOnly
+        case .vector:
+            .vectorOnly
         case .hybrid(let alpha):
             .hybrid(alpha: clampHybridAlpha(alpha))
         }
@@ -1302,6 +1307,8 @@ package actor MemoryOrchestrator {
         switch mode {
         case .text:
             return "text"
+        case .vector:
+            return "vector"
         case .hybrid(let alpha):
             return "hybrid(alpha=\(String(format: "%.3f", Double(alpha))))"
         }

--- a/Sources/WaxCLI/DaemonCompatibility.swift
+++ b/Sources/WaxCLI/DaemonCompatibility.swift
@@ -154,10 +154,12 @@ private extension CLIDaemonSession {
         switch modeString {
         case "text":
             mode = .text
+        case "vector":
+            mode = .vector
         case "hybrid":
             mode = .hybrid(alpha: 0.5)
         default:
-            throw CLIError("mode must be one of: text, hybrid")
+            throw CLIError("mode must be one of: text, vector, hybrid")
         }
 
         let topK = request.topK ?? 10

--- a/Sources/WaxCLI/SearchCommand.swift
+++ b/Sources/WaxCLI/SearchCommand.swift
@@ -5,7 +5,7 @@ import Wax
 struct SearchCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "search",
-        abstract: "Search memory frames by text or hybrid mode"
+        abstract: "Search memory frames by text, vector, or hybrid mode"
     )
 
     @OptionGroup var store: VectorStoreOptions
@@ -13,7 +13,7 @@ struct SearchCommand: AsyncParsableCommand {
     @Argument(help: "Search query")
     var query: String
 
-    @Option(name: .customLong("mode"), help: "Search mode: text or hybrid (default: text)")
+    @Option(name: .customLong("mode"), help: "Search mode: text, vector, or hybrid (default: text)")
     var mode: String = "text"
 
     @Option(name: .customLong("top-k"), help: "Maximum results to return (1-200, default 10)")
@@ -21,22 +21,24 @@ struct SearchCommand: AsyncParsableCommand {
 
     func runAsync() async throws {
         let modeLower = mode.lowercased()
-        guard modeLower == "text" || modeLower == "hybrid" else {
-            throw CLIError("mode must be one of: text, hybrid")
+        guard modeLower == "text" || modeLower == "vector" || modeLower == "hybrid" else {
+            throw CLIError("mode must be one of: text, vector, hybrid")
         }
         guard topK >= 1, topK <= 200 else {
             throw CLIError("top-k must be between 1 and 200")
         }
 
         let searchMode: MemoryOrchestrator.DirectSearchMode
-        let requireVector = store.requireVector || modeLower == "hybrid"
+        let requireVector = store.requireVector || modeLower == "vector" || modeLower == "hybrid"
         switch modeLower {
         case "text":
             searchMode = .text
+        case "vector":
+            searchMode = .vector
         case "hybrid":
             searchMode = .hybrid(alpha: 0.5)
         default:
-            throw CLIError("mode must be one of: text, hybrid")
+            throw CLIError("mode must be one of: text, vector, hybrid")
         }
 
         if AgentBrokerPolicy.shouldUseBroker(store: store) {

--- a/Tests/WaxIntegrationTests/MemorySearchOptionsTests.swift
+++ b/Tests/WaxIntegrationTests/MemorySearchOptionsTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+import Wax
+
+@Test
+func memorySearchOptionsExposeVectorOnlyAndHybridAlpha() async throws {
+    var defaultOptions = Memory.SearchOptions.default
+    defaultOptions.mode = .hybrid()
+
+    let explicitHybrid = Memory.SearchOptions(mode: .hybrid(alpha: 0.25))
+    let vectorOnly = Memory.SearchOptions(mode: .vectorOnly)
+
+    #expect(defaultOptions.mode == .hybrid(alpha: 0.5))
+    #expect(explicitHybrid.mode == .hybrid(alpha: 0.25))
+    #expect(vectorOnly.mode == .vectorOnly)
+}
+
+@Test
+func memoryFacadeRunsVectorOnlySearch() async throws {
+    try await TempFiles.withTempFile { url in
+        let memory = try await Memory(
+            at: url,
+            config: .init(enableTextSearch: false, enableVectorSearch: true),
+            embedding: DeterministicEmbeddingProvider()
+        )
+
+        try await memory.save("Wax vector search should find this frame.", metadata: ["id": "needle"])
+        try await memory.flush()
+
+        let results = try await memory.search(
+            "find the frame",
+            options: .init(topK: 1, mode: .vectorOnly)
+        )
+
+        #expect(results.items.first?.metadata["id"] == "needle")
+        #expect(results.items.first?.sources.contains(.vector) == true)
+
+        try await memory.close()
+    }
+}
+
+private struct DeterministicEmbeddingProvider: EmbeddingProvider, Sendable {
+    let dimensions: Int = 2
+    let normalize: Bool = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "Test",
+        model: "Deterministic",
+        dimensions: 2,
+        normalized: true
+    )
+
+    func embed(_ text: String) async throws -> [Float] {
+        [1.0, 0.0]
+    }
+}


### PR DESCRIPTION
## Summary

- expose public `Memory.RetrievalMode.vectorOnly` and `Memory.RetrievalMode.hybrid(alpha:)` so callers can choose lexical, vector, or weighted hybrid retrieval without going through MCP/CLI internals
- add `BuiltInEmbeddings.make(...)` with public MiniLM/Arctic provider selection and runtime options
- thread vector-only direct search through `MemoryOrchestrator.DirectSearchMode` and CLI/broker mode parsing

## Motivation

Downstream consumers need to run retrieval evaluation sweeps over text-only, vector-only, and hybrid alpha values. Wax already has most of the lower-level machinery, but the public `Memory` facade only exposed text-only and fixed-alpha hybrid search, while built-in embedder construction was effectively trapped behind command-line/MCP code paths.

## Compatibility

Existing default search behavior remains hybrid with alpha 0.5. Callers that need explicit tuning can now pass `.hybrid(alpha:)` or `.vectorOnly`.

## Tests

- `swift test --filter MemorySearchOptionsTests`
