### PR TITLE
release: waxmcp v0.1.25 — vendor homebrew formula, drop submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Resources/npm/waxmcp/homebrew-wax"]
-	path = Resources/npm/waxmcp/homebrew-wax
-	url = https://github.com/christopherkarani/homebrew-wax.git

--- a/.pi/extensions/wax-agents/package.json
+++ b/.pi/extensions/wax-agents/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "wax-agents",
+  "version": "0.1.25",
+  "description": "Wax-specific multi-agent orchestration for pi",
+  "dependencies": {
+    "typebox": "^1.0.0"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/Resources/hermes/README.md
+++ b/Resources/hermes/README.md
@@ -108,7 +108,7 @@ Add to your Hermes `~/.hermes/config.yaml`:
 mcp_servers:
   wax-memory:
     command: "npx"
-    args: ["-y", "waxmcp@0.1.24", "mcp", "serve"]
+    args: ["-y", "waxmcp@0.1.25", "mcp", "serve"]
     env:
       WAX_MCP_FEATURE_LICENSE: "0"
       WAX_MCP_FEATURE_STRUCTURED_MEMORY: "1"
@@ -125,7 +125,7 @@ mcp_servers:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `command` | `npx` | Launcher for waxmcp |
-| `args` | `["-y", "waxmcp@0.1.24", "mcp", "serve"]` | Arguments passed to waxmcp |
+| `args` | `["-y", "waxmcp@0.1.25", "mcp", "serve"]` | Arguments passed to waxmcp |
 | `env.WAX_MCP_FEATURE_LICENSE` | `"0"` | Disable license checks |
 | `env.WAX_MCP_FEATURE_STRUCTURED_MEMORY` | `"1""` | Enable structured memory tools |
 | `timeout` | `120` | MCP call timeout in seconds |

--- a/Resources/hermes/wax-memory-plugin/plugin.yaml
+++ b/Resources/hermes/wax-memory-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.24
+version: 0.1.25
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -1,0 +1,44 @@
+class Wax < Formula
+  desc "On-device memory and RAG framework with MCP server for Claude Code"
+  homepage "https://github.com/christopherkarani/Wax"
+  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.25.tar.gz"
+  sha256 "b5c5462e878de9df30007d9ea92522eed62e502055b8ce0a4994e78314cc938f"
+  license "MIT"
+
+  depends_on xcode: ["16.3", :build]
+
+  def install
+    # The upstream repo defines a `waxTests` target with a custom path of
+    # `Tests/WaxTests`, but empty directories aren't included in GitHub source
+    # archives. Ensure the directory exists so SwiftPM's package graph
+    # validation succeeds.
+    mkdir_p "Tests/WaxTests"
+
+    # CoreML on-device ANE compilation can hang in CLI contexts; default to CPU-only for reliability.
+    inreplace "Sources/WaxVectorSearchMiniLM/MiniLMEmbedder.swift",
+      "computeUnitsOrder: [MLComputeUnits] = [.cpuAndNeuralEngine, .all, .cpuOnly]",
+      "computeUnitsOrder: [MLComputeUnits] = [.cpuOnly]"
+
+    system "swift", "build", "--disable-sandbox", "-c", "release",
+           "--product", "wax-cli", "--traits", "default,MCPServer"
+    system "swift", "build", "--disable-sandbox", "-c", "release",
+           "--product", "wax-mcp", "--traits", "default,MCPServer"
+
+    libexec.install ".build/release/wax-cli" => "waxmcp"
+    libexec.install ".build/release/wax-mcp"
+    libexec.install Dir[".build/release/*.bundle"]
+
+    rm_f bin/"waxmcp"
+    rm_f bin/"wax-mcp"
+    bin.write_exec_script libexec/"waxmcp"
+    bin.write_exec_script libexec/"wax-mcp"
+  end
+
+  test do
+    output = shell_output("#{bin}/waxmcp --help")
+    assert_match "USAGE:", output
+
+    health = shell_output("#{bin}/waxmcp vector-health --format text --store-path #{testpath}/health.wax")
+    assert_match "Vector health: PASS", health
+  end
+end

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxmcp",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "npx launcher for the Wax MCP server",
   "repository": {
     "type": "git",

--- a/Resources/openclaw/wax-memory-plugin/package.json
+++ b/Resources/openclaw/wax-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wax/openclaw-wax-memory",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "description": "OpenClaw memory plugin for Wax-backed agent memory.",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "openclaw": ">=2026.3.24-beta.2"
   },
   "dependencies": {
-    "waxmcp": "0.1.24"
+    "waxmcp": "0.1.25"
   },
   "devDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/Resources/scripts/quality/submodule_contract_tests.sh
+++ b/Resources/scripts/quality/submodule_contract_tests.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Assert the public Wax tree has no git submodules.
+# Submodules broke SwiftPM resolve when a gitlink pointed at an unpublished
+# homebrew-wax commit (0.1.24). Formula lives as normal tracked files now.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
@@ -9,18 +12,20 @@ fail() {
   exit 1
 }
 
+if [[ -e .gitmodules ]]; then
+  fail ".gitmodules must not exist (Homebrew formula is vendored; no submodules)"
+fi
+
 while read -r mode _ _ path; do
   [[ "$mode" == "160000" ]] || continue
-
-  name="$(git config --file .gitmodules --get-regexp '^submodule\..*\.path$' \
-    | awk -v target="$path" '$2 == target { print $1 }' \
-    | sed -E 's/^submodule\.([^.]*)\.path$/\1/' \
-    | head -n 1 || true)"
-
-  [[ -n "$name" ]] || fail "gitlink $path has no .gitmodules path entry"
-
-  git config --file .gitmodules --get "submodule.$name.url" >/dev/null \
-    || fail "gitlink $path has no .gitmodules url entry"
+  fail "gitlink $path is not allowed (submodules break SwiftPM package resolve)"
 done < <(git ls-files -s)
+
+# Formula must remain a normal file at the stable path used by release scripts.
+FORMULA="Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb"
+[[ -f "$FORMULA" ]] || fail "missing vendored Homebrew formula at $FORMULA"
+mode="$(git ls-files -s -- "$FORMULA" | awk '{print $1}')"
+[[ "$mode" == "100644" || "$mode" == "100755" ]] \
+  || fail "Homebrew formula must be a normal tracked file (got mode ${mode:-missing})"
 
 echo "submodule_contract_tests: ok"

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -23,7 +23,7 @@ import WaxVectorSearchArctic
 #endif
 
 enum WaxMCPServerMetadata {
-    static let version = "0.1.24"
+    static let version = "0.1.25"
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -25,7 +25,6 @@ SERVER_SWIFT="$ROOT/Sources/WaxMCPServer/main.swift"
 OPENCLAW_PKG="$ROOT/Resources/openclaw/wax-memory-plugin"
 OPENCODE_PKG="$ROOT/.pi/extensions/wax-agents"
 HOMEBREW_FORMULA="$ROOT/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb"
-HOMEBREW_REPO="$ROOT/Resources/npm/waxmcp/homebrew-wax"
 SYNC_SCRIPT="$ROOT/Resources/scripts/sync-waxmcp-version.sh"
 HERMES_README="$ROOT/Resources/hermes/README.md"
 HERMES_PLUGIN="$ROOT/Resources/hermes/wax-memory-plugin"
@@ -238,15 +237,15 @@ if [[ "$CURRENT_OPCODE" != "$TARGET_VERSION" ]]; then
 fi
 
 # Surfaces 5+6: Homebrew formula
+# Use sed -E (BSD/macOS + GNU) — basic sed \+ is not portable on macOS.
 if [[ "$CURRENT_HOMEBREW" != "$TARGET_VERSION" ]]; then
   # Update URL
-  sed -i '' \
-    "s|archive/refs/tags/waxmcp-v[0-9]\+\.[0-9]\+\.[0-9]\+|archive/refs/tags/waxmcp-v${TARGET_VERSION}|g" \
+  sed -i '' -E \
+    "s|archive/refs/tags/waxmcp-v[0-9]+\\.[0-9]+\\.[0-9]+|archive/refs/tags/waxmcp-v${TARGET_VERSION}|g" \
     "$HOMEBREW_FORMULA"
-  
-  # Compute SHA from local git archive
-  # GitHub uses: git archive --format=tar.gz --prefix=repo-tag/ tag
-  # We approximate this with the current HEAD
+
+  # Compute SHA from local git archive of the working tree index when possible.
+  # GitHub source archives use: git archive --format=tar.gz --prefix=Wax-<tag>/ <tag>
   TMP_ARCHIVE=$(mktemp -t wax-homebrew-sha.XXXXXX.tar.gz)
   git -C "$ROOT" archive --format=tar.gz \
     --prefix="Wax-waxmcp-v${TARGET_VERSION}/" \
@@ -254,14 +253,14 @@ if [[ "$CURRENT_HOMEBREW" != "$TARGET_VERSION" ]]; then
       rm -f "$TMP_ARCHIVE"
       fail "git archive failed — cannot compute Homebrew SHA"
     }
-  
+
   NEW_SHA=$(shasum -a 256 "$TMP_ARCHIVE" | awk '{print $1}')
   rm -f "$TMP_ARCHIVE"
-  
-  sed -i '' \
-    "s|sha256 \"[a-f0-9]\+\"|sha256 \"${NEW_SHA}\"|" \
+
+  sed -i '' -E \
+    "s|sha256 \"[a-f0-9]+\"|sha256 \"${NEW_SHA}\"|" \
     "$HOMEBREW_FORMULA"
-  
+
   info "Homebrew formula → $TARGET_VERSION (SHA: ${NEW_SHA:0:16}...)"
   echo "     ⚠️  SHA computed from local git archive — verify after pushing tag:"
   echo "        curl -sL https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v${TARGET_VERSION}.tar.gz | shasum -a 256"
@@ -270,19 +269,19 @@ fi
 # Surface 8: Hermes README
 if [[ -f "$HERMES_README" ]]; then
   # Update version references in Hermes README
-  sed -i '' \
-    "s|waxmcp-v[0-9]\+\.[0-9]\+\.[0-9]\+|waxmcp-v${TARGET_VERSION}|g" \
+  sed -i '' -E \
+    "s|waxmcp-v[0-9]+\\.[0-9]+\\.[0-9]+|waxmcp-v${TARGET_VERSION}|g" \
     "$HERMES_README"
-  sed -i '' \
-    "s|waxmcp@[0-9]\+\.[0-9]\+\.[0-9]\+|waxmcp@${TARGET_VERSION}|g" \
+  sed -i '' -E \
+    "s|waxmcp@[0-9]+\\.[0-9]+\\.[0-9]+|waxmcp@${TARGET_VERSION}|g" \
     "$HERMES_README"
   info "Hermes README → $TARGET_VERSION"
 fi
 
 # Surface 9: Hermes plugin
 if [[ -f "$HERMES_PLUGIN/plugin.yaml" ]] && [[ "$CURRENT_HERMES" != "$TARGET_VERSION" ]]; then
-  sed -i '' \
-    "s|^version: [0-9]\+\.[0-9]\+\.[0-9]\+|version: ${TARGET_VERSION}|" \
+  sed -i '' -E \
+    "s|^version: [0-9]+\\.[0-9]+\\.[0-9]+|version: ${TARGET_VERSION}|" \
     "$HERMES_PLUGIN/plugin.yaml"
   info "Hermes plugin → $TARGET_VERSION"
 fi

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -24,7 +24,6 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 VALIDATE_SCRIPT="$SCRIPT_DIR/validate-congruency.sh"
 NPM_PKG="$ROOT/Resources/npm/waxmcp"
 OPENCLAW_PKG="$ROOT/Resources/openclaw/wax-memory-plugin"
-HOMEBREW_REPO="$ROOT/Resources/npm/waxmcp/homebrew-wax"
 
 TAG="next"
 PROMOTE=false
@@ -171,28 +170,38 @@ else
 fi
 
 # ── Phase 3: Homebrew instructions ──────────────────────────────────────────
+# Formula is vendored in-tree (not a git submodule). Sync the external tap
+# repo separately so SwiftPM consumers never recurse into homebrew-wax.
 phase "Phase 3: Homebrew formula"
 
-if [[ -d "$HOMEBREW_REPO/.git" ]]; then
-  info "Homebrew tap repo found at $HOMEBREW_REPO"
+HOMEBREW_FORMULA="$ROOT/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb"
+HOMEBREW_TAP_URL="https://github.com/christopherkarani/homebrew-wax.git"
 
+if [[ -n "${HOMEBREW_WAX_TAP:-}" && -d "${HOMEBREW_WAX_TAP}/.git" ]]; then
+  info "Syncing formula into HOMEBREW_WAX_TAP=$HOMEBREW_WAX_TAP"
   if [[ "$DRY_RUN" == true ]]; then
-    echo "  [DRY-RUN] Would push homebrew-wax formula update"
+    echo "  [DRY-RUN] Would copy $HOMEBREW_FORMULA → $HOMEBREW_WAX_TAP/Formula/wax.rb and push"
   else
-    cd "$HOMEBREW_REPO"
-    if git diff --quiet 2>/dev/null; then
-      info "No changes in homebrew-wax — nothing to push"
+    mkdir -p "$HOMEBREW_WAX_TAP/Formula"
+    cp "$HOMEBREW_FORMULA" "$HOMEBREW_WAX_TAP/Formula/wax.rb"
+    cd "$HOMEBREW_WAX_TAP"
+    if git diff --quiet -- Formula/wax.rb 2>/dev/null && git diff --cached --quiet -- Formula/wax.rb 2>/dev/null; then
+      info "External homebrew-wax tap already up to date"
     else
       git add Formula/wax.rb
       git commit -m "bump wax to v$RESOLVED_VERSION"
-      git push origin master
+      git push origin HEAD
       info "Homebrew formula pushed to christopherkarani/homebrew-wax"
     fi
     cd "$ROOT"
   fi
 else
-  echo "  ⚠️  Homebrew tap repo not found at $HOMEBREW_REPO"
-  echo "     Push manually: cd $HOMEBREW_REPO && git push"
+  echo "  ℹ️  Formula is vendored at Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb"
+  echo "     Sync external tap (not a submodule) after tagging:"
+  echo "       git clone $HOMEBREW_TAP_URL /tmp/homebrew-wax"
+  echo "       cp $HOMEBREW_FORMULA /tmp/homebrew-wax/Formula/wax.rb"
+  echo "       (cd /tmp/homebrew-wax && git commit -am 'bump wax to v$RESOLVED_VERSION' && git push)"
+  echo "     Or set HOMEBREW_WAX_TAP=/path/to/clone and re-run publish."
 fi
 
 # ── Phase 4: Summary ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Root cause:** `0.1.24` pinned submodule `homebrew-wax` @ `5fa25bc`, which was never pushed to `christopherkarani/homebrew-wax`. SwiftPM recursive checkout failed.
- **Fix:** Remove the git submodule entirely; track `Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb` as a normal file so SPM consumers never clone the tap.
- **Release:** Bump all version surfaces to **0.1.25**.
- Harden `submodule_contract_tests.sh` to forbid future gitlinks/`.gitmodules`.
- Update `publish-all.sh` to sync the external tap via `HOMEBREW_WAX_TAP` (optional) instead of assuming a submodule `.git`.

## Test plan
- [x] `scripts/validate-congruency.sh` → all surfaces 0.1.25
- [x] `Resources/scripts/quality/submodule_contract_tests.sh`
- [x] `Resources/scripts/quality/homebrew_formula_tests.sh`
- [ ] After merge: tag `0.1.25` + `waxmcp-v0.1.25`, push tags (triggers npm release workflow)
- [ ] Fresh `swift package resolve` against `0.1.25` succeeds without submodule errors
- [ ] Sync external `homebrew-wax` tap formula after GitHub archive SHA is known

## Notes
- PR #77 merged first as requested.
- Do not force-move the broken `0.1.24` tags; consumers should move to ≥0.1.25.