### PR TITLE
Resolve resource bundles when host binary is symlinked (Mint installs)

### DIFF
--- a/Sources/Wax/RAG/NativeBpeTokenizer.swift
+++ b/Sources/Wax/RAG/NativeBpeTokenizer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WaxCore
 
 package final class NativeBpeTokenizer: @unchecked Sendable {
     package enum Encoding: String, Sendable {
@@ -233,10 +234,15 @@ package final class NativeBpeTokenizer: @unchecked Sendable {
         return data
     }
 
+    private static let resourceBundle: Bundle = WaxBundleResolver.resolveModule(
+        named: "Wax_Wax.bundle",
+        moduleFallback: .module
+    )
+
     private static func loadEncoding(_ encoding: Encoding) throws -> ([Data: UInt32], [UInt32: Data]) {
         let url =
-            Bundle.module.url(forResource: encoding.rawValue, withExtension: "tiktoken")
-            ?? Bundle.module.url(forResource: encoding.rawValue, withExtension: "tiktoken", subdirectory: "RAG/Resources")
+            resourceBundle.url(forResource: encoding.rawValue, withExtension: "tiktoken")
+            ?? resourceBundle.url(forResource: encoding.rawValue, withExtension: "tiktoken", subdirectory: "RAG/Resources")
 
         guard let url else {
             throw NativeBpeError.missingResource(encoding: encoding.rawValue)
@@ -263,8 +269,8 @@ package final class NativeBpeTokenizer: @unchecked Sendable {
     /// Returns the directory that contains Wax’s bundled `.tiktoken` encoding files.
     static func bundledEncodingDirectoryURL() -> URL? {
         let url =
-            Bundle.module.url(forResource: Encoding.cl100kBase.rawValue, withExtension: "tiktoken")
-            ?? Bundle.module.url(forResource: Encoding.cl100kBase.rawValue, withExtension: "tiktoken", subdirectory: "RAG/Resources")
+            resourceBundle.url(forResource: Encoding.cl100kBase.rawValue, withExtension: "tiktoken")
+            ?? resourceBundle.url(forResource: Encoding.cl100kBase.rawValue, withExtension: "tiktoken", subdirectory: "RAG/Resources")
         return url?.deletingLastPathComponent()
     }
 }

--- a/Sources/WaxBertTokenizer/BertTokenizer.swift
+++ b/Sources/WaxBertTokenizer/BertTokenizer.swift
@@ -407,7 +407,11 @@ private extension BertTokenizer {
         }
         vocabCache.lock.unlock()
 
-        guard let url = Bundle.module.url(forResource: "bert_tokenizer_vocab", withExtension: "txt") else {
+        let bundle = WaxBertBundleResolver.resolveModule(
+            named: "Wax_WaxBertTokenizer.bundle",
+            moduleFallback: .module
+        )
+        guard let url = bundle.url(forResource: "bert_tokenizer_vocab", withExtension: "txt") else {
             throw BertTokenizerError.io("Missing vocabulary file: bert_tokenizer_vocab.txt")
         }
         let vocabTxt = try String(contentsOf: url, encoding: .utf8)

--- a/Sources/WaxBertTokenizer/BundleResolver.swift
+++ b/Sources/WaxBertTokenizer/BundleResolver.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Locates SwiftPM resource bundles when the host binary is launched through a
+/// symlink (Mint, Homebrew taps, `ln -s` installs, etc.). SwiftPM's
+/// auto-generated `Bundle.module` accessor uses `Bundle.main.bundleURL` which
+/// does **not** resolve symlinks, so it cannot find the `*.bundle` directories
+/// that sit next to the real executable.
+///
+/// This is a target-local copy of `WaxCore.WaxBundleResolver` so that
+/// `WaxBertTokenizer` does not need to pull in `WaxCore` (and its transitive
+/// dependencies) just for bundle resolution.
+enum WaxBertBundleResolver {
+    static func resolveModule(named bundleName: String, moduleFallback: Bundle) -> Bundle {
+        if moduleFallback.bundleURL.lastPathComponent == bundleName,
+           FileManager.default.fileExists(atPath: moduleFallback.bundlePath) {
+            return moduleFallback
+        }
+        for directory in candidateDirectories() {
+            let candidate = directory.appendingPathComponent(bundleName)
+            if let bundle = Bundle(url: candidate) { return bundle }
+        }
+        return moduleFallback
+    }
+
+    private static func candidateDirectories() -> [URL] {
+        var directories: [URL] = []
+        let mainBundleURL = Bundle.main.bundleURL
+        directories.append(mainBundleURL)
+
+        if let executablePath = Bundle.main.executablePath {
+            let launched = URL(fileURLWithPath: executablePath)
+            let resolved = launched.resolvingSymlinksInPath()
+            directories.append(launched.deletingLastPathComponent())
+            if resolved.path != launched.path {
+                directories.append(resolved.deletingLastPathComponent())
+            }
+        }
+        return directories
+    }
+}

--- a/Sources/WaxCore/BundleResolver.swift
+++ b/Sources/WaxCore/BundleResolver.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Locates SwiftPM resource bundles when the host binary is launched through a
+/// symlink (Mint, Homebrew taps, `ln -s` installs, etc.). SwiftPM's
+/// auto-generated `Bundle.module` accessor uses `Bundle.main.bundleURL` which
+/// does **not** resolve symlinks, so it cannot find the `*.bundle` directories
+/// that sit next to the real executable.
+///
+/// `resolveModule(named:moduleFallback:)` tries, in order:
+/// 1. The provided `moduleFallback` (SwiftPM's `Bundle.module`) — this is
+///    correct for app/test/framework hosts and for direct executable launches.
+/// 2. The directory of the binary as launched (symlink target's parent).
+/// 3. The directory of the resolved binary (real install location).
+///
+/// Pass the bundle name SwiftPM would emit (`<Package>_<Target>.bundle`).
+public enum WaxBundleResolver {
+    public static func resolveModule(named bundleName: String, moduleFallback: Bundle) -> Bundle {
+        if moduleFallback.bundleURL.lastPathComponent == bundleName,
+           FileManager.default.fileExists(atPath: moduleFallback.bundlePath) {
+            return moduleFallback
+        }
+        for directory in candidateDirectories() {
+            let candidate = directory.appendingPathComponent(bundleName)
+            if let bundle = Bundle(url: candidate) { return bundle }
+        }
+        return moduleFallback
+    }
+
+    private static func candidateDirectories() -> [URL] {
+        var directories: [URL] = []
+        let mainBundleURL = Bundle.main.bundleURL
+        directories.append(mainBundleURL)
+
+        if let executablePath = Bundle.main.executablePath {
+            let launched = URL(fileURLWithPath: executablePath)
+            let resolved = launched.resolvingSymlinksInPath()
+            directories.append(launched.deletingLastPathComponent())
+            if resolved.path != launched.path {
+                directories.append(resolved.deletingLastPathComponent())
+            }
+        }
+        return directories
+    }
+}

--- a/Sources/WaxVectorSearch/MetalVectorEngine.swift
+++ b/Sources/WaxVectorSearch/MetalVectorEngine.swift
@@ -277,7 +277,10 @@ package actor MetalVectorEngine {
 
     private static func loadMetalLibrary(device: MTLDevice) throws -> MTLLibrary {
         #if SWIFT_PACKAGE
-        let bundle = Bundle.module
+        let bundle = WaxBundleResolver.resolveModule(
+            named: "Wax_WaxVectorSearch.bundle",
+            moduleFallback: .module
+        )
         #else
         let bundle = Bundle(for: MetalVectorEngine.self)
         #endif

--- a/Sources/WaxVectorSearchArctic/CoreML/ArcticEmbeddings.swift
+++ b/Sources/WaxVectorSearchArctic/CoreML/ArcticEmbeddings.swift
@@ -260,7 +260,11 @@ private extension ArcticEmbeddings {
     }
 
     static func loadModelFromBundle(configuration: MLModelConfiguration) throws -> snowflake_arctic_embed_s {
-        if let compiledURL = Bundle.module.url(forResource: "snowflake-arctic-embed-s", withExtension: "mlmodelc") {
+        let bundle = WaxBundleResolver.resolveModule(
+            named: "Wax_WaxVectorSearchArctic.bundle",
+            moduleFallback: .module
+        )
+        if let compiledURL = bundle.url(forResource: "snowflake-arctic-embed-s", withExtension: "mlmodelc") {
             let core = try MLModel(contentsOf: compiledURL, configuration: configuration)
             return snowflake_arctic_embed_s(model: core)
         }

--- a/Sources/WaxVectorSearchMiniLM/CoreML/MiniLMEmbeddings.swift
+++ b/Sources/WaxVectorSearchMiniLM/CoreML/MiniLMEmbeddings.swift
@@ -273,7 +273,11 @@ private extension MiniLMEmbeddings {
     }
 
     static func loadModelFromBundle(configuration: MLModelConfiguration) throws -> all_MiniLM_L6_v2 {
-        if let compiledURL = Bundle.module.url(forResource: "all-MiniLM-L6-v2", withExtension: "mlmodelc") {
+        let bundle = WaxBundleResolver.resolveModule(
+            named: "Wax_WaxVectorSearchMiniLM.bundle",
+            moduleFallback: .module
+        )
+        if let compiledURL = bundle.url(forResource: "all-MiniLM-L6-v2", withExtension: "mlmodelc") {
             let core = try MLModel(contentsOf: compiledURL, configuration: configuration)
             return all_MiniLM_L6_v2(model: core)
         }


### PR DESCRIPTION
## Summary
- Hosts that launch Wax via a symlink (Mint, Homebrew taps, manual `ln -s`) fatal-error on first `Bundle.module` access: SwiftPM's auto-generated accessor reads `Bundle.main.bundleURL` without resolving symlinks, so the `*.bundle` directories sitting next to the real executable are invisible.
- Adds `WaxBundleResolver` (in `WaxCore`, with a target-local copy in `WaxBertTokenizer` to avoid pulling `WaxCore` + `swift-crypto` into the tokenizer target). It prefers `Bundle.module` when valid, then falls back to the launched-binary directory and the symlink-resolved binary directory.
- Migrates the six user-facing `Bundle.module` callsites (`NativeBpeTokenizer`, `BertTokenizer`, `MetalVectorEngine`, `MiniLMEmbeddings.loadModelFromBundle`, `ArcticEmbeddings.loadModelFromBundle`). CoreML-generated `urlOfModelInThisBundle` is intentionally left alone — those files regenerate on rebuild, and the wrappers' explicit bundle-fallback path is what fires in practice.

## Reproduction
```bash
mint install NickTrienens2025/CodeContextKit   # any Wax-consuming binary
cckit
# Wax/resource_bundle_accessor.swift:12: Fatal error: could not load resource bundle:
#   from /Users/<user>/.mint/bin/Wax_Wax.bundle
#   or  /private/var/folders/.../Wax_Wax.bundle
```
With the fix, the resolver walks the symlink target and finds `Wax_Wax.bundle` (and siblings) next to the real binary.

## Test plan
- [x] `swift build` — clean
- [x] `swift test --filter "BertTokenizer|NativeBpe|Bundle"` — 14 tests pass (includes `bertTokenizerVocabLoadsOnceAcrossInstances`, the tiktoken native tokenizer tests, and the existing symlink-resolution tests under `WaxCLI`)
- [ ] Reviewer: smoke-test a `mint install` of any Wax executable consumer on macOS

## Notes
- No public API changes other than the new `public enum WaxBundleResolver` in `WaxCore`.
- App/test/framework hosts hit the `Bundle.module` fast path and observe no behavior change.