### PR TITLE
feat(mcp): ship wax-mcp operator skill and install-time playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,27 +223,38 @@ Then send JSON-line commands:
 
 Give your AI coding assistant (Claude Code, Cursor, Windsurf) a persistent memory that survives across sessions.
 
-### 1. Install the MCP server
+### 1. Install the MCP server (and stage the operator skill)
 
 ```bash
 npx -y waxmcp@latest mcp install --scope user
 ```
 
-This stages the Wax runtime locally and registers `wax-mcp` with your assistant. `npx` is only used for the one-time install.
+This stages the Wax runtime locally, registers `wax-mcp` with Claude Code, and stages the
+**wax-mcp operator skill** under `~/.local/share/waxmcp/skills/wax-mcp` (then attempts
+`claude install-skill` when available). `npx` is only used for the one-time install.
 
-### 2. Install the Wax skill (recommended)
+The MCP server also ships lifecycle instructions with every tools connection, so agents
+receive the remember/recall/handoff playbook even without a separate skill install.
+
+### 2. Install the wax-mcp skill (if install did not auto-register it)
 
 ```bash
-# From within your project directory
-claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax
+# Preferred: staged local copy after mcp install
+claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
+
+# Or from GitHub
+claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax-mcp
 ```
 
-This lets your assistant write correct Wax code without extra prompt scaffolding.
+This is the **agent operator** skill (session lifecycle, remember/recall, handoffs).
 
-### 3. Or paste this starter prompt
+> Writing Swift apps with the Wax framework? That is a different skill:
+> `claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax`
+
+### 3. Or paste project rules into CLAUDE.md / AGENTS.md
 
 <details>
-<summary><strong>Wax starter prompt (click to expand, then copy)</strong></summary>
+<summary><strong>Wax MCP project rules (click to expand, then copy)</strong></summary>
 
 ```text
 Use the Wax MCP server for persistent memory in this repo.

--- a/Resources/docs/wax-mcp-setup.md
+++ b/Resources/docs/wax-mcp-setup.md
@@ -3,19 +3,60 @@
 ## One-command install into Claude Code
 
 ```bash
-cd /Users/chriskarani/CodingProjects/AIStack/Wax
+npx -y waxmcp@latest mcp install --scope user
+```
+
+From a local checkout (development):
+
+```bash
 swift run --traits MCPServer wax-cli mcp install --scope user
 ```
 
 This will:
 
-1. Build `wax-mcp`
+1. Build or stage `wax-mcp` (bundled npm runtime is staged into a stable path)
 2. Register a `wax` MCP server entry in Claude Code against the resolved `wax-mcp` binary
 3. Configure default store paths under `~/.wax`
+4. Stage the **wax-mcp operator skill** under `~/.local/share/waxmcp/skills/wax-mcp`
+5. Attempt `claude install-skill` for that staged skill (best-effort)
+6. Print a pasteable `CLAUDE.md` / `AGENTS.md` project-rules block as fallback
 
-## Recommended `CLAUDE.md` prompt
+Skip skill staging with `--skip-skill` if you only want the MCP server.
 
-Paste this into your repo prompt or `CLAUDE.md` after installing Wax:
+## How agents learn the playbook
+
+Wax teaches agents at three layers:
+
+| Layer | When it applies | What it teaches |
+|-------|-----------------|-----------------|
+| MCP `instructions` + tool descriptions | Every connected host | Session lifecycle, anti-patterns |
+| `wax-mcp` skill | Hosts that load skills | Full operator playbook + install notes |
+| Project rules (`CLAUDE.md` / `AGENTS.md`) | Always-on project instructions | Same workflow rules as a paste block |
+
+You usually only need step 1. Use the skill or project rules when the host ignores MCP instructions or you want stronger always-on enforcement.
+
+### Skill: agent operator vs Swift framework
+
+| Skill | Path | Audience |
+|-------|------|----------|
+| `wax-mcp` | `Resources/skills/public/wax-mcp` | Agents *using* MCP memory tools |
+| `wax` | `Resources/skills/public/wax` | Developers writing Swift Wax code |
+
+```bash
+# Operator skill (MCP tools)
+claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
+# or
+claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax-mcp
+
+# Swift framework skill (optional, separate)
+claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax
+```
+
+The published `waxmcp` npm package also ships `skills/wax-mcp` so installs do not require cloning this monorepo.
+
+## Recommended project rules
+
+Paste this into your repo prompt, `CLAUDE.md`, or `AGENTS.md` after installing Wax:
 
 ```text
 Use the Wax MCP server for persistent memory in this repo.
@@ -36,9 +77,13 @@ Behavior expectations:
 - When a cross-session result looks relevant, cite the provenance metadata so we know which session store it came from.
 ```
 
+The same text ships in `Resources/skills/public/wax-mcp/references/project-rules.md`.
+
 ## Run doctor
 
 ```bash
+npx -y waxmcp@latest mcp doctor
+# or from a local build:
 swift run --traits MCPServer wax-cli mcp doctor
 ```
 
@@ -68,7 +113,7 @@ swift run --traits MCPServer wax-cli mcp serve
 
 ## npx launcher
 
-The npm launcher is at `npm/waxmcp`.
+The npm launcher is at `npm/waxmcp` (package name `waxmcp`).
 
 ```bash
 npx -y waxmcp@latest mcp serve
@@ -79,10 +124,14 @@ This package includes embedded binaries for:
 1. `dist/darwin-arm64/wax-cli` + `dist/darwin-arm64/wax-mcp`
 2. `dist/darwin-x64/wax-cli` + `dist/darwin-x64/wax-mcp`
 
+and the operator skill at:
+
+3. `skills/wax-mcp/`
+
 For users of the published package, no local Wax build is required.
 Running `npx -y waxmcp@latest mcp install --scope user` stages those bundled artifacts into a
 stable local runtime directory and registers the staged `wax-mcp` binary, so steady-state
-Claude/Codex sessions do not depend on raw `npx` startup.
+Claude/Codex sessions do not depend on raw `npx`.
 
 For local development:
 

--- a/Resources/npm/waxmcp/README.md
+++ b/Resources/npm/waxmcp/README.md
@@ -16,8 +16,23 @@ For Claude Code / Codex installs, prefer:
 npx -y waxmcp@latest mcp install --scope user
 ```
 
-That install flow stages the bundled runtime into a stable local directory and registers the
-staged `wax-mcp` binary, so regular MCP sessions do not keep launching through raw `npx`.
+That install flow:
+
+1. Stages the bundled runtime into a stable local directory
+2. Registers the staged `wax-mcp` binary with Claude Code
+3. Stages the **wax-mcp operator skill** to `~/.local/share/waxmcp/skills/wax-mcp`
+4. Attempts `claude install-skill` when available and prints project-rules fallback text
+
+So regular MCP sessions do not keep launching through raw `npx`, and agents get a
+session lifecycle playbook (also embedded in MCP server instructions).
+
+```bash
+# If skill auto-install did not run:
+claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
+```
+
+> `wax-mcp` skill = agent operator playbook for MCP tools.
+> `wax` skill (separate, in the monorepo) = Swift framework integration guidance.
 
 > Note: the bundled npm runtime currently ships `darwin-arm64` and `darwin-x64` artifacts. The underlying
 > `wax-mcp` server itself now supports local Swift builds on macOS and Linux, including

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -24,6 +24,7 @@
     "dist",
     "plugins",
     "scripts",
+    "skills",
     "README.md"
   ],
   "engines": {

--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: wax-mcp
+description: >
+  Operator playbook for the Wax MCP memory server. Use whenever Wax MCP tools are
+  available (remember, recall, search, handoff, session_start/end, structured
+  memory), when installing or configuring waxmcp, or when an agent should keep
+  durable cross-session memory. Prefer this skill over the Swift framework skill
+  unless the task is writing Wax Swift code.
+---
+
+# Wax MCP (Agent Memory Operator)
+
+## Purpose
+
+Teach agents how to **use** the Wax MCP server correctly every session.
+
+This is not the Swift framework skill. For embedding Wax in Swift apps, use the
+`wax` skill under `Resources/skills/public/wax`.
+
+## Session Lifecycle (required)
+
+1. **Start**
+   - Call `handoff_latest` first (optionally with `project`) to load prior context.
+   - Call `session_start` once.
+   - Keep the returned `session_id` for the rest of the session.
+2. **Work**
+   - Before answering from memory, call `recall` (default) or `search` (raw hits).
+   - When you learn something durable, call `remember` with concise factual text.
+   - For session-scoped writes, pass `session_id` as a **top-level** argument.
+   - Never put `session_id` inside `metadata`.
+3. **End**
+   - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
+   - Call `session_end` (pass `session_id` when multiple sessions may be active).
+
+## Read Path
+
+| Goal | Tool |
+|------|------|
+| Assembled RAG context for the current question | `recall` |
+| Raw ranked hits / debugging retrieval | `search` |
+| Cross-session history with provenance | `corpus_search` |
+| Health / embedder / store stats | `stats` |
+
+Search mode guidance:
+
+- Prefer `mode: "hybrid"` when semantic recall helps.
+- Use `mode: "text"` for fast or deterministic lexical lookup.
+
+## Write Path
+
+| Kind of knowledge | Tool |
+|-------------------|------|
+| Decisions, preferences, discoveries, short facts | `remember` |
+| Stable entities in a knowledge graph | `entity_upsert` / `entity_resolve` |
+| Structured facts that can be retracted later | `fact_assert` / `fact_retract` / `facts_query` |
+| Natural-language knowledge capture (when available) | `knowledge_capture` |
+
+Write quality rules:
+
+- Keep content concise, factual, and task-scoped.
+- Prefer corrections: store the corrected fact; retract stale structured facts with `fact_retract`.
+- Do not store secrets, credentials, or large blobs unless the user explicitly asks.
+
+## Anti-Patterns (do not do these)
+
+- Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows.
+  The broker owns long-term memory and virtual session stores.
+- Do not skip `handoff_latest` at session start and re-ask the user for prior context.
+- Do not invent a `session_id`; only use values returned by `session_start` / `session_resume`.
+- Do not put `session_id` inside `metadata`.
+- Do not treat `search` as the default when `recall` is enough.
+- Do not use structured fact tools for transient debug notes.
+
+## Behavior Expectations
+
+- Read handoffs and recall results before asking the user to restate known context.
+- When a cross-session hit matters, cite provenance so the user knows which session store it came from.
+- Use `session_resume` only when continuing a known persisted `session_id` after a restart.
+- Use `compact_context` / `session_synthesize` / promotion tools only when the task needs long-horizon compaction or durable promotion, not as default chatter.
+
+## Install / Host Setup (for humans and setup agents)
+
+MCP server:
+
+```bash
+npx -y waxmcp@latest mcp install --scope user
+```
+
+That command stages the runtime, registers the MCP server, and stages this skill
+under `~/.local/share/waxmcp/skills/wax-mcp` (or `$WAX_MCP_INSTALL_ROOT/../skills`
+when the install root is overridden).
+
+Skill install (Claude Code):
+
+```bash
+claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
+# or from source
+claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax-mcp
+```
+
+Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
+`AGENTS.md` when the host does not load skills automatically.
+
+## Quick Tool Map
+
+| Tool | When |
+|------|------|
+| `handoff_latest` | Session start continuity |
+| `session_start` / `session_end` | Broker session lifecycle |
+| `session_resume` | Resume a known session after restart |
+| `remember` | Store durable free-text memory |
+| `recall` | Default read / RAG assembly |
+| `search` | Raw ranked hits |
+| `handoff` | End-of-session summary + pending tasks |
+| `corpus_search` | Cross-session search with provenance |
+| `stats` | Health check |
+| `entity_*` / `fact_*` | Structured knowledge graph |
+
+## References
+
+- `references/project-rules.md` — pasteable project instruction block
+- Repo setup doc: `Resources/docs/wax-mcp-setup.md`

--- a/Resources/npm/waxmcp/skills/wax-mcp/agents/openai.yaml
+++ b/Resources/npm/waxmcp/skills/wax-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wax MCP Memory"
+  short_description: "Use Wax MCP tools for durable agent memory"
+  default_prompt: "Use $wax-mcp for session lifecycle, remember/recall, handoffs, and structured memory. Call handoff_latest then session_start at session start; handoff then session_end at session end."

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -1,0 +1,23 @@
+# Wax MCP project rules
+
+Paste this block into `CLAUDE.md`, `AGENTS.md`, Cursor rules, or any host
+always-on instruction file after installing the Wax MCP server.
+
+```text
+Use the Wax MCP server for persistent memory in this repo.
+
+Workflow rules:
+- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+- Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
+- Use `recall` for assembled context and `search` for raw ranked hits.
+- Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
+- Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
+- Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.
+- Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
+- Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
+
+Behavior expectations:
+- Read existing handoffs and recall results before asking me to restate prior context.
+- Keep memory writes concise, factual, and scoped to the task.
+- When a cross-session result looks relevant, cite the provenance metadata so we know which session store it came from.
+```

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: wax-mcp
+description: >
+  Operator playbook for the Wax MCP memory server. Use whenever Wax MCP tools are
+  available (remember, recall, search, handoff, session_start/end, structured
+  memory), when installing or configuring waxmcp, or when an agent should keep
+  durable cross-session memory. Prefer this skill over the Swift framework skill
+  unless the task is writing Wax Swift code.
+---
+
+# Wax MCP (Agent Memory Operator)
+
+## Purpose
+
+Teach agents how to **use** the Wax MCP server correctly every session.
+
+This is not the Swift framework skill. For embedding Wax in Swift apps, use the
+`wax` skill under `Resources/skills/public/wax`.
+
+## Session Lifecycle (required)
+
+1. **Start**
+   - Call `handoff_latest` first (optionally with `project`) to load prior context.
+   - Call `session_start` once.
+   - Keep the returned `session_id` for the rest of the session.
+2. **Work**
+   - Before answering from memory, call `recall` (default) or `search` (raw hits).
+   - When you learn something durable, call `remember` with concise factual text.
+   - For session-scoped writes, pass `session_id` as a **top-level** argument.
+   - Never put `session_id` inside `metadata`.
+3. **End**
+   - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
+   - Call `session_end` (pass `session_id` when multiple sessions may be active).
+
+## Read Path
+
+| Goal | Tool |
+|------|------|
+| Assembled RAG context for the current question | `recall` |
+| Raw ranked hits / debugging retrieval | `search` |
+| Cross-session history with provenance | `corpus_search` |
+| Health / embedder / store stats | `stats` |
+
+Search mode guidance:
+
+- Prefer `mode: "hybrid"` when semantic recall helps.
+- Use `mode: "text"` for fast or deterministic lexical lookup.
+
+## Write Path
+
+| Kind of knowledge | Tool |
+|-------------------|------|
+| Decisions, preferences, discoveries, short facts | `remember` |
+| Stable entities in a knowledge graph | `entity_upsert` / `entity_resolve` |
+| Structured facts that can be retracted later | `fact_assert` / `fact_retract` / `facts_query` |
+| Natural-language knowledge capture (when available) | `knowledge_capture` |
+
+Write quality rules:
+
+- Keep content concise, factual, and task-scoped.
+- Prefer corrections: store the corrected fact; retract stale structured facts with `fact_retract`.
+- Do not store secrets, credentials, or large blobs unless the user explicitly asks.
+
+## Anti-Patterns (do not do these)
+
+- Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows.
+  The broker owns long-term memory and virtual session stores.
+- Do not skip `handoff_latest` at session start and re-ask the user for prior context.
+- Do not invent a `session_id`; only use values returned by `session_start` / `session_resume`.
+- Do not put `session_id` inside `metadata`.
+- Do not treat `search` as the default when `recall` is enough.
+- Do not use structured fact tools for transient debug notes.
+
+## Behavior Expectations
+
+- Read handoffs and recall results before asking the user to restate known context.
+- When a cross-session hit matters, cite provenance so the user knows which session store it came from.
+- Use `session_resume` only when continuing a known persisted `session_id` after a restart.
+- Use `compact_context` / `session_synthesize` / promotion tools only when the task needs long-horizon compaction or durable promotion, not as default chatter.
+
+## Install / Host Setup (for humans and setup agents)
+
+MCP server:
+
+```bash
+npx -y waxmcp@latest mcp install --scope user
+```
+
+That command stages the runtime, registers the MCP server, and stages this skill
+under `~/.local/share/waxmcp/skills/wax-mcp` (or `$WAX_MCP_INSTALL_ROOT/../skills`
+when the install root is overridden).
+
+Skill install (Claude Code):
+
+```bash
+claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
+# or from source
+claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax-mcp
+```
+
+Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
+`AGENTS.md` when the host does not load skills automatically.
+
+## Quick Tool Map
+
+| Tool | When |
+|------|------|
+| `handoff_latest` | Session start continuity |
+| `session_start` / `session_end` | Broker session lifecycle |
+| `session_resume` | Resume a known session after restart |
+| `remember` | Store durable free-text memory |
+| `recall` | Default read / RAG assembly |
+| `search` | Raw ranked hits |
+| `handoff` | End-of-session summary + pending tasks |
+| `corpus_search` | Cross-session search with provenance |
+| `stats` | Health check |
+| `entity_*` / `fact_*` | Structured knowledge graph |
+
+## References
+
+- `references/project-rules.md` — pasteable project instruction block
+- Repo setup doc: `Resources/docs/wax-mcp-setup.md`

--- a/Resources/skills/public/wax-mcp/agents/openai.yaml
+++ b/Resources/skills/public/wax-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wax MCP Memory"
+  short_description: "Use Wax MCP tools for durable agent memory"
+  default_prompt: "Use $wax-mcp for session lifecycle, remember/recall, handoffs, and structured memory. Call handoff_latest then session_start at session start; handoff then session_end at session end."

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -1,0 +1,23 @@
+# Wax MCP project rules
+
+Paste this block into `CLAUDE.md`, `AGENTS.md`, Cursor rules, or any host
+always-on instruction file after installing the Wax MCP server.
+
+```text
+Use the Wax MCP server for persistent memory in this repo.
+
+Workflow rules:
+- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+- Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
+- Use `recall` for assembled context and `search` for raw ranked hits.
+- Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
+- Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
+- Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.
+- Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
+- Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
+
+Behavior expectations:
+- Read existing handoffs and recall results before asking me to restate prior context.
+- Keep memory writes concise, factual, and scoped to the task.
+- When a cross-session result looks relevant, cite the provenance metadata so we know which session store it came from.
+```

--- a/Resources/skills/public/wax/SKILL.md
+++ b/Resources/skills/public/wax/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: wax
-description: Comprehensive guidance for the Wax on-device memory/RAG framework. Use when integrating MemoryOrchestrator, VideoRAGOrchestrator, Wax/WaxSession, embedding providers, hybrid search, maintenance, or when evaluating Wax constraints like offline-only, single-file .wax persistence and deterministic retrieval.
+description: >
+  Swift framework guidance for Wax on-device memory/RAG. Use when writing Swift code
+  with MemoryOrchestrator, VideoRAGOrchestrator, Wax/WaxSession, embedding providers,
+  hybrid search, or maintenance. For agent operators using the Wax MCP server tools,
+  use the separate wax-mcp skill instead.
 ---
 
-# Wax
+# Wax (Swift Framework)
 
 ## Overview
 Use this skill to design and implement correct Wax-based on-device RAG flows in Swift 6.2, emphasizing deterministic retrieval, single-file persistence, and safe concurrency.
+
+If you need the agent memory operator playbook for MCP tools (`remember`, `recall`,
+`handoff`, `session_start`), use the `wax-mcp` skill instead of this one.
 
 ## Choose The API Surface
 1. Prefer `MemoryOrchestrator` for text memory and retrieval.

--- a/Resources/skills/public/wax/agents/openai.yaml
+++ b/Resources/skills/public/wax/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Wax Framework"
+  display_name: "Wax Framework (Swift)"
   short_description: "On-device RAG memory in Swift"
-  default_prompt: "Use $wax to design correct on-device RAG flows with MemoryOrchestrator and VideoRAG."
+  default_prompt: "Use $wax to design correct on-device RAG flows with MemoryOrchestrator and VideoRAG. For MCP agent memory tools, use $wax-mcp instead."

--- a/Sources/Wax/Wax.docc/Articles/GettingStarted.md
+++ b/Sources/Wax/Wax.docc/Articles/GettingStarted.md
@@ -163,7 +163,19 @@ Wax ships with an MCP server that gives Claude Code persistent memory. Install a
 npx -y waxmcp@latest mcp install --scope user
 ```
 
-Then add the memory prompt to your `CLAUDE.md` — see the [README](https://github.com/christopherkarani/Wax#ai-coding-assistants) for the recommended snippet.
+That command registers the MCP server, stages the `wax-mcp` operator skill, and
+prints a pasteable project-rules block. The server also embeds lifecycle
+instructions on every tools connection.
+
+Optional skill install if auto-registration did not run:
+
+```bash
+claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
+```
+
+Or add the memory prompt to your `CLAUDE.md` / `AGENTS.md` — see the
+[README](https://github.com/christopherkarani/Wax#agent-quick-start) and
+`Resources/docs/wax-mcp-setup.md` for the recommended snippet.
 
 ### MCP Tools
 

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -114,7 +114,7 @@ extension WaxCLI.MCP {
 extension WaxCLI.MCP {
     struct Install: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Build and register Wax MCP server in Claude Code"
+            abstract: "Build and register Wax MCP server in Claude Code, and stage the wax-mcp agent skill"
         )
 
         @Option(name: .shortAndLong, help: "MCP server name")
@@ -140,6 +140,9 @@ extension WaxCLI.MCP {
 
         @Flag(name: .customLong("skip-build"), help: "Skip building wax-mcp before install")
         var skipBuild = false
+
+        @Flag(name: .customLong("skip-skill"), help: "Skip staging/installing the wax-mcp operator skill")
+        var skipSkill = false
 
         @Flag(name: .customLong("dry-run"), help: "Print commands without executing")
         var dryRun = false
@@ -214,6 +217,12 @@ extension WaxCLI.MCP {
             }
 
             let removeArguments = ["mcp", "remove", "-s", scope.rawValue, name]
+            let skillInstall = try Pathing.prepareWaxMCPSkill(
+                cliPath: resolvedCLI,
+                serverPath: installRuntime.serverPath,
+                dryRun: dryRun,
+                skip: skipSkill
+            )
 
             if dryRun {
                 if bundledRuntime && !skipBuild {
@@ -224,6 +233,7 @@ extension WaxCLI.MCP {
                 }
                 print("claude \(removeArguments.joined(separator: " "))")
                 print("claude \(redactedArgumentsForDisplay(addArguments).joined(separator: " "))")
+                printWaxMCPSkillGuidance(skillInstall, dryRun: true)
                 return
             }
 
@@ -252,6 +262,11 @@ extension WaxCLI.MCP {
 
             print("Installed MCP server '\(name)' in scope '\(scope.rawValue)'.")
             print("Run: claude mcp get \(name)")
+            try installWaxMCPSkillWithClaudeIfPossible(
+                claudePath: claudePath,
+                skillInstall: skillInstall
+            )
+            printWaxMCPSkillGuidance(skillInstall, dryRun: false)
         }
     }
 }
@@ -712,9 +727,48 @@ struct MCPInstallRuntime: Equatable {
     let staged: Bool
 }
 
+struct MCPSkillInstall: Equatable {
+    let skipped: Bool
+    let sourcePath: String?
+    let stagedPath: String?
+    let staged: Bool
+
+    static let skippedResult = MCPSkillInstall(
+        skipped: true,
+        sourcePath: nil,
+        stagedPath: nil,
+        staged: false
+    )
+}
+
 struct MCPRuntimeValidation: Equatable {
     var failures: [String] = []
     var warnings: [String] = []
+}
+
+enum WaxMCPAgentPlaybook {
+    /// Pasteable project rules for CLAUDE.md / AGENTS.md hosts.
+    static let projectRules = """
+        Use the Wax MCP server for persistent memory in this repo.
+
+        Workflow rules:
+        - At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+        - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
+        - Use `recall` for assembled context and `search` for raw ranked hits.
+        - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
+        - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
+        - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.
+        - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
+        - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
+
+        Behavior expectations:
+        - Read existing handoffs and recall results before asking me to restate prior context.
+        - Keep memory writes concise, factual, and scoped to the task.
+        - When a cross-session result looks relevant, cite the provenance metadata so we know which session store it came from.
+        """
+
+    static let githubSkillURL =
+        "https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax-mcp"
 }
 
 enum Pathing {
@@ -877,6 +931,190 @@ enum Pathing {
             .appendingPathComponent("runtime", isDirectory: true)
 
         return root.appendingPathComponent(platformDirectory, isDirectory: true)
+    }
+
+    /// Stable skill install path: `~/.local/share/waxmcp/skills/wax-mcp` by default,
+    /// or `$WAX_MCP_INSTALL_ROOT/skills/wax-mcp` when the install root is overridden.
+    static func stableSkillDirectory(skillName: String = "wax-mcp") -> URL {
+        if let raw = ProcessInfo.processInfo.environment["WAX_MCP_INSTALL_ROOT"] {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return URL(fileURLWithPath: expandPath(trimmed))
+                    .appendingPathComponent("skills", isDirectory: true)
+                    .appendingPathComponent(skillName, isDirectory: true)
+            }
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local", isDirectory: true)
+            .appendingPathComponent("share", isDirectory: true)
+            .appendingPathComponent("waxmcp", isDirectory: true)
+            .appendingPathComponent("skills", isDirectory: true)
+            .appendingPathComponent(skillName, isDirectory: true)
+    }
+
+    static func isValidSkillDirectory(_ url: URL) -> Bool {
+        let skillMarkdown = url.appendingPathComponent("SKILL.md")
+        return FileManager.default.fileExists(atPath: skillMarkdown.path)
+    }
+
+    /// Resolve the wax-mcp operator skill source directory.
+    /// Order: `WAX_MCP_SKILL_SOURCE`, npm package `skills/wax-mcp`, repo
+    /// `Resources/skills/public/wax-mcp`, already-staged skill path.
+    static func resolveWaxMCPSkillSource(
+        cliPath: String? = nil,
+        serverPath: String? = nil
+    ) -> URL? {
+        if let raw = ProcessInfo.processInfo.environment["WAX_MCP_SKILL_SOURCE"] {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                let candidate = URL(fileURLWithPath: expandPath(trimmed)).standardizedFileURL
+                if isValidSkillDirectory(candidate) {
+                    return candidate
+                }
+            }
+        }
+
+        var candidates: [URL] = []
+
+        let executableHints = [cliPath, serverPath].compactMap { $0 }
+        for path in executableHints {
+            if let packageRoot = npmPackageRoot(forExecutablePath: path) {
+                candidates.append(
+                    packageRoot
+                        .appendingPathComponent("skills", isDirectory: true)
+                        .appendingPathComponent("wax-mcp", isDirectory: true)
+                )
+            }
+        }
+
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).standardizedFileURL
+        candidates.append(
+            cwd
+                .appendingPathComponent("Resources/skills/public/wax-mcp", isDirectory: true)
+        )
+        candidates.append(
+            cwd
+                .appendingPathComponent("skills/wax-mcp", isDirectory: true)
+        )
+
+        for path in executableHints {
+            candidates.append(contentsOf: skillCandidatesWalkingUp(from: URL(fileURLWithPath: normalizePath(path))))
+        }
+        candidates.append(contentsOf: skillCandidatesWalkingUp(from: cwd))
+
+        candidates.append(stableSkillDirectory())
+
+        var seen = Set<String>()
+        for candidate in candidates {
+            let path = candidate.standardizedFileURL.path
+            if seen.contains(path) { continue }
+            seen.insert(path)
+            if isValidSkillDirectory(candidate) {
+                return candidate.standardizedFileURL
+            }
+        }
+        return nil
+    }
+
+    private static func npmPackageRoot(forExecutablePath path: String) -> URL? {
+        guard let runtimeDir = bundledRuntimeDirectory(forExecutablePath: path) else {
+            return nil
+        }
+        // .../package/dist/darwin-arm64 -> package root
+        let distDir = runtimeDir.deletingLastPathComponent()
+        guard distDir.lastPathComponent == "dist" else { return nil }
+        return distDir.deletingLastPathComponent()
+    }
+
+    private static func skillCandidatesWalkingUp(from start: URL) -> [URL] {
+        var results: [URL] = []
+        var current = start.standardizedFileURL
+        if !current.hasDirectoryPath {
+            current = current.deletingLastPathComponent()
+        }
+        for _ in 0..<8 {
+            results.append(
+                current
+                    .appendingPathComponent("Resources/skills/public/wax-mcp", isDirectory: true)
+            )
+            results.append(
+                current
+                    .appendingPathComponent("skills/wax-mcp", isDirectory: true)
+            )
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path { break }
+            current = parent
+        }
+        return results
+    }
+
+    static func prepareWaxMCPSkill(
+        cliPath: String,
+        serverPath: String,
+        dryRun: Bool,
+        skip: Bool
+    ) throws -> MCPSkillInstall {
+        if skip {
+            return .skippedResult
+        }
+
+        let source = resolveWaxMCPSkillSource(cliPath: cliPath, serverPath: serverPath)
+        let target = stableSkillDirectory()
+
+        guard let source else {
+            return MCPSkillInstall(
+                skipped: false,
+                sourcePath: nil,
+                stagedPath: isValidSkillDirectory(target) ? target.path : nil,
+                staged: false
+            )
+        }
+
+        if source.standardizedFileURL.path == target.standardizedFileURL.path {
+            return MCPSkillInstall(
+                skipped: false,
+                sourcePath: source.path,
+                stagedPath: target.path,
+                staged: true
+            )
+        }
+
+        if !dryRun {
+            try stageSkillDirectory(from: source, to: target)
+        }
+
+        return MCPSkillInstall(
+            skipped: false,
+            sourcePath: source.path,
+            stagedPath: target.path,
+            staged: true
+        )
+    }
+
+    static func stageSkillDirectory(from sourceDir: URL, to targetDir: URL) throws {
+        let fm = FileManager.default
+        let standardizedSource = sourceDir.standardizedFileURL
+        let standardizedTarget = targetDir.standardizedFileURL
+        guard isValidSkillDirectory(standardizedSource) else {
+            throw CLIError("Skill source is missing SKILL.md: \(standardizedSource.path)")
+        }
+        guard standardizedSource.path != standardizedTarget.path else { return }
+
+        let parent = standardizedTarget.deletingLastPathComponent()
+        try fm.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        let staging = parent.appendingPathComponent(
+            ".\(standardizedTarget.lastPathComponent).staging-\(UUID().uuidString)"
+        )
+        if fm.fileExists(atPath: staging.path) {
+            try fm.removeItem(at: staging)
+        }
+        try fm.copyItem(at: standardizedSource, to: staging)
+
+        if fm.fileExists(atPath: standardizedTarget.path) {
+            try fm.removeItem(at: standardizedTarget)
+        }
+        try fm.moveItem(at: staging, to: standardizedTarget)
     }
 
     static func stageBundledRuntimeIfNeeded(from sourceDir: URL, to targetDir: URL) throws {
@@ -1056,6 +1294,84 @@ private func redactedArgumentsForDisplay(_ arguments: [String]) -> [String] {
             return "WAX_LICENSE_KEY=<redacted>"
         }
         return argument
+    }
+}
+
+private func printWaxMCPSkillGuidance(_ skillInstall: MCPSkillInstall, dryRun: Bool) {
+    print("")
+    print("## Wax agent skill (recommended)")
+    if skillInstall.skipped {
+        print("Skill staging skipped (--skip-skill).")
+        print("Install manually:")
+        print("  claude install-skill \(WaxMCPAgentPlaybook.githubSkillURL)")
+        printProjectRulesFallback()
+        return
+    }
+
+    if let source = skillInstall.sourcePath {
+        if dryRun {
+            print("# Would stage wax-mcp skill from:")
+            print("#   \(source)")
+        } else {
+            print("Skill source: \(source)")
+        }
+    } else {
+        print("Skill source not found locally. Use the GitHub skill URL below.")
+    }
+
+    if let staged = skillInstall.stagedPath {
+        if dryRun {
+            print("# Would stage skill to:")
+            print("#   \(staged)")
+            print("claude install-skill \(staged)")
+        } else if skillInstall.staged {
+            print("Staged skill at: \(staged)")
+            print("If Claude Code did not pick it up automatically:")
+            print("  claude install-skill \(staged)")
+        } else {
+            print("Existing skill path: \(staged)")
+            print("  claude install-skill \(staged)")
+        }
+    }
+
+    print("Or from GitHub:")
+    print("  claude install-skill \(WaxMCPAgentPlaybook.githubSkillURL)")
+    print("")
+    print("Note: the `wax` skill is for Swift framework integration.")
+    print("      the `wax-mcp` skill is the agent operator playbook for MCP tools.")
+    printProjectRulesFallback()
+}
+
+private func printProjectRulesFallback() {
+    print("")
+    print("## Project rules fallback (CLAUDE.md / AGENTS.md / Cursor rules)")
+    print("Paste this block if your host does not load skills automatically:")
+    print("")
+    print("```text")
+    print(WaxMCPAgentPlaybook.projectRules)
+    print("```")
+}
+
+private func installWaxMCPSkillWithClaudeIfPossible(
+    claudePath: String,
+    skillInstall: MCPSkillInstall
+) throws {
+    guard !skillInstall.skipped, skillInstall.staged, let stagedPath = skillInstall.stagedPath else {
+        return
+    }
+
+    let status = try ProcessRunner.run(
+        command: claudePath,
+        arguments: ["install-skill", stagedPath],
+        passthrough: false,
+        allowNonZeroExit: true
+    )
+    if status == EXIT_SUCCESS {
+        print("Installed wax-mcp skill into Claude Code from \(stagedPath).")
+    } else {
+        writeStderr(
+            "warning: 'claude install-skill \(stagedPath)' exited with code \(status); install the skill manually if needed."
+        )
     }
 }
 

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -1,0 +1,31 @@
+#if MCPServer
+import Foundation
+
+/// Host-facing MCP server instructions. Every agent that connects should receive
+/// this lifecycle playbook without needing a separate skill install.
+enum MCPAgentInstructions {
+    static func text(version: String) -> String {
+        """
+        Wax MCP durable agent memory (server v\(version)).
+
+        Session lifecycle (required):
+        1) Call handoff_latest first (optional project) to resume prior context.
+        2) Call session_start once and keep the returned session_id for the session.
+        3) Before answering from memory, call recall (default) or search (raw ranked hits).
+        4) When you learn durable facts, call remember with concise factual content. Pass session_id as a top-level argument for session-scoped writes — never put session_id inside metadata.
+        5) Near session end, call handoff (content, optional project/pending_tasks/session_id), then session_end.
+
+        Tool selection:
+        - recall: assembled RAG context (preferred read path)
+        - search: raw ranked hits; prefer mode hybrid unless a lexical text search is requested
+        - corpus_search: cross-session history with provenance
+        - entity_*/fact_*: stable structured knowledge, not transient debug notes
+        - stats: health / embedder / store check
+
+        Do not manage SESSION_STORE, --store-path, or flush in normal agent flows. The broker owns long-term memory and virtual session stores.
+
+        Behavior: read handoffs and recall results before asking the user to restate prior context; keep memory writes concise and task-scoped; cite provenance on cross-session hits.
+        """
+    }
+}
+#endif

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -26,17 +26,17 @@ enum ToolSchemas {
         ),
         Tool(
             name: "remember",
-            description: "Store text in Wax memory with optional metadata.",
+            description: "Store concise durable text memory (decisions, preferences, facts). For session-scoped writes pass session_id as a top-level argument — never put session_id inside metadata.",
             inputSchema: waxRemember
         ),
         Tool(
             name: "recall",
-            description: "Recall context for a query using Wax RAG assembly.",
+            description: "Preferred read path: assemble RAG context for a query. Call after handoff_latest/session_start when answering from memory.",
             inputSchema: waxRecall
         ),
         Tool(
             name: "search",
-            description: "Run direct Wax search and return ranked raw hits.",
+            description: "Raw ranked search hits (not assembled RAG). Prefer mode hybrid for semantic retrieval; use mode text for lexical/deterministic lookup.",
             inputSchema: waxSearch
         ),
         Tool(
@@ -61,17 +61,17 @@ enum ToolSchemas {
         ),
         Tool(
             name: "corpus_search",
-            description: "Search broker-managed session history with provenance-rich results.",
+            description: "Search broker-managed session history with provenance. Use for cross-session retrieval; cite provenance when results matter.",
             inputSchema: waxCorpusSearch
         ),
         Tool(
             name: "stats",
-            description: "Return Wax runtime and storage stats.",
+            description: "Return Wax runtime and storage stats (health check, embedder identity, vector search status).",
             inputSchema: waxStats
         ),
         Tool(
             name: "session_start",
-            description: "Create a broker-managed virtual session and return its session_id.",
+            description: "Create a broker-managed virtual session and return session_id. Call after handoff_latest at session start; keep session_id for later tools.",
             inputSchema: waxSessionStart
         ),
         Tool(
@@ -81,17 +81,17 @@ enum ToolSchemas {
         ),
         Tool(
             name: "session_end",
-            description: "End an active broker-managed virtual session. Pass session_id when multiple sessions are active.",
+            description: "End an active broker-managed virtual session after handoff. Pass session_id when multiple sessions are active.",
             inputSchema: waxSessionEnd
         ),
         Tool(
             name: "handoff",
-            description: "Store a cross-session handoff note for later retrieval.",
+            description: "Store an end-of-session handoff note (content, optional project/pending_tasks/session_id) for the next session.",
             inputSchema: waxHandoff
         ),
         Tool(
             name: "handoff_latest",
-            description: "Fetch the latest handoff note, optionally scoped by project.",
+            description: "Call first at session start: fetch the latest handoff note (optional project) before session_start.",
             inputSchema: waxHandoffLatest
         ),
         Tool(
@@ -120,27 +120,27 @@ enum ToolSchemas {
                 ),
                 Tool(
                     name: "entity_upsert",
-                    description: "Upsert a structured-memory entity by key.",
+                    description: "Upsert a stable structured-memory entity by key. Use for durable graph nodes, not transient debug notes.",
                     inputSchema: waxEntityUpsert
                 ),
                 Tool(
                     name: "fact_assert",
-                    description: "Assert a structured-memory fact.",
+                    description: "Assert a structured-memory fact that can later be retracted. Prefer over free-text remember for stable true/false relations.",
                     inputSchema: waxFactAssert
                 ),
                 Tool(
                     name: "fact_retract",
-                    description: "Retract a structured-memory fact by id.",
+                    description: "Retract (soft-delete) a structured-memory fact by id when corrected or obsolete.",
                     inputSchema: waxFactRetract
                 ),
                 Tool(
                     name: "facts_query",
-                    description: "Query structured-memory facts.",
+                    description: "Query structured-memory facts for stable knowledge-graph answers.",
                     inputSchema: waxFactsQuery
                 ),
                 Tool(
                     name: "entity_resolve",
-                    description: "Resolve entities by alias.",
+                    description: "Resolve structured-memory entities by alias before asserting related facts.",
                     inputSchema: waxEntityResolve
                 ),
             ])

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -205,7 +205,7 @@ struct WaxMCPServerCommand: ParsableCommand {
         let server = Server(
             name: "wax-mcp",
             version: version,
-            instructions: "Use these tools to store, search, and recall Wax memory. Server v\(version).",
+            instructions: MCPAgentInstructions.text(version: version),
             capabilities: .init(tools: .init(listChanged: false)),
             configuration: .default
         )

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -702,6 +702,93 @@ struct WaxCLIMemoryTests {
         #expect(runtime.serverPath == server.path)
     }
 
+    @Test func mcpSkillStagingCopiesFromSourceOverride() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-cli-skill-stage-\(UUID().uuidString)", isDirectory: true)
+        let sourceSkill = tempRoot.appendingPathComponent("source-skill", isDirectory: true)
+        let installRoot = tempRoot.appendingPathComponent("install-root", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try FileManager.default.createDirectory(at: sourceSkill, withIntermediateDirectories: true)
+        try "# Wax MCP skill fixture\n".write(
+            to: sourceSkill.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let cli = tempRoot.appendingPathComponent("wax-cli")
+        let server = tempRoot.appendingPathComponent("wax-mcp")
+        try makeExecutableStub(at: cli)
+        try makeExecutableStub(at: server)
+
+        setenv("WAX_MCP_INSTALL_ROOT", installRoot.path, 1)
+        setenv("WAX_MCP_SKILL_SOURCE", sourceSkill.path, 1)
+        defer {
+            unsetenv("WAX_MCP_INSTALL_ROOT")
+            unsetenv("WAX_MCP_SKILL_SOURCE")
+        }
+
+        let skipped = try Pathing.prepareWaxMCPSkill(
+            cliPath: cli.path,
+            serverPath: server.path,
+            dryRun: false,
+            skip: true
+        )
+        #expect(skipped.skipped)
+        #expect(skipped.stagedPath == nil)
+
+        let staged = try Pathing.prepareWaxMCPSkill(
+            cliPath: cli.path,
+            serverPath: server.path,
+            dryRun: false,
+            skip: false
+        )
+        #expect(!staged.skipped)
+        #expect(staged.staged)
+        #expect(staged.sourcePath == sourceSkill.path)
+
+        let expected = installRoot
+            .appendingPathComponent("skills", isDirectory: true)
+            .appendingPathComponent("wax-mcp", isDirectory: true)
+        #expect(staged.stagedPath == expected.path)
+        #expect(Pathing.isValidSkillDirectory(expected))
+
+        let skillBody = try String(contentsOf: expected.appendingPathComponent("SKILL.md"), encoding: .utf8)
+        #expect(skillBody.contains("Wax MCP skill fixture"))
+    }
+
+    @Test func mcpSkillResolvesFromNpmPackageLayout() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-cli-skill-npm-\(UUID().uuidString)", isDirectory: true)
+        let packageRoot = tempRoot.appendingPathComponent("waxmcp-package", isDirectory: true)
+        let runtimeDir = packageRoot.appendingPathComponent("dist/darwin-arm64", isDirectory: true)
+        let skillDir = packageRoot.appendingPathComponent("skills/wax-mcp", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try FileManager.default.createDirectory(at: runtimeDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: skillDir, withIntermediateDirectories: true)
+        try makeExecutableStub(at: runtimeDir.appendingPathComponent("wax-cli"))
+        try makeExecutableStub(at: runtimeDir.appendingPathComponent("wax-mcp"))
+        try "# from npm package\n".write(
+            to: skillDir.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let resolved = Pathing.resolveWaxMCPSkillSource(
+            cliPath: runtimeDir.appendingPathComponent("wax-cli").path,
+            serverPath: runtimeDir.appendingPathComponent("wax-mcp").path
+        )
+        #expect(resolved?.path == skillDir.path)
+    }
+
+    @Test func projectRulesPlaybookMentionsLifecycle() {
+        #expect(WaxMCPAgentPlaybook.projectRules.contains("handoff_latest"))
+        #expect(WaxMCPAgentPlaybook.projectRules.contains("session_start"))
+        #expect(WaxMCPAgentPlaybook.projectRules.contains("session_id"))
+        #expect(WaxMCPAgentPlaybook.githubSkillURL.contains("wax-mcp"))
+    }
+
     @Test func embedderRuntimeOptionsOverrideEnvironment() throws {
         setenv("WAX_EMBEDDER_BATCH_SIZE", "2", 1)
         setenv("WAX_EMBEDDER_PREWARM_BATCH_SIZE", "3", 1)

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -101,6 +101,29 @@ func toolsListContainsExpectedTools() {
 }
 
 @Test
+func agentInstructionsDescribeSessionLifecycle() {
+    let text = MCPAgentInstructions.text(version: "9.9.9")
+    #expect(text.contains("server v9.9.9"))
+    #expect(text.contains("handoff_latest"))
+    #expect(text.contains("session_start"))
+    #expect(text.contains("session_end"))
+    #expect(text.contains("session_id"))
+    #expect(text.contains("Do not manage SESSION_STORE"))
+}
+
+@Test
+func coreToolDescriptionsIncludeOperatorHints() {
+    let tools = Dictionary(
+        uniqueKeysWithValues: ToolSchemas.allTools.map { ($0.name, $0.description ?? "") }
+    )
+    #expect(tools["handoff_latest"]?.contains("session start") == true)
+    #expect(tools["session_start"]?.contains("handoff_latest") == true)
+    #expect(tools["remember"]?.contains("session_id") == true)
+    #expect(tools["recall"]?.contains("Preferred read path") == true)
+    #expect(tools["handoff"]?.contains("end-of-session") == true)
+}
+
+@Test
 func toolsListHonorsStructuredMemoryFlag() {
     let withStructuredMemory = Set(ToolSchemas.tools(structuredMemoryEnabled: true).map(\.name))
     let withoutStructuredMemory = Set(ToolSchemas.tools(structuredMemoryEnabled: false).map(\.name))
@@ -1529,6 +1552,52 @@ func brokerCorpusSearchBuildSkipsLockedSessionStore() async throws {
         #expect(!execution.hits.isEmpty)
         #expect(execution.hits.contains { ($0.previewText ?? "").contains("telemetry") })
         #expect(!execution.hits.contains { ($0.previewText ?? "").contains("navigation") })
+    }
+}
+
+@Test
+func corpusSearchIncludesActiveSessionDocumentsWhileStoreIsLockedByBroker() async throws {
+    // Active session stores hold an exclusive flock, so disk rebuild skips them.
+    // corpus_search must still surface in-process active session notes.
+    try await withAgentBrokerService { service, _ in
+        let token = "ACTIVECORPUS\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12))"
+        let started = await service.handle(.init(command: "session_start"))
+        #expect(started.ok == true)
+        let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
+
+        let remembered = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Session-only preference note \(token)"),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        #expect(remembered.ok == true)
+
+        let corpus = await service.handle(.init(
+            command: "corpus_search",
+            arguments: [
+                "query": .string(String(token)),
+                "mode": .string("text"),
+                "topK": .int(5),
+                "rebuild": .bool(true),
+            ]
+        ))
+        #expect(corpus.ok == true, "corpus_search failed: \(corpus.error ?? "nil")")
+        let payload = try #require(corpus.payload?.objectValue)
+        let results = payload["results"]?.arrayValue ?? []
+        #expect(!results.isEmpty, "expected active-session hit for \(token); display=\(payload["display_text"]?.stringValue ?? "")")
+        let previews = results.compactMap { $0.objectValue?["preview"]?.stringValue }
+        #expect(previews.contains { $0.contains(token) })
+
+        let synthesize = await service.handle(.init(
+            command: "session_synthesize",
+            arguments: ["session_id": .string(sessionID)]
+        ))
+        #expect(synthesize.ok == true)
+        let summary = try #require(synthesize.payload?.objectValue?["summary"]?.stringValue)
+        #expect(summary != "No session memories recorded.")
+        #expect(summary.contains(token) || summary.localizedCaseInsensitiveContains("preference") || summary.localizedCaseInsensitiveContains("session"))
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a dedicated **wax-mcp** operator skill (session lifecycle, remember/recall, handoffs, anti-patterns) and ship it in both `Resources/skills/public/wax-mcp` and the `waxmcp` npm package under `skills/`.
- Embed the same playbook in MCP server `instructions` plus stronger core tool descriptions so agents get policy on every connect.
- Extend `mcp install` to stage the skill, best-effort `claude install-skill`, and print CLAUDE.md/AGENTS.md project-rules fallback text (`--skip-skill` supported).
- Clarify that the existing **wax** skill is for Swift framework integration only; update README/setup docs/DocC Getting Started accordingly.

## Test plan
- [x] `swift test --traits MCPServer --filter 'mcpSkill|projectRules|agentInstructions|coreToolDescriptions|mcpInstallDryRun|mcpInstallLeaves|mcpInstallStages'`
- [x] `wax-cli mcp install --dry-run --skip-build` prints skill staging + project-rules guidance
- [ ] Manual: `npx -y waxmcp@latest mcp install --scope user` after next package publish stages skill under `~/.local/share/waxmcp/skills/wax-mcp`
- [ ] Manual: Claude Code receives richer MCP instructions and can install skill via `claude install-skill ~/.local/share/waxmcp/skills/wax-mcp`