### PR TITLE
fix: harden public API — ghost-vector sweep, Config.embedding, explicit re-exports, typed errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ A: Wax uses a write-ahead log (WAL) and dual headers. The store recovers automat
 A: Wax is optimized for Apple Silicon (M-series). It may run on Intel via Rosetta but vector acceleration requires Metal performance shaders best supported on Apple Silicon.
 
 **Q: I get "embedder unavailable" when using hybrid search.**  
-A: Hybrid and vector search require a local embedding model. In Swift, `Memory(at:)` auto-configures the built-in MiniLM embedder on iOS 18/macOS 15+ (default `MiniLMEmbeddings` trait), or you can pass any custom `EmbeddingProvider` via `Memory(at:embedding:)`. On older OS versions, use text-only search or provide a custom embedder. The CLI/MCP server fail loudly when the embedder is unavailable; the Swift SDK reports the effective retrieval mode via `results.diagnostics` and `memory.stats()`.
+A: Hybrid and vector search require a local embedding model. In Swift, `Memory(at:)` auto-configures the built-in MiniLM embedder on iOS 18/macOS 15+ (default `MiniLMEmbeddings` trait), or you can select any custom `EmbeddingProvider` via `Memory.Config.embedding = .custom(...)`. On older OS versions, use text-only search or provide a custom embedder. The CLI/MCP server fail loudly when the embedder is unavailable; the Swift SDK reports the effective retrieval mode via `results.diagnostics` and `memory.stats()`.
 
 ---
 

--- a/Resources/skills/public/wax/SKILL.md
+++ b/Resources/skills/public/wax/SKILL.md
@@ -23,7 +23,7 @@ If you need the agent memory operator playbook for MCP tools (`remember`, `recal
 ## Core Workflow
 1. Choose a `.wax` store URL.
 2. Open `Memory(at:)` — on iOS 18/macOS 15+ with the default `MiniLMEmbeddings` trait, the built-in MiniLM embedder is wired automatically.
-3. Or pass a custom `EmbeddingProvider` via `Memory(at:embedding:)`, or force a built-in via `Memory(at:builtInEmbedding: .miniLM)` (throws when unavailable).
+3. Or select the embedder in config: `Memory(at: url) { $0.embedding = .custom(MyEmbedder()) }`, or force a built-in via `$0.embedding = .builtIn(.miniLM)` (throws when unavailable).
 4. Call `save(...)` to ingest and `search(...)` to retrieve `RAGContext`.
 5. Call `flush()` or `close()` to persist.
 
@@ -112,7 +112,7 @@ func demoCustomEmbedder() async throws {
         .appendingPathComponent("wax-vector")
         .appendingPathExtension("wax")
 
-    let memory = try await Memory(at: url, embedding: MyEmbedder())
+    let memory = try await Memory(at: url) { $0.embedding = .custom(MyEmbedder()) }
     try await memory.save("Vector search enabled.")
 
     let results = try await memory.search("vector", options: .init(mode: .vectorOnly))

--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -8,11 +8,8 @@ Source: `Sources/Wax/Memory.swift`
 
 - `public actor Memory`
 - `public init(at url: URL, config: Memory.Config = .default) async throws`
-  - When `config.enableVectorSearch == true` (default), automatically wires the built-in MiniLM embedder on iOS 18/macOS 15+ (requires the default `MiniLMEmbeddings` package trait). On older OS versions or if the model is unavailable, the store runs text-only — check `stats()` or `RAGContext.diagnostics`.
-- `public init(at url: URL, configure: (inout Memory.Config) -> Void) async throws`
-- `public init(at: URL, config: Memory.Config = .default, embedding: some EmbeddingProvider) async throws`
-- `public init(at: URL, embedding: some EmbeddingProvider, configure: (inout Memory.Config) -> Void) async throws`
-- `public init(at: URL, config: Memory.Config = .default, builtInEmbedding: BuiltInEmbeddingProvider, embeddingOptions: BuiltInEmbeddingProviderOptions = .default) async throws` — throws `BuiltInEmbeddingProviderError.unavailable` when the provider is unavailable on this OS/build.
+  - Embedder selection lives on `config.embedding` (`Memory.EmbeddingSource`, default `.automatic`). With `.automatic` and `config.enableVectorSearch == true` (default), the built-in MiniLM embedder is wired on iOS 18/macOS 15+ (requires the default `MiniLMEmbeddings` package trait). On older OS versions or if the model is unavailable, the store runs text-only — check `stats()` or `RAGContext.diagnostics`.
+- `public init(at url: URL, configure: (inout Memory.Config) -> Void) async throws` — convenience closure form of the above.
 - `public func save(_ text: String, metadata: [String: String] = [:]) async throws`
 - `public func save<each S: StringProtocol>(_ texts: repeat each S) async throws`
 - `public func search(_ query: String, options: Memory.SearchOptions = .default) async throws -> Memory.Results`
@@ -25,7 +22,15 @@ Source: `Sources/Wax/Memory.swift`
 
 ### Memory.Config
 
-`public struct Config: Sendable, Equatable` with `enableTextSearch` (true), `enableVectorSearch` (true), `enableStructuredMemory` (false), `enableAccessStatsScoring` (false), `enableAsyncEnrichment` (false), `ingestConcurrency` (1), `ingestBatchSize` (32), `requireOnDeviceProviders` (true); `public static let .default`.
+`public struct Config: Sendable` with `enableTextSearch` (true), `enableVectorSearch` (true), `enableStructuredMemory` (false), `enableAccessStatsScoring` (false), `enableAsyncEnrichment` (false), `ingestConcurrency` (1), `ingestBatchSize` (32), `requireOnDeviceProviders` (true), `embedding` (`.automatic`); `public static let .default`.
+
+### Memory.EmbeddingSource
+
+`public enum EmbeddingSource: Sendable` — selects the embedder for a store:
+
+- `.automatic` — built-in MiniLM when the platform/build supports it, text-only fallback otherwise.
+- `.builtIn(BuiltInEmbeddingProvider, BuiltInEmbeddingProviderOptions = .default)` — force a built-in provider; store creation throws `BuiltInEmbeddingProviderError.unavailable` when the provider is unavailable on this OS/build.
+- `.custom(any EmbeddingProvider)` — bring your own embedder.
 
 ### Memory.SearchOptions / RetrievalMode / TimeRange
 
@@ -72,7 +77,7 @@ Source: `Sources/WaxVectorSearch/Embeddings/EmbeddingProvider.swift`
 
 ## Errors
 
-- `public enum WaxError` (WaxCore) — `Memory.Error` typealias.
+- `public enum WaxError` (WaxCore) — `Memory.Error` typealias. Catchable cases include `featureDisabled(feature:)` (API requires a config feature that is off), `missingEmbedder` (vector search enabled but no embedder configured), `invalidEmbedding(reason:)` (provider returned a bad vector), `frameNotFound(frameId:)`, `capacityExceeded(limit:requested:)`, `lockUnavailable`, `writerBusy`, `writerTimeout`, plus format/IO cases (`invalidHeader`, `invalidFooter`, `invalidToc`, `encodingError`, `decodingError`, `walCorruption`, `checksumMismatch`, `io`).
 
 ## Foundation Models Tools (iOS 26/macOS 26+)
 
@@ -85,6 +90,6 @@ The following are `package`-access internals. They are used by Wax's own CLI/MCP
 - `MemoryOrchestrator`, `OrchestratorConfig`, `FastRAGConfig` (the engine behind `Memory`)
 - `PhotoRAGOrchestrator`, `VideoRAGOrchestrator`, `MultimodalEmbeddingProvider`, `VideoTranscriptProvider` (experimental multimodal pipelines; host apps cannot use them yet)
 - `WaxSession`, `Wax` actor, `SearchRequest`, `SearchResponse`, `FrameFilter`, structured-memory types (`EntityKey`, facts)
-- `MiniLMEmbedder` (use `BuiltInEmbeddings.make(.miniLM)` or `Memory(at:builtInEmbedding:)` instead)
+- `MiniLMEmbedder` (use `BuiltInEmbeddings.make(.miniLM)` or `Memory.Config.embedding = .builtIn(.miniLM)` instead)
 
 Agent-facing access to structured memory, photo, and video memory is available through the Wax MCP server tools (`entity_upsert`, `fact_assert`, `facts_query`, `photo_*`, `video_*`), not through `import Wax`.

--- a/Resources/skills/public/wax/templates/init-store-embedder.md
+++ b/Resources/skills/public/wax/templates/init-store-embedder.md
@@ -36,7 +36,8 @@ struct <EMBEDDER_TYPE>: EmbeddingProvider {
 }
 
 let storeURL = <STORE_URL>
-let memory = try await Memory(at: storeURL, embedding: <EMBEDDER_TYPE>()) { config in
+let memory = try await Memory(at: storeURL) { config in
+    config.embedding = .custom(<EMBEDDER_TYPE>())
     <CONFIG_OVERRIDES>
 }
 ```
@@ -46,7 +47,7 @@ Alternative (built-in MiniLM, throws when unavailable):
 import Wax
 
 let storeURL = <STORE_URL>
-let memory = try await Memory(at: storeURL, builtInEmbedding: .miniLM)
+let memory = try await Memory(at: storeURL) { $0.embedding = .builtIn(.miniLM) }
 ```
 
 Alternative (automatic: built-in MiniLM when the platform supports it, text-only otherwise):

--- a/Sources/Wax/Adapters/WaxFoundationModelSession.swift
+++ b/Sources/Wax/Adapters/WaxFoundationModelSession.swift
@@ -651,12 +651,11 @@ public extension Memory {
         additionalTools: [any Tool] = [],
         sessionConfiguration: FoundationModelsMemorySessionConfig = .default
     ) async throws -> WaxFoundationModelSession {
-        let memory: Memory
+        var config = config
         if let embedding {
-            memory = try await Memory(at: url, config: config, embedding: embedding)
-        } else {
-            memory = try await Memory(at: url, config: config)
+            config.embedding = .custom(embedding)
         }
+        let memory = try await Memory(at: url, config: config)
         return WaxFoundationModelSession(
             memory: memory,
             model: model,
@@ -679,12 +678,9 @@ public extension Memory {
         additionalTools: [any Tool] = [],
         sessionConfiguration: FoundationModelsMemorySessionConfig = .default
     ) async throws -> WaxFoundationModelSession {
-        let memory = try await Memory(
-            at: url,
-            config: config,
-            builtInEmbedding: builtInEmbedding,
-            embeddingOptions: embeddingOptions
-        )
+        var config = config
+        config.embedding = .builtIn(builtInEmbedding, embeddingOptions)
+        let memory = try await Memory(at: url, config: config)
         return WaxFoundationModelSession(
             memory: memory,
             model: model,

--- a/Sources/Wax/Adapters/WaxMemoryTool.swift
+++ b/Sources/Wax/Adapters/WaxMemoryTool.swift
@@ -369,12 +369,11 @@ public extension Memory {
         embedding: (any EmbeddingProvider)? = nil,
         toolConfig: WaxMemoryToolConfig = .default
     ) async throws -> WaxMemoryTool {
-        let memory: Memory
+        var config = config
         if let embedding {
-            memory = try await Memory(at: url, config: config, embedding: embedding)
-        } else {
-            memory = try await Memory(at: url, config: config)
+            config.embedding = .custom(embedding)
         }
+        let memory = try await Memory(at: url, config: config)
         return WaxMemoryTool(memory: memory, config: toolConfig)
     }
 }

--- a/Sources/Wax/Broker/AgentBrokerProtocol.swift
+++ b/Sources/Wax/Broker/AgentBrokerProtocol.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WaxCore
 
 #if canImport(Glibc)
 import Glibc

--- a/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
+++ b/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WaxCore
+import WaxVectorSearch
 
 #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
 import WaxVectorSearchMiniLM

--- a/Sources/Wax/Enrichment/EntityExtractor.swift
+++ b/Sources/Wax/Enrichment/EntityExtractor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WaxCore
 
 /// Deterministic offline entity extraction for async enrichment.
 package enum EntityExtractor {

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Intuitive high-level facade for Wax memory operations.
 public actor Memory {
-    public struct Config: Sendable, Equatable {
+    public struct Config: Sendable {
         public var enableTextSearch: Bool
         public var enableVectorSearch: Bool
         public var enableStructuredMemory: Bool
@@ -11,6 +11,8 @@ public actor Memory {
         public var ingestConcurrency: Int
         public var ingestBatchSize: Int
         public var requireOnDeviceProviders: Bool
+        /// Which embedding provider backs vector search.
+        public var embedding: EmbeddingSource
 
         public init(
             enableTextSearch: Bool = true,
@@ -20,7 +22,8 @@ public actor Memory {
             enableAsyncEnrichment: Bool = false,
             ingestConcurrency: Int = 1,
             ingestBatchSize: Int = 32,
-            requireOnDeviceProviders: Bool = true
+            requireOnDeviceProviders: Bool = true,
+            embedding: EmbeddingSource = .automatic
         ) {
             self.enableTextSearch = enableTextSearch
             self.enableVectorSearch = enableVectorSearch
@@ -30,9 +33,26 @@ public actor Memory {
             self.ingestConcurrency = ingestConcurrency
             self.ingestBatchSize = ingestBatchSize
             self.requireOnDeviceProviders = requireOnDeviceProviders
+            self.embedding = embedding
         }
 
         public static let `default` = Config()
+    }
+
+    /// Selects the embedding provider that backs vector search for a ``Memory`` store.
+    public enum EmbeddingSource: Sendable {
+        /// Wire the built-in MiniLM embedder automatically on iOS 18/macOS 15+ when Wax
+        /// is built with the default `MiniLMEmbeddings` trait. On older OS versions, or
+        /// if the model is unavailable, the store falls back to text-only search;
+        /// inspect ``RAGContext/diagnostics`` on search results or ``Memory/stats()``
+        /// to see which mode is actually in effect.
+        case automatic
+        /// Use one of Wax's built-in embedding providers. Store creation throws if the
+        /// provider cannot be constructed (trait compiled out, model missing, or
+        /// unsupported OS).
+        case builtIn(BuiltInEmbeddingProvider, BuiltInEmbeddingProviderOptions = .default)
+        /// Use a custom embedding provider.
+        case custom(any EmbeddingProvider)
     }
 
     public enum EmbeddingPolicy: Sendable, Equatable {
@@ -96,72 +116,28 @@ public actor Memory {
 
     /// Create or open a memory store at the given URL.
     ///
-    /// When `config.enableVectorSearch` is true (the default), the built-in MiniLM
-    /// embedder is wired automatically on iOS 18/macOS 15+ when Wax is built with the
-    /// default `MiniLMEmbeddings` trait. On older OS versions, or if the model is
-    /// unavailable, the store falls back to text-only search; inspect
-    /// ``RAGContext/diagnostics`` on search results or ``stats()`` to see which mode
-    /// is actually in effect.
+    /// Embedder selection lives on ``Config/embedding`` and defaults to
+    /// ``EmbeddingSource/automatic``: the built-in MiniLM embedder is wired on
+    /// iOS 18/macOS 15+ when Wax is built with the default `MiniLMEmbeddings` trait.
+    /// On older OS versions, or if the model is unavailable, the store falls back to
+    /// text-only search; inspect ``RAGContext/diagnostics`` on search results or
+    /// ``stats()`` to see which mode is actually in effect.
     public init(at url: URL, config: Config = .default) async throws {
         self.orchestrator = try await MemoryOrchestrator(
             at: url,
             config: Self.makeOrchestratorConfig(config),
-            embedder: Self.makeAutoEmbedderIfPossible(config: config)
+            embedder: try await Self.makeEmbedder(for: config)
         )
     }
 
     /// Create or open a memory store at the given URL with inline configuration.
     ///
-    /// The same automatic built-in embedder wiring as ``init(at:config:)-9v8q0`` applies.
+    /// The same embedder selection as ``init(at:config:)`` applies; set
+    /// ``Config/embedding`` inside the closure to use a built-in or custom provider.
     public init(at url: URL, configure: (inout Config) -> Void) async throws {
         var config = Config.default
         configure(&config)
-        self.orchestrator = try await MemoryOrchestrator(
-            at: url,
-            config: Self.makeOrchestratorConfig(config),
-            embedder: Self.makeAutoEmbedderIfPossible(config: config)
-        )
-    }
-
-    public init(
-        at url: URL,
-        config: Config = .default,
-        embedding: some EmbeddingProvider
-    ) async throws {
-        self.orchestrator = try await MemoryOrchestrator(
-            at: url,
-            config: Self.makeOrchestratorConfig(config),
-            embedder: embedding
-        )
-    }
-
-    public init(
-        at url: URL,
-        embedding: some EmbeddingProvider,
-        configure: (inout Config) -> Void
-    ) async throws {
-        var config = Config.default
-        configure(&config)
-        self.orchestrator = try await MemoryOrchestrator(
-            at: url,
-            config: Self.makeOrchestratorConfig(config),
-            embedder: embedding
-        )
-    }
-
-    /// Open memory with one of Wax's built-in embedding providers.
-    public init(
-        at url: URL,
-        config: Config = .default,
-        builtInEmbedding provider: BuiltInEmbeddingProvider,
-        embeddingOptions: BuiltInEmbeddingProviderOptions = .default
-    ) async throws {
-        let embedding = try await BuiltInEmbeddings.make(provider, options: embeddingOptions)
-        self.orchestrator = try await MemoryOrchestrator(
-            at: url,
-            config: Self.makeOrchestratorConfig(config),
-            embedder: embedding
-        )
+        try await self.init(at: url, config: config)
     }
 
     /// Persist text into memory.
@@ -305,9 +281,21 @@ public actor Memory {
         )
     }
 
-    /// Builds the default on-device embedder for the no-embedder initializers when vector
-    /// search is requested. Returns nil (text-only fallback) on unsupported OS versions,
-    /// when the `MiniLMEmbeddings` trait is compiled out, or when the model fails to load.
+    /// Resolves the embedder for ``Config/embedding``. `.automatic` returns nil
+    /// (text-only fallback) on unsupported OS versions, when the `MiniLMEmbeddings`
+    /// trait is compiled out, or when the model fails to load; `.builtIn` throws
+    /// instead of falling back so misconfiguration surfaces immediately.
+    private static func makeEmbedder(for config: Config) async throws -> (any EmbeddingProvider)? {
+        switch config.embedding {
+        case .automatic:
+            return await Self.makeAutoEmbedderIfPossible(config: config)
+        case .builtIn(let provider, let options):
+            return try await BuiltInEmbeddings.make(provider, options: options)
+        case .custom(let provider):
+            return provider
+        }
+    }
+
     private static func makeAutoEmbedderIfPossible(config: Config) async -> (any EmbeddingProvider)? {
         guard config.enableVectorSearch else { return nil }
         #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -398,7 +398,7 @@ package actor MemoryOrchestrator {
         }
 
         if useVectorSearch, localEmbedder == nil {
-            throw WaxError.io("enableVectorSearch=true requires an EmbeddingProvider for ingest-time embeddings")
+            throw WaxError.missingEmbedder
         }
 
         if chunkCount == 1 {
@@ -413,7 +413,7 @@ package actor MemoryOrchestrator {
             let chunkEmbedding: [Float]?
             if useVectorSearch {
                 guard let localEmbedder else {
-                    throw WaxError.io("enableVectorSearch=true requires an EmbeddingProvider for ingest-time embeddings")
+                    throw WaxError.missingEmbedder
                 }
                 chunkEmbedding = try await Self.embedOne(
                     chunk,
@@ -443,7 +443,7 @@ package actor MemoryOrchestrator {
 
             if let chunkEmbedding {
                 guard let localEmbedder else {
-                    throw WaxError.io("enableVectorSearch=true requires an EmbeddingProvider for ingest-time embeddings")
+                    throw WaxError.missingEmbedder
                 }
                 let frameId = try await localSession.put(
                     chunkData,
@@ -2001,7 +2001,7 @@ package actor MemoryOrchestrator {
 
     private func ensureStructuredMemoryEnabled() throws {
         guard config.enableStructuredMemory else {
-            throw WaxError.io("structured memory is disabled")
+            throw WaxError.featureDisabled(feature: "structured memory")
         }
     }
 

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -620,7 +620,7 @@ package actor PhotoRAGOrchestrator {
             globalEmbedding = VectorMath.normalizeL2(globalEmbedding)
         }
         guard globalEmbedding.count == embedder.dimensions else {
-            throw WaxError.io("embedder produced \(globalEmbedding.count) dims for image, expected \(embedder.dimensions)")
+            throw WaxError.invalidEmbedding(reason: "embedder produced \(globalEmbedding.count) dims for image, expected \(embedder.dimensions)")
         }
 
         // Root frame
@@ -766,7 +766,7 @@ package actor PhotoRAGOrchestrator {
                                     vec = VectorMath.normalizeL2(vec)
                                 }
                                 guard vec.count == self.embedder.dimensions else {
-                                    throw WaxError.io("embedder produced \(vec.count) dims for region image, expected \(self.embedder.dimensions)")
+                                    throw WaxError.invalidEmbedding(reason: "embedder produced \(vec.count) dims for region image, expected \(self.embedder.dimensions)")
                                 }
                                 return (index, vec)
                             }
@@ -786,7 +786,7 @@ package actor PhotoRAGOrchestrator {
                                         vec = VectorMath.normalizeL2(vec)
                                     }
                                     guard vec.count == self.embedder.dimensions else {
-                                        throw WaxError.io("embedder produced \(vec.count) dims for region image, expected \(self.embedder.dimensions)")
+                                        throw WaxError.invalidEmbedding(reason: "embedder produced \(vec.count) dims for region image, expected \(self.embedder.dimensions)")
                                     }
                                     return (index, vec)
                                 }
@@ -1106,9 +1106,13 @@ package actor PhotoRAGOrchestrator {
         }
 
         var next = IndexState()
+        var retiredVectorIds: Set<UInt64> = []
 
         for meta in metas {
-            guard meta.status != .deleted else { continue }
+            guard meta.status != .deleted else {
+                retiredVectorIds.insert(meta.id)
+                continue
+            }
             guard let kind = meta.kind else { continue }
             if !kind.hasPrefix("photo.") && kind != FrameKind.syncState { continue }
             guard let entries = meta.metadata?.entries,
@@ -1116,13 +1120,19 @@ package actor PhotoRAGOrchestrator {
             else { continue }
 
             if kind == FrameKind.root {
-                guard meta.supersededBy == nil else { continue }
+                guard meta.supersededBy == nil else {
+                    retiredVectorIds.insert(meta.id)
+                    continue
+                }
                 next.rootByAssetID[assetID] = meta.id
                 next.assetIDByRoot[meta.id] = assetID
             }
 
             if let parentId = meta.parentId {
-                guard !supersededRoots.contains(parentId) else { continue }
+                guard !supersededRoots.contains(parentId) else {
+                    retiredVectorIds.insert(meta.id)
+                    continue
+                }
                 var refs = next.derivedByRoot[parentId] ?? DerivedRefs()
                 switch kind {
                 case FrameKind.ocrSummary:
@@ -1149,6 +1159,26 @@ package actor PhotoRAGOrchestrator {
         }
 
         index = next
+        await sweepRetiredVectors(retiredVectorIds)
+    }
+
+    /// Removes vectors for frames outside the live index (superseded trees, deleted
+    /// frames). Stores written before vector cleanup existed can otherwise keep serving
+    /// ghost hits for retired frames. Best-effort: a sweep failure must not block
+    /// opening or reindexing the store.
+    private func sweepRetiredVectors(_ frameIds: Set<UInt64>) async {
+        guard !frameIds.isEmpty else { return }
+        for frameId in frameIds {
+            do {
+                try await session.removeVector(frameId: frameId)
+            } catch {
+                WaxDiagnostics.logSwallowed(
+                    error,
+                    context: "PhotoRAG retired-vector sweep",
+                    fallback: "stale vector may remain in the committed index"
+                )
+            }
+        }
     }
 
     private static func isSearchablePhotoKind(_ kind: String) -> Bool {
@@ -1313,7 +1343,7 @@ package actor PhotoRAGOrchestrator {
             var vec = try await embedder.embed(image: cg)
             if embedder.normalize, !vec.isEmpty { vec = VectorMath.normalizeL2(vec) }
             guard vec.count == embedder.dimensions else {
-                throw WaxError.io("embedder produced \(vec.count) dims for query image, expected \(embedder.dimensions)")
+                throw WaxError.invalidEmbedding(reason: "embedder produced \(vec.count) dims for query image, expected \(embedder.dimensions)")
             }
             imageEmbedding = vec
         } else {
@@ -1357,7 +1387,7 @@ package actor PhotoRAGOrchestrator {
         var vec = try await embedder.embed(text: text)
         if embedder.normalize, !vec.isEmpty { vec = VectorMath.normalizeL2(vec) }
         guard vec.count == embedder.dimensions else {
-            throw WaxError.io("embedder produced \(vec.count) dims for query text, expected \(embedder.dimensions)")
+            throw WaxError.invalidEmbedding(reason: "embedder produced \(vec.count) dims for query text, expected \(embedder.dimensions)")
         }
         await queryEmbeddingCache?.set(key, value: vec)
         return vec

--- a/Sources/Wax/PublicAliases.swift
+++ b/Sources/Wax/PublicAliases.swift
@@ -1,3 +1,15 @@
-@_exported import WaxCore
-@_exported import WaxTextSearch
-@_exported import WaxVectorSearch
+import WaxCore
+import WaxVectorSearch
+
+// Explicit public re-exports of the WaxCore/WaxVectorSearch types that are part of
+// Wax's documented public API (see Resources/skills/public/wax/references/public-api.md).
+// Anything not listed here is an implementation detail; add a typealias only together
+// with a docs entry. `@_exported import` was removed because it silently leaks every
+// public symbol of the underlying modules into Wax's namespace.
+
+public typealias WaxError = WaxCore.WaxError
+
+public typealias EmbeddingProvider = WaxVectorSearch.EmbeddingProvider
+public typealias BatchEmbeddingProvider = WaxVectorSearch.BatchEmbeddingProvider
+public typealias EmbeddingIdentity = WaxVectorSearch.EmbeddingIdentity
+public typealias ProviderExecutionMode = WaxVectorSearch.ProviderExecutionMode

--- a/Sources/Wax/VectorSearchSession.swift
+++ b/Sources/Wax/VectorSearchSession.swift
@@ -68,7 +68,7 @@ package actor WaxVectorSearchSession {
         var merged = options
         if let identity {
             if let expectedDims = identity.dimensions, expectedDims != embedding.count {
-                throw WaxError.io("embedding identity dimension mismatch: expected \(expectedDims), got \(embedding.count)")
+                throw WaxError.invalidEmbedding(reason: "dimension mismatch: expected \(expectedDims), got \(embedding.count)")
             }
             var metadata = merged.metadata ?? Metadata()
             if let provider = identity.provider { metadata.entries["memvid.embedding.provider"] = provider }
@@ -110,7 +110,7 @@ package actor WaxVectorSearchSession {
         if let identity {
             for (index, _) in options.enumerated() {
                 if let expectedDims = identity.dimensions, expectedDims != embeddings[index].count {
-                    throw WaxError.io("embedding identity dimension mismatch: expected \(expectedDims), got \(embeddings[index].count)")
+                    throw WaxError.invalidEmbedding(reason: "dimension mismatch: expected \(expectedDims), got \(embeddings[index].count)")
                 }
                 var metadata = mergedOptions[index].metadata ?? Metadata()
                 if let provider = identity.provider { metadata.entries["memvid.embedding.provider"] = provider }

--- a/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
+++ b/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
@@ -777,9 +777,13 @@ package actor VideoRAGOrchestrator {
         }
 
         var next = IndexState()
+        var retiredVectorIds: Set<UInt64> = []
 
         for meta in metas {
-            guard meta.status != .deleted else { continue }
+            guard meta.status != .deleted else {
+                retiredVectorIds.insert(meta.id)
+                continue
+            }
             guard let kind = meta.kind else { continue }
             if kind != FrameKind.root && kind != FrameKind.segment { continue }
             guard let entries = meta.metadata?.entries else { continue }
@@ -791,7 +795,10 @@ package actor VideoRAGOrchestrator {
             let vid = VideoID(source: src, id: sourceID)
 
             if kind == FrameKind.root {
-                guard meta.supersededBy == nil else { continue }
+                guard meta.supersededBy == nil else {
+                    retiredVectorIds.insert(meta.id)
+                    continue
+                }
                 next.rootByVideoID[vid] = meta.id
                 next.rootMetaByVideoID[vid] = meta
                 continue
@@ -799,7 +806,10 @@ package actor VideoRAGOrchestrator {
 
             // Segment: only if parent root is current.
             if let parentId = meta.parentId {
-                guard !supersededRoots.contains(parentId) else { continue }
+                guard !supersededRoots.contains(parentId) else {
+                    retiredVectorIds.insert(meta.id)
+                    continue
+                }
                 if next.rootByVideoID[vid] == parentId {
                     next.segmentIdsByVideoID[vid, default: []].insert(meta.id)
                 }
@@ -807,6 +817,26 @@ package actor VideoRAGOrchestrator {
         }
 
         index = next
+        await sweepRetiredVectors(retiredVectorIds)
+    }
+
+    /// Removes vectors for frames outside the live index (superseded trees, deleted
+    /// frames). Stores written before vector cleanup existed can otherwise keep serving
+    /// ghost hits for retired frames. Best-effort: a sweep failure must not block
+    /// opening or reindexing the store.
+    private func sweepRetiredVectors(_ frameIds: Set<UInt64>) async {
+        guard !frameIds.isEmpty else { return }
+        for frameId in frameIds {
+            do {
+                try await session.removeVector(frameId: frameId)
+            } catch {
+                WaxDiagnostics.logSwallowed(
+                    error,
+                    context: "VideoRAG retired-vector sweep",
+                    fallback: "stale vector may remain in the committed index"
+                )
+            }
+        }
     }
 
     private func isDegraded(videoID: VideoID) -> Bool {

--- a/Sources/Wax/Wax.docc/Articles/GettingStarted.md
+++ b/Sources/Wax/Wax.docc/Articles/GettingStarted.md
@@ -41,13 +41,17 @@ let memory = try await Memory(at: URL(filePath: "memory.wax"))
 To configure the built-in embedder explicitly (and fail loudly when it is unavailable):
 
 ```swift
-let memory = try await Memory(at: URL(filePath: "memory.wax"), builtInEmbedding: .miniLM)
+let memory = try await Memory(at: URL(filePath: "memory.wax")) { config in
+    config.embedding = .builtIn(.miniLM)
+}
 ```
 
-To bring your own embedding model, conform to `EmbeddingProvider` and pass it in:
+To bring your own embedding model, conform to `EmbeddingProvider` and select it in the config:
 
 ```swift
-let memory = try await Memory(at: URL(filePath: "memory.wax"), embedding: MyEmbedder())
+let memory = try await Memory(at: URL(filePath: "memory.wax")) { config in
+    config.embedding = .custom(MyEmbedder())
+}
 ```
 
 The store creates a new `.wax` file if one doesn't exist, or opens and recovers an existing one.

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -148,7 +148,7 @@ package actor WaxSession {
 
     package func searchText(query: String, topK: Int) async throws -> [TextSearchResult] {
         guard config.enableTextSearch, let textEngine else {
-            throw WaxError.io("text search is disabled")
+            throw WaxError.featureDisabled(feature: "text search")
         }
         return try await textEngine.search(query: query, topK: topK)
     }
@@ -158,7 +158,7 @@ package actor WaxSession {
     package func indexText(frameId: UInt64, text: String) async throws {
         try ensureWritable()
         guard config.enableTextSearch, let textEngine else {
-            throw WaxError.io("text search is disabled")
+            throw WaxError.featureDisabled(feature: "text search")
         }
         try await textEngine.index(frameId: frameId, text: text)
     }
@@ -166,7 +166,7 @@ package actor WaxSession {
     package func indexTextBatch(frameIds: [UInt64], texts: [String]) async throws {
         try ensureWritable()
         guard config.enableTextSearch, let textEngine else {
-            throw WaxError.io("text search is disabled")
+            throw WaxError.featureDisabled(feature: "text search")
         }
         try await textEngine.indexBatch(frameIds: frameIds, texts: texts)
     }
@@ -174,7 +174,7 @@ package actor WaxSession {
     package func removeText(frameId: UInt64) async throws {
         try ensureWritable()
         guard config.enableTextSearch, let textEngine else {
-            throw WaxError.io("text search is disabled")
+            throw WaxError.featureDisabled(feature: "text search")
         }
         try await textEngine.remove(frameId: frameId)
     }
@@ -188,7 +188,7 @@ package actor WaxSession {
     package func removeVector(frameId: UInt64) async throws {
         try ensureWritable()
         guard config.enableVectorSearch else {
-            throw WaxError.io("vector search is disabled")
+            throw WaxError.featureDisabled(feature: "vector search")
         }
         pendingRemovedFrameIds.insert(frameId)
         guard let concreteVectorEngine else {
@@ -207,14 +207,14 @@ package actor WaxSession {
     ) async throws -> EntityRowID {
         try ensureWritable()
         guard config.enableStructuredMemory, let textEngine else {
-            throw WaxError.io("structured memory is disabled")
+            throw WaxError.featureDisabled(feature: "structured memory")
         }
         return try await textEngine.upsertEntity(key: key, kind: kind, aliases: aliases, nowMs: nowMs)
     }
 
     package func resolveEntities(matchingAlias alias: String, limit: Int) async throws -> [StructuredEntityMatch] {
         guard config.enableStructuredMemory, let textEngine else {
-            throw WaxError.io("structured memory is disabled")
+            throw WaxError.featureDisabled(feature: "structured memory")
         }
         return try await textEngine.resolveEntities(matchingAlias: alias, limit: limit)
     }
@@ -230,7 +230,7 @@ package actor WaxSession {
     ) async throws -> FactRowID {
         try ensureWritable()
         guard config.enableStructuredMemory, let textEngine else {
-            throw WaxError.io("structured memory is disabled")
+            throw WaxError.featureDisabled(feature: "structured memory")
         }
         return try await textEngine.assertFact(
             subject: subject,
@@ -246,7 +246,7 @@ package actor WaxSession {
     package func retractFact(factId: FactRowID, atMs: Int64) async throws {
         try ensureWritable()
         guard config.enableStructuredMemory, let textEngine else {
-            throw WaxError.io("structured memory is disabled")
+            throw WaxError.featureDisabled(feature: "structured memory")
         }
         try await textEngine.retractFact(factId: factId, atMs: atMs)
     }
@@ -258,7 +258,7 @@ package actor WaxSession {
         limit: Int
     ) async throws -> StructuredFactsResult {
         guard config.enableStructuredMemory, let textEngine else {
-            throw WaxError.io("structured memory is disabled")
+            throw WaxError.featureDisabled(feature: "structured memory")
         }
         return try await textEngine.facts(about: subject, predicate: predicate, asOf: asOf, limit: limit)
     }
@@ -271,7 +271,7 @@ package actor WaxSession {
         limit: Int
     ) async throws -> StructuredEdgesResult {
         guard config.enableStructuredMemory, let textEngine else {
-            throw WaxError.io("structured memory is disabled")
+            throw WaxError.featureDisabled(feature: "structured memory")
         }
         return try await textEngine.edges(for: entity, direction: direction, predicate: predicate, asOf: asOf, limit: limit)
     }

--- a/Sources/WaxCLI/AgentDaemonClient.swift
+++ b/Sources/WaxCLI/AgentDaemonClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Wax
+import WaxCore
 
 enum AgentBrokerPolicy {
     static func shouldUseBroker(store: StoreOptions, commit: Bool = true) -> Bool {

--- a/Sources/WaxCLI/EntityCommand.swift
+++ b/Sources/WaxCLI/EntityCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import Wax
+import WaxCore
 
 struct EntityUpsertCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/WaxCLI/FactsCommand.swift
+++ b/Sources/WaxCLI/FactsCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import Wax
+import WaxCore
 
 struct FactAssertCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/WaxCore/Compression/CompressionKind.swift
+++ b/Sources/WaxCore/Compression/CompressionKind.swift
@@ -1,5 +1,5 @@
 /// Supported compression algorithms for frame payload bytes (v1).
-package enum CompressionKind: Sendable, Equatable {
+enum CompressionKind: Sendable, Equatable {
     case none
     case lzfse
     case lz4

--- a/Sources/WaxCore/Compression/PayloadCompressor.swift
+++ b/Sources/WaxCore/Compression/PayloadCompressor.swift
@@ -7,7 +7,7 @@ import WaxCoreCompressionC
 #endif
 
 /// Payload compression backend selected per platform.
-package enum PayloadCompressor {
+enum PayloadCompressor {
     package static func compress(_ data: Data, algorithm: CompressionKind) throws -> Data {
         guard algorithm != .none else { return data }
         if data.isEmpty { return Data() }

--- a/Sources/WaxCore/FileFormat/IndexManifests.swift
+++ b/Sources/WaxCore/FileFormat/IndexManifests.swift
@@ -109,7 +109,7 @@ extension VecIndexManifest: BinaryCodable {
     }
 }
 
-package struct IndexManifests: Equatable, Sendable {
+struct IndexManifests: Equatable, Sendable {
     package var lex: LexIndexManifest?
     package var vec: VecIndexManifest?
 

--- a/Sources/WaxCore/FileFormat/SegmentCatalog.swift
+++ b/Sources/WaxCore/FileFormat/SegmentCatalog.swift
@@ -26,7 +26,7 @@ private enum SegmentCatalogValidation {
     }
 }
 
-package struct SegmentCatalogEntry: Equatable, Sendable {
+struct SegmentCatalogEntry: Equatable, Sendable {
     package var segmentId: UInt64
     package var bytesOffset: UInt64
     package var bytesLength: UInt64
@@ -51,7 +51,7 @@ package struct SegmentCatalogEntry: Equatable, Sendable {
     }
 }
 
-package struct SegmentCatalog: Equatable, Sendable {
+struct SegmentCatalog: Equatable, Sendable {
     package var entries: [SegmentCatalogEntry]
 
     package init(entries: [SegmentCatalogEntry] = []) {

--- a/Sources/WaxCore/FileFormat/TicketRef.swift
+++ b/Sources/WaxCore/FileFormat/TicketRef.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-package struct TicketRef: Equatable, Sendable {
+struct TicketRef: Equatable, Sendable {
     package var issuer: String
     package var seqNo: UInt64
     package var expiresInSecs: UInt64

--- a/Sources/WaxCore/FileFormat/WaxEnums.swift
+++ b/Sources/WaxCore/FileFormat/WaxEnums.swift
@@ -17,14 +17,14 @@ package enum FrameStatus: UInt8, Equatable, Sendable {
     case deleted = 1
 }
 
-package enum SegmentCompression: UInt8, Equatable, Sendable {
+enum SegmentCompression: UInt8, Equatable, Sendable {
     case none = 0
     case lzfse = 1
     case lz4 = 2
     case deflate = 3
 }
 
-package enum SegmentKind: UInt8, Equatable, Sendable {
+enum SegmentKind: UInt8, Equatable, Sendable {
     case lex = 0
     case vec = 1
     case time = 2

--- a/Sources/WaxCore/FileFormat/WaxHeaderPage.swift
+++ b/Sources/WaxCore/FileFormat/WaxHeaderPage.swift
@@ -19,7 +19,7 @@ package struct WaxHeaderPage: Equatable, Sendable {
     private static let replaySnapshotValidFlag: UInt64 = 0x1
     private static let replaySnapshotMagic = Data([0x57, 0x41, 0x4C, 0x53, 0x4E, 0x41, 0x50, 0x31]) // WALSNAP1
 
-    package struct WALReplaySnapshot: Equatable, Sendable {
+    struct WALReplaySnapshot: Equatable, Sendable {
         package var fileGeneration: UInt64
         package var walCommittedSeq: UInt64
         package var footerOffset: UInt64
@@ -61,12 +61,12 @@ package struct WaxHeaderPage: Equatable, Sendable {
     package var walCheckpointPos: UInt64
     package var walCommittedSeq: UInt64
 
-    package var walReplaySnapshot: WALReplaySnapshot?
+    var walReplaySnapshot: WALReplaySnapshot?
 
     package var tocChecksum: Data
     package var headerChecksum: Data
 
-    package init(
+    init(
         formatVersion: UInt16 = Constants.specVersion,
         specMajor: UInt8 = Constants.specMajor,
         specMinor: UInt8 = Constants.specMinor,

--- a/Sources/WaxCore/FileFormat/WaxTOC.swift
+++ b/Sources/WaxCore/FileFormat/WaxTOC.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-package struct TimeIndexManifest: Equatable, Sendable {
+struct TimeIndexManifest: Equatable, Sendable {
     package var bytesOffset: UInt64
     package var bytesLength: UInt64
     package var entryCount: UInt64
@@ -42,15 +42,15 @@ extension TimeIndexManifest: BinaryCodable {
 package struct WaxTOC: Equatable, Sendable {
     package var tocVersion: UInt64
     package var frames: [FrameMeta]
-    package var indexes: IndexManifests
-    package var timeIndex: TimeIndexManifest?
-    package var segmentCatalog: SegmentCatalog
-    package var ticketRef: TicketRef
+    var indexes: IndexManifests
+    var timeIndex: TimeIndexManifest?
+    var segmentCatalog: SegmentCatalog
+    var ticketRef: TicketRef
     package var memoryBinding: MemoryBinding?
     package var merkleRoot: Data
     package var tocChecksum: Data
 
-    package init(
+    init(
         tocVersion: UInt64,
         frames: [FrameMeta],
         indexes: IndexManifests,

--- a/Sources/WaxCore/IO/FDFile.swift
+++ b/Sources/WaxCore/IO/FDFile.swift
@@ -317,7 +317,7 @@ package final class FDFile {
 
     /// Map a writable region of the file at the given offset and length.
     /// The returned region must be closed to unmap the memory.
-    package func mapWritable(length: Int, at offset: UInt64) throws -> MappedWritableRegion {
+    func mapWritable(length: Int, at offset: UInt64) throws -> MappedWritableRegion {
         try ensureOpen()
         guard length > 0 else {
             throw WaxError.io("mapWritable length must be > 0")
@@ -453,7 +453,7 @@ package final class FDFile {
 extension FDFile: @unchecked Sendable {}
 
 /// RAII wrapper around a writable mmap region.
-package final class MappedWritableRegion: @unchecked Sendable {
+final class MappedWritableRegion: @unchecked Sendable {
     private let basePointer: UnsafeMutableRawPointer
     private let mappedLength: Int
     package let buffer: UnsafeMutableRawBufferPointer

--- a/Sources/WaxCore/StructuredMemory/PredicateRowID.swift
+++ b/Sources/WaxCore/StructuredMemory/PredicateRowID.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Stable row identifier for a stored predicate.
-package struct PredicateRowID: RawRepresentable, Hashable, Codable, Sendable, Comparable {
+struct PredicateRowID: RawRepresentable, Hashable, Codable, Sendable, Comparable {
     package var rawValue: Int64
 
     package init(rawValue: Int64) {

--- a/Sources/WaxCore/WAL/WALEntryCodec.swift
+++ b/Sources/WaxCore/WAL/WALEntryCodec.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-package enum WALEntryCodec {
-    package enum OpCode: UInt8 {
+enum WALEntryCodec {
+    enum OpCode: UInt8 {
         case putFrame = 0x01
         case deleteFrame = 0x02
         case supersedeFrame = 0x03

--- a/Sources/WaxCore/WAL/WALRecord.swift
+++ b/Sources/WaxCore/WAL/WALRecord.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-package struct WALFlags: OptionSet, Sendable, Equatable {
+struct WALFlags: OptionSet, Sendable, Equatable {
     package let rawValue: UInt32
 
     package init(rawValue: UInt32) {
@@ -10,7 +10,7 @@ package struct WALFlags: OptionSet, Sendable, Equatable {
     package static let isPadding = WALFlags(rawValue: 1 << 0)
 }
 
-package struct WALRecordHeader: Equatable, Sendable {
+struct WALRecordHeader: Equatable, Sendable {
     package static let size: Int = 48
 
     package var sequence: UInt64
@@ -82,7 +82,7 @@ package struct WALRecordHeader: Equatable, Sendable {
     }
 }
 
-package enum WALRecord: Equatable, Sendable {
+enum WALRecord: Equatable, Sendable {
     package static let headerSize: Int = WALRecordHeader.size
     package static let checksumSize: Int = 32
     package static let paddingChecksum: Data = SHA256Checksum.digest(Data())

--- a/Sources/WaxCore/WAL/WALRingReader.swift
+++ b/Sources/WaxCore/WAL/WALRingReader.swift
@@ -1,5 +1,5 @@
 import Foundation
-package struct WALRecordLocation: Equatable, Sendable {
+struct WALRecordLocation: Equatable, Sendable {
     package var offset: UInt64
     package var record: WALRecord
 
@@ -9,7 +9,7 @@ package struct WALRecordLocation: Equatable, Sendable {
     }
 }
 
-package struct WALScanState: Equatable, Sendable {
+struct WALScanState: Equatable, Sendable {
     package var lastSequence: UInt64
     package var writePos: UInt64
     package var pendingBytes: UInt64
@@ -21,7 +21,7 @@ package struct WALScanState: Equatable, Sendable {
     }
 }
 
-package struct WALPendingScanResult: Equatable, Sendable {
+struct WALPendingScanResult: Equatable, Sendable {
     package var pendingMutations: [PendingMutation]
     package var state: WALScanState
 
@@ -64,7 +64,7 @@ package final class WALRingReader {
         return header.isSentinel || header.sequence == 0
     }
 
-    package func scanRecords(from checkpointPos: UInt64, committedSeq: UInt64) throws -> [WALRecordLocation] {
+    func scanRecords(from checkpointPos: UInt64, committedSeq: UInt64) throws -> [WALRecordLocation] {
         return try scanInternal(from: checkpointPos, committedSeq: committedSeq) { offset, header, payload in
             let record = WALRecord.data(sequence: header.sequence, flags: header.flags, payload: payload)
             return WALRecordLocation(offset: offset, record: record)
@@ -78,7 +78,7 @@ package final class WALRingReader {
         }
     }
 
-    package func scanPendingMutationsWithState(from checkpointPos: UInt64, committedSeq: UInt64) throws -> WALPendingScanResult {
+    func scanPendingMutationsWithState(from checkpointPos: UInt64, committedSeq: UInt64) throws -> WALPendingScanResult {
         guard walSize > 0 else {
             return WALPendingScanResult(
                 pendingMutations: [],
@@ -177,7 +177,7 @@ package final class WALRingReader {
         return WALPendingScanResult(pendingMutations: pendingMutations, state: state)
     }
 
-    package func scanState(from checkpointPos: UInt64) throws -> WALScanState {
+    func scanState(from checkpointPos: UInt64) throws -> WALScanState {
         guard walSize > 0 else { return WALScanState(lastSequence: 0, writePos: 0, pendingBytes: 0) }
 
         let start = checkpointPos % walSize

--- a/Sources/WaxCore/WAL/WALRingWriter.swift
+++ b/Sources/WaxCore/WAL/WALRingWriter.swift
@@ -71,7 +71,7 @@ package final class WALRingWriter {
     }
 
     @discardableResult
-    package func append(payload: Data, flags: WALFlags = []) throws -> UInt64 {
+    func append(payload: Data, flags: WALFlags = []) throws -> UInt64 {
         guard !isFaulted else {
             throw WaxError.io("WAL writer is faulted after a partial write failure")
         }
@@ -192,7 +192,7 @@ package final class WALRingWriter {
 
     /// Append multiple payloads in a single pass, reusing padding and wrap calculations.
     /// Returns the sequence numbers for the appended data records (padding records are excluded).
-    package func appendBatch(payloads: [Data], flags: WALFlags = []) throws -> [UInt64] {
+    func appendBatch(payloads: [Data], flags: WALFlags = []) throws -> [UInt64] {
         guard !isFaulted else {
             throw WaxError.io("WAL writer is faulted after a partial write failure")
         }

--- a/Sources/WaxCore/WaxError.swift
+++ b/Sources/WaxCore/WaxError.swift
@@ -15,6 +15,14 @@ public enum WaxError: Error, LocalizedError, Sendable {
     case io(String)
     case writerBusy
     case writerTimeout
+    /// An API was called that requires a feature disabled in the store configuration
+    /// (for example text search, vector search, or structured memory).
+    case featureDisabled(feature: String)
+    /// An embedding provider returned a vector that failed validation
+    /// (wrong dimensions, non-finite values, or zero magnitude).
+    case invalidEmbedding(reason: String)
+    /// Vector search is enabled but no embedding provider is configured.
+    case missingEmbedder
 
     public var errorDescription: String? {
         switch self {
@@ -44,6 +52,12 @@ public enum WaxError: Error, LocalizedError, Sendable {
             return "Writer session already active"
         case .writerTimeout:
             return "Timed out waiting for writer session"
+        case .featureDisabled(let feature):
+            return "Feature disabled: \(feature). Enable it in the store configuration to use this API."
+        case .invalidEmbedding(let reason):
+            return "Invalid embedding: \(reason)"
+        case .missingEmbedder:
+            return "Vector search requires an embedding provider; set Memory.Config.embedding or disable vector search."
         }
     }
 }

--- a/Sources/WaxCrashHarness/main.swift
+++ b/Sources/WaxCrashHarness/main.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Wax
+import WaxCore
 
 private enum HarnessError: Error, CustomStringConvertible {
     case invalidArgument(String)
@@ -107,7 +108,7 @@ struct WaxCrashHarness {
             throw HarnessError.childDidNotCrash(status: child.status, reason: child.reason)
         }
 
-        let recovered = try await Wax.open(at: url, options: WaxOptions(walReplayStateSnapshotEnabled: true))
+        let recovered = try await WaxCore.Wax.open(at: url, options: WaxOptions(walReplayStateSnapshotEnabled: true))
         let stats = await recovered.stats()
         guard stats.frameCount == scenario.expectedCommittedFramesAfterRecovery else {
             throw HarnessError.invariantFailed(
@@ -133,7 +134,7 @@ struct WaxCrashHarness {
     /// Seeds the store with a single "seed" frame and returns its allocated frame ID.
     @discardableResult
     private static func seedStore(at url: URL) async throws -> UInt64 {
-        let wax = try await Wax.create(at: url, options: WaxOptions(walReplayStateSnapshotEnabled: true))
+        let wax = try await WaxCore.Wax.create(at: url, options: WaxOptions(walReplayStateSnapshotEnabled: true))
         let seedFrameId = try await wax.put(Data("seed".utf8), options: FrameMetaSubset(searchText: "seed"))
         try await wax.commit()
         try await wax.close()
@@ -164,7 +165,7 @@ struct WaxCrashHarness {
         }
 
         let url = URL(fileURLWithPath: storePath)
-        let wax = try await Wax.open(at: url, options: WaxOptions(walReplayStateSnapshotEnabled: true))
+        let wax = try await WaxCore.Wax.open(at: url, options: WaxOptions(walReplayStateSnapshotEnabled: true))
         _ = try await wax.put(
             Data("payload-\(scenario.rawValue)".utf8),
             options: FrameMetaSubset(searchText: "payload-\(scenario.rawValue)")

--- a/Sources/WaxVectorSearchArctic/ArcticEmbedder.swift
+++ b/Sources/WaxVectorSearchArctic/ArcticEmbedder.swift
@@ -126,7 +126,7 @@ package actor ArcticEmbedder: EmbeddingProvider, BatchEmbeddingProvider, QueryAw
             throw WaxError.io("Arctic embedding failed to produce a vector.")
         }
         if vector.count != dimensions {
-            throw WaxError.io("Arctic produced \(vector.count) dims, expected \(dimensions).")
+            throw WaxError.invalidEmbedding(reason: "Arctic produced \(vector.count) dims, expected \(dimensions).")
         }
         return vector
     }
@@ -176,7 +176,7 @@ package actor ArcticEmbedder: EmbeddingProvider, BatchEmbeddingProvider, QueryAw
         }
         for vector in vectors {
             if vector.count != dimensions {
-                throw WaxError.io("Arctic produced \(vector.count) dims, expected \(dimensions).")
+                throw WaxError.invalidEmbedding(reason: "Arctic produced \(vector.count) dims, expected \(dimensions).")
             }
         }
         return vectors

--- a/Sources/WaxVectorSearchMiniLM/MiniLMEmbedder.swift
+++ b/Sources/WaxVectorSearchMiniLM/MiniLMEmbedder.swift
@@ -131,7 +131,7 @@ package actor MiniLMEmbedder: EmbeddingProvider, BatchEmbeddingProvider {
             throw WaxError.io("MiniLMAll embedding failed to produce a vector.")
         }
         if vector.count != dimensions {
-            throw WaxError.io("MiniLMAll produced \(vector.count) dims, expected \(dimensions).")
+            throw WaxError.invalidEmbedding(reason: "MiniLMAll produced \(vector.count) dims, expected \(dimensions).")
         }
         return try Self.validatedNormalizedVector(vector, dimensions: dimensions)
     }
@@ -180,7 +180,7 @@ package actor MiniLMEmbedder: EmbeddingProvider, BatchEmbeddingProvider {
         }
         for vector in vectors {
             if vector.count != dimensions {
-                throw WaxError.io("MiniLMAll produced \(vector.count) dims, expected \(dimensions).")
+                throw WaxError.invalidEmbedding(reason: "MiniLMAll produced \(vector.count) dims, expected \(dimensions).")
             }
         }
         return try vectors.map { try Self.validatedNormalizedVector($0, dimensions: dimensions) }
@@ -259,17 +259,17 @@ extension MiniLMEmbedder {
 private extension MiniLMEmbedder {
     static func validatedNormalizedVector(_ vector: [Float], dimensions: Int) throws -> [Float] {
         guard vector.count == dimensions else {
-            throw WaxError.io("MiniLMAll produced \(vector.count) dims, expected \(dimensions).")
+            throw WaxError.invalidEmbedding(reason: "MiniLMAll produced \(vector.count) dims, expected \(dimensions).")
         }
         guard vector.allSatisfy(\.isFinite) else {
-            throw WaxError.io("MiniLMAll produced a non-finite embedding value.")
+            throw WaxError.invalidEmbedding(reason: "MiniLMAll produced a non-finite embedding value.")
         }
         let sumOfSquares = vector.reduce(Float(0)) { $0 + $1 * $1 }
         guard sumOfSquares.isFinite else {
-            throw WaxError.io("MiniLMAll produced a non-finite embedding magnitude.")
+            throw WaxError.invalidEmbedding(reason: "MiniLMAll produced a non-finite embedding magnitude.")
         }
         guard sumOfSquares > 0 else {
-            throw WaxError.io("MiniLMAll produced a zero-magnitude embedding.")
+            throw WaxError.invalidEmbedding(reason: "MiniLMAll produced a zero-magnitude embedding.")
         }
         let inverseMagnitude = 1 / sqrt(sumOfSquares)
         return vector.map { $0 * inverseMagnitude }

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Dispatch
 import Testing
 import Wax
+import WaxCore
 @testable import wax_cli
 #if canImport(Darwin)
 import Darwin

--- a/Tests/WaxCoreTests/CompressionTests.swift
+++ b/Tests/WaxCoreTests/CompressionTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-import WaxCore
+@testable import WaxCore
 
 private func repeatedData(_ seed: Data, count: Int) -> Data {
     var out = Data()

--- a/Tests/WaxIntegrationTests/BuiltInEmbeddingsPublicAPITests.swift
+++ b/Tests/WaxIntegrationTests/BuiltInEmbeddingsPublicAPITests.swift
@@ -15,8 +15,11 @@ func builtInEmbeddingsMiniLMProducesFiniteVectorAndHybridSearch() async throws {
 
         let memory = try await Memory(
             at: url,
-            config: .init(enableVectorSearch: true, requireOnDeviceProviders: true),
-            embedding: embedder
+            config: .init(
+                enableVectorSearch: true,
+                requireOnDeviceProviders: true,
+                embedding: .custom(embedder)
+            )
         )
         try await memory.save(
             "Vector fact: the constellation project uses CoreML MiniLM embeddings for hybrid search."

--- a/Tests/WaxIntegrationTests/CorpusSourceDocumentsTests.swift
+++ b/Tests/WaxIntegrationTests/CorpusSourceDocumentsTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 @Test
 func corpusSourceDocumentsExcludesSupersededActiveDocuments() async throws {

--- a/Tests/WaxIntegrationTests/CoverageGapTests.swift
+++ b/Tests/WaxIntegrationTests/CoverageGapTests.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 // MARK: - Shared test stubs
 

--- a/Tests/WaxIntegrationTests/DeduplicationTests.swift
+++ b/Tests/WaxIntegrationTests/DeduplicationTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test func rememberIdenticalContentTwiceIsIdempotent() async throws {
     try await TempFiles.withTempFile { url in

--- a/Tests/WaxIntegrationTests/DeterminismPropertyTests.swift
+++ b/Tests/WaxIntegrationTests/DeterminismPropertyTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test
 func rrfFusionIsIdempotentForSameInputs() {

--- a/Tests/WaxIntegrationTests/EnrichmentPipelineTests.swift
+++ b/Tests/WaxIntegrationTests/EnrichmentPipelineTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 @Test
 func enrichmentPipelineProcessesEnqueuedTasks() async throws {

--- a/Tests/WaxIntegrationTests/FastRAGIntegrationTests.swift
+++ b/Tests/WaxIntegrationTests/FastRAGIntegrationTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test
 func fastRAGIntegrationCreateRecallReopen() async throws {

--- a/Tests/WaxIntegrationTests/FastRAGTests.swift
+++ b/Tests/WaxIntegrationTests/FastRAGTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 @Test
 func fastRAGProducesSnippetsAndSingleExpansionWhenAvailable() async throws {

--- a/Tests/WaxIntegrationTests/FileIngestTests.swift
+++ b/Tests/WaxIntegrationTests/FileIngestTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private func makeFileIngestTextOnlyConfig() -> OrchestratorConfig {
     var config = OrchestratorConfig.default

--- a/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
+++ b/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test
 func rewriteLiveSetDropsNonLivePayloadsAndPreservesFrameState() async throws {

--- a/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
+++ b/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
@@ -2,6 +2,7 @@
 import Foundation
 import XCTest
 @testable import Wax
+import WaxCore
 
 private enum LongMemoryBenchmarkError: Error {
     case missingFixture(String)

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorErrorTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorErrorTests.swift
@@ -85,3 +85,56 @@ func memoryOrchestratorWriteReadEmbeddingsEmptyRoundTrip() async throws {
         #expect(decoded.isEmpty)
     }
 }
+
+@Test
+func memoryOrchestratorStructuredMemoryDisabledThrowsFeatureDisabled() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = TestHelpers.defaultMemoryConfig(vector: false)
+        config.enableStructuredMemory = false
+        let orchestrator = try await MemoryOrchestrator(at: url, config: config)
+
+        do {
+            _ = try await orchestrator.resolveEntities(matchingAlias: "alice")
+            #expect(Bool(false), "structured memory lookup with the feature disabled must throw")
+        } catch let error as WaxError {
+            guard case .featureDisabled(let feature) = error else {
+                #expect(Bool(false), "expected WaxError.featureDisabled, got \(error)")
+                return
+            }
+            #expect(feature == "structured memory")
+        } catch {
+            #expect(Bool(false))
+        }
+        try await orchestrator.close()
+    }
+}
+
+@Test
+func memoryOrchestratorVectorStoreWithoutEmbedderThrowsMissingEmbedder() async throws {
+    try await TempFiles.withTempFile { url in
+        let config = TestHelpers.defaultMemoryConfig(vector: true)
+        let seeded = try await MemoryOrchestrator(
+            at: url,
+            config: config,
+            embedder: DeterministicTextEmbedder(dimensions: 2)
+        )
+        try await seeded.remember("Seeded vector store phrase.")
+        try await seeded.close()
+
+        // Reopening a store that already has a committed vector index keeps vector
+        // search enabled; writing without an embedder must fail with a typed error.
+        let reopened = try await MemoryOrchestrator(at: url, config: config)
+        do {
+            try await reopened.remember("This write needs an embedder but none is configured.")
+            #expect(Bool(false), "remember without embedder on a vector store must throw")
+        } catch let error as WaxError {
+            guard case .missingEmbedder = error else {
+                #expect(Bool(false), "expected WaxError.missingEmbedder, got \(error)")
+                return
+            }
+        } catch {
+            #expect(Bool(false))
+        }
+        try await reopened.close()
+    }
+}

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorSessionGraphAndStatsTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorSessionGraphAndStatsTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test
 func structuredMemoryBridgeRoundTripPersistsAcrossReopen() async throws {

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
@@ -610,6 +610,9 @@ private extension String {
 
 #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM)
 import WaxVectorSearchMiniLM
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 @Test
 func miniLMAdapterSymbolsExistWhenAvailable() async {

--- a/Tests/WaxIntegrationTests/MemorySearchOptionsTests.swift
+++ b/Tests/WaxIntegrationTests/MemorySearchOptionsTests.swift
@@ -20,8 +20,11 @@ func memoryFacadeRunsVectorOnlySearch() async throws {
     try await TempFiles.withTempFile { url in
         let memory = try await Memory(
             at: url,
-            config: .init(enableTextSearch: false, enableVectorSearch: true),
-            embedding: DeterministicEmbeddingProvider()
+            config: .init(
+                enableTextSearch: false,
+                enableVectorSearch: true,
+                embedding: .custom(DeterministicEmbeddingProvider())
+            )
         )
 
         try await memory.save("Wax vector search should find this frame.", metadata: ["id": "needle"])
@@ -115,8 +118,11 @@ func memorySearchReportsVectorDiagnosticsWithEmbedder() async throws {
     try await TempFiles.withTempFile { url in
         let memory = try await Memory(
             at: url,
-            config: .init(enableTextSearch: true, enableVectorSearch: true),
-            embedding: DeterministicEmbeddingProvider()
+            config: .init(
+                enableTextSearch: true,
+                enableVectorSearch: true,
+                embedding: .custom(DeterministicEmbeddingProvider())
+            )
         )
 
         try await memory.save("Wax vector diagnostics should report the vector lane.")

--- a/Tests/WaxIntegrationTests/Mocks/FrameBuilders.swift
+++ b/Tests/WaxIntegrationTests/Mocks/FrameBuilders.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 enum FrameBuilders {
     static func photoRootMetadata(

--- a/Tests/WaxIntegrationTests/ModelBindingTests.swift
+++ b/Tests/WaxIntegrationTests/ModelBindingTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private struct BindingTestEmbedder: EmbeddingProvider, Sendable {
     let dimensions: Int

--- a/Tests/WaxIntegrationTests/PDFIngestTests.swift
+++ b/Tests/WaxIntegrationTests/PDFIngestTests.swift
@@ -4,6 +4,9 @@ import CoreText
 import PDFKit
 import Testing
 import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private enum PDFFixtures {
     static let pageOnePhrase = "crimson"

--- a/Tests/WaxIntegrationTests/PerformanceImprovementsTests.swift
+++ b/Tests/WaxIntegrationTests/PerformanceImprovementsTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 actor CountingEmbedder: EmbeddingProvider {
     nonisolated let dimensions: Int

--- a/Tests/WaxIntegrationTests/PhotoRAGConstraintQueriesTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGConstraintQueriesTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreGraphics
 import Testing
 import Wax
+import WaxCore
 
 private struct StubMultimodalEmbedder: MultimodalEmbeddingProvider {
     let executionMode: ProviderExecutionMode = .onDeviceOnly

--- a/Tests/WaxIntegrationTests/PhotoRAGDeleteVectorDurabilityTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGDeleteVectorDurabilityTests.swift
@@ -4,6 +4,8 @@ import Foundation
 import Testing
 @testable import Wax
 import WaxVectorSearch
+import WaxCore
+import WaxTextSearch
 
 // Byte-level proof that PhotoRAG delete and re-ingest (supersede) remove vectors from
 // the committed vector index, mirroring MemoryDeleteVectorDurabilityTests. Before the
@@ -110,6 +112,54 @@ func photoRAGReingestRemovesSupersededRootVectorFromCommittedVecBytes() async th
             "superseded photo root vector still present in committed vec after re-ingest"
         )
         #expect(afterIds.contains(newRootId))
+
+        try await orchestrator.flush()
+    }
+}
+
+@Test
+func photoRAGRebuildSweepsLegacyGhostVectorForSupersededTree() async throws {
+    try await TempFiles.withTempFile { storeURL in
+        let imageURL = storeURL.deletingLastPathComponent()
+            .appendingPathComponent("wax-ghost-sweep-photo-\(UUID().uuidString).png")
+        try photoDeleteTinyPNGData.write(to: imageURL)
+        defer { try? FileManager.default.removeItem(at: imageURL) }
+
+        let orchestrator = try await photoDeleteMakeOrchestrator(storeURL: storeURL)
+        let file = PhotoFile(id: "legacy-ghost", url: imageURL, captureDate: Date(timeIntervalSince1970: 1_700_000_000))
+
+        try await orchestrator.ingest(files: [file])
+        try await orchestrator.flush()
+
+        let wax = await orchestrator.wax
+        let oldRootId = try await photoDeleteRootId(wax: wax, assetID: "legacy-ghost", superseded: false)
+
+        // Re-ingest supersedes the tree; current cleanup removes its vectors.
+        try await orchestrator.ingest(files: [file])
+        try await orchestrator.flush()
+        let newRootId = try await photoDeleteRootId(wax: wax, assetID: "legacy-ghost", superseded: false)
+
+        // Simulate a store written before vector cleanup existed: the superseded
+        // root's vector is still present in the committed index.
+        try await wax.putEmbedding(frameId: oldRootId, vector: [1, 0, 0, 0])
+        try await orchestrator.flush()
+        let legacyBytes = try await wax.readCommittedVecIndexBytes()
+        #expect(
+            try photoDeleteCommittedVecFrameIds(from: legacyBytes!).contains(oldRootId),
+            "setup: injected legacy ghost must be committed"
+        )
+
+        // The next index rebuild sweeps retired-tree vectors out of the committed index.
+        try await orchestrator.ingest(files: [
+            PhotoFile(id: "sweep-trigger", url: imageURL, captureDate: Date(timeIntervalSince1970: 1_700_000_100))
+        ])
+        try await orchestrator.flush()
+
+        let sweptBytes = try await wax.readCommittedVecIndexBytes()
+        #expect(sweptBytes != nil)
+        let sweptIds = try photoDeleteCommittedVecFrameIds(from: sweptBytes!)
+        #expect(!sweptIds.contains(oldRootId), "legacy ghost vector survived the retired-tree sweep")
+        #expect(sweptIds.contains(newRootId), "current root vector must survive the sweep")
 
         try await orchestrator.flush()
     }

--- a/Tests/WaxIntegrationTests/PhotoRAGOrchestratorTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGOrchestratorTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreGraphics
 import Testing
 import Wax
+import WaxCore
 
 private struct StubMultimodalEmbedder: MultimodalEmbeddingProvider {
     let executionMode: ProviderExecutionMode = .onDeviceOnly

--- a/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
+++ b/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
@@ -3,6 +3,7 @@ import Darwin
 import Foundation
 import XCTest
 @testable import Wax
+import WaxCore
 
 final class ProductionReadinessStabilityTests: XCTestCase {
     private enum Profile: String {

--- a/Tests/WaxIntegrationTests/RAGBenchmarkSupport.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarkSupport.swift
@@ -2,6 +2,7 @@
 import Foundation
 import XCTest
 @testable import Wax
+import WaxCore
 
 struct BenchmarkScale {
     var name: String

--- a/Tests/WaxIntegrationTests/RAGBenchmarks.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarks.swift
@@ -2,6 +2,7 @@
 import XCTest
 import Foundation
 @testable import Wax
+import WaxCore
 
 final class RAGPerformanceBenchmarks: XCTestCase {
     private let scale = BenchmarkScale.current()

--- a/Tests/WaxIntegrationTests/RAGConfigClampingTests.swift
+++ b/Tests/WaxIntegrationTests/RAGConfigClampingTests.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 private let tinyPNGData = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6Q5+YAAAAASUVORK5CYII=")!
 private let tinyPhotoQueryImage = PhotoQueryImage(data: tinyPNGData, format: .png)

--- a/Tests/WaxIntegrationTests/READMEExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/READMEExamplesTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test
 func readmeQuickStartImportsFoundationBeforeWax() throws {

--- a/Tests/WaxIntegrationTests/SemanticRetrievalGateTests.swift
+++ b/Tests/WaxIntegrationTests/SemanticRetrievalGateTests.swift
@@ -56,7 +56,7 @@ func memoryDefaultInitAutoWiresBuiltInEmbedderAndRetrievesParaphrase() async thr
 @Test
 func memoryBuiltInMiniLMHybridSearchRunsVectorLaneForParaphrase() async throws {
     try await TempFiles.withTempFile { url in
-        let memory = try await Memory(at: url, builtInEmbedding: .miniLM)
+        let memory = try await Memory(at: url) { $0.embedding = .builtIn(.miniLM) }
 
         try await memory.save(semanticGateTarget)
         for distractor in semanticGateDistractors {

--- a/Tests/WaxIntegrationTests/SessionRuntimeStatsTests.swift
+++ b/Tests/WaxIntegrationTests/SessionRuntimeStatsTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 @Test
 func sessionRuntimeStatsIgnoresDeletedSupersededAndPendingSessionFrames() async throws {

--- a/Tests/WaxIntegrationTests/StructuredMemoryCRUDTests.swift
+++ b/Tests/WaxIntegrationTests/StructuredMemoryCRUDTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 @Test func upsertEntityNormalizesAliasesAndResolves() async throws {
     let engine = try FTS5SearchEngine.inMemory()

--- a/Tests/WaxIntegrationTests/StructuredMemorySchemaTests.swift
+++ b/Tests/WaxIntegrationTests/StructuredMemorySchemaTests.swift
@@ -7,6 +7,9 @@ import Wax
 // tests are excluded at compile time rather than at runtime.
 #if canImport(SQLite3)
 import SQLite3
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private enum SQLiteBlobInspector {
     static func int32Pragma(_ pragma: String, fromSerialized data: Data) throws -> Int32 {

--- a/Tests/WaxIntegrationTests/StructuredMemoryWaxPersistenceTests.swift
+++ b/Tests/WaxIntegrationTests/StructuredMemoryWaxPersistenceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test func structuredMemoryPersistsAcrossReopen() async throws {
     let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/WaxIntegrationTests/SurrogateIndexTests.swift
+++ b/Tests/WaxIntegrationTests/SurrogateIndexTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test
 func surrogateFrameIdReturnsNilWhenSourceFrameDeleted() async throws {

--- a/Tests/WaxIntegrationTests/SurrogateMaintenanceTests.swift
+++ b/Tests/WaxIntegrationTests/SurrogateMaintenanceTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 @Test
 func optimizeSurrogatesCreatesSurrogateFramesAndExcludesFromDefaultSearch() async throws {

--- a/Tests/WaxIntegrationTests/TemporalRecallIntegrationTests.swift
+++ b/Tests/WaxIntegrationTests/TemporalRecallIntegrationTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 private func makeTemporalRecallStore(
     at url: URL,

--- a/Tests/WaxIntegrationTests/TextSearchEngineTests.swift
+++ b/Tests/WaxIntegrationTests/TextSearchEngineTests.swift
@@ -7,6 +7,9 @@ import Wax
 // are excluded at compile time; the CI only runs WaxCoreTests on Linux.
 #if canImport(SQLite3)
 import SQLite3
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private enum SQLiteBlobInspector {
     static func int32Pragma(_ pragma: String, fromSerialized data: Data) throws -> Int32 {

--- a/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private actor HangingVectorEngine: VectorSearchEngine {
     let dimensions: Int

--- a/Tests/WaxIntegrationTests/TimestampOverrideTests.swift
+++ b/Tests/WaxIntegrationTests/TimestampOverrideTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 @Test
 func putTimestampOverridePersists() async throws {

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -4,6 +4,9 @@ import Metal
 #endif
 import Testing
 @testable import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private actor DeterministicVectorResultsEngine: VectorSearchEngine {
     let dimensions: Int

--- a/Tests/WaxIntegrationTests/VersionRelationTests.swift
+++ b/Tests/WaxIntegrationTests/VersionRelationTests.swift
@@ -251,6 +251,9 @@ import Wax
 
 #if canImport(SQLite3)
 import SQLite3
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private enum VersionRelationSQLiteFixture {
     static func int32Pragma(_ pragma: String, fromSerialized data: Data) throws -> Int32 {

--- a/Tests/WaxIntegrationTests/VideoRAGDeleteVectorDurabilityTests.swift
+++ b/Tests/WaxIntegrationTests/VideoRAGDeleteVectorDurabilityTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Wax
 import WaxVectorSearch
+import WaxCore
+import WaxTextSearch
 
 // Byte-level proof that VideoRAG delete and re-ingest (supersede) remove segment
 // vectors from the committed vector index. Before the fix, VideoRAGOrchestrator only
@@ -147,6 +149,58 @@ func videoRAGReingestRemovesSupersededSegmentVectorsFromCommittedVecBytes() asyn
         }
         for segmentId in newSegmentIds {
             #expect(afterIds.contains(segmentId))
+        }
+
+        try await orchestrator.flush()
+    }
+}
+
+@Test
+func videoRAGRebuildSweepsLegacyGhostVectorForSupersededTree() async throws {
+    try await TempFiles.withTempFile { storeURL in
+        let mp4URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("mp4")
+        defer { try? FileManager.default.removeItem(at: mp4URL) }
+        try await VideoRAGTestVideoGenerator.writeTinyMP4(to: mp4URL, width: 32, height: 32, frameCount: 2, fps: 2)
+
+        let orchestrator = try await videoDeleteMakeOrchestrator(storeURL: storeURL)
+        let file = VideoFile(id: "legacy-ghost", url: mp4URL, captureDate: nil)
+
+        try await orchestrator.ingest(files: [file])
+        try await orchestrator.flush()
+
+        let wax = await orchestrator.wax
+        let oldRootId = try await videoDeleteRootId(wax: wax, superseded: false)
+        let oldSegmentIds = try await videoDeleteSegmentIds(wax: wax, underRoot: oldRootId)
+        let ghostSegmentId = try #require(oldSegmentIds.first, "setup: ingest must produce segment frames")
+
+        // Re-ingest supersedes the tree; current cleanup removes its vectors.
+        try await orchestrator.ingest(files: [file])
+        try await orchestrator.flush()
+        let newRootId = try await videoDeleteRootId(wax: wax, superseded: false)
+        let newSegmentIds = try await videoDeleteSegmentIds(wax: wax, underRoot: newRootId)
+
+        // Simulate a store written before vector cleanup existed: a superseded
+        // segment vector is still present in the committed index.
+        try await wax.putEmbedding(frameId: ghostSegmentId, vector: [1, 0, 0, 0, 0, 0, 0, 0])
+        try await orchestrator.flush()
+        let legacyBytes = try await wax.readCommittedVecIndexBytes()
+        #expect(
+            try videoDeleteCommittedVecFrameIds(from: legacyBytes!).contains(ghostSegmentId),
+            "setup: injected legacy ghost must be committed"
+        )
+
+        // The next index rebuild sweeps retired-tree vectors out of the committed index.
+        try await orchestrator.ingest(files: [VideoFile(id: "sweep-trigger", url: mp4URL, captureDate: nil)])
+        try await orchestrator.flush()
+
+        let sweptBytes = try await wax.readCommittedVecIndexBytes()
+        #expect(sweptBytes != nil)
+        let sweptIds = try videoDeleteCommittedVecFrameIds(from: sweptBytes!)
+        #expect(!sweptIds.contains(ghostSegmentId), "legacy ghost vector survived the retired-tree sweep")
+        for segmentId in newSegmentIds {
+            #expect(sweptIds.contains(segmentId), "current segment vectors must survive the sweep")
         }
 
         try await orchestrator.flush()

--- a/Tests/WaxIntegrationTests/VideoRAGFileIngestIntegrationTests.swift
+++ b/Tests/WaxIntegrationTests/VideoRAGFileIngestIntegrationTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Wax
+import WaxCore
 
 private struct TestVideoEmbedder: MultimodalEmbeddingProvider {
     let executionMode: ProviderExecutionMode = .onDeviceOnly

--- a/Tests/WaxIntegrationTests/VideoRAGRecallOnlyTests.swift
+++ b/Tests/WaxIntegrationTests/VideoRAGRecallOnlyTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
 
 private struct StubVideoEmbedder: MultimodalEmbeddingProvider {
     let executionMode: ProviderExecutionMode = .onDeviceOnly

--- a/Tests/WaxIntegrationTests/VideoRAGTestSupport.swift
+++ b/Tests/WaxIntegrationTests/VideoRAGTestSupport.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import CoreVideo
 import Foundation
 import Wax
+import WaxCore
 
 enum VideoRAGTestSupport {
     static func openWritableTextOnlySession(wax: Wax) async throws -> WaxSession {

--- a/Tests/WaxIntegrationTests/WaxSessionTests.swift
+++ b/Tests/WaxIntegrationTests/WaxSessionTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 @Test func unifiedSession_textAndStructuredPersistWithSingleCommit() async throws {
     try await TempFiles.withTempFile { url in

--- a/Tests/WaxTests/TextSearchDocsTests.swift
+++ b/Tests/WaxTests/TextSearchDocsTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WaxCore
 
 @Test
 func textSearchDocsDoNotAdvertisePackageOnlyFTS5EngineAsPublicAPI() throws {

--- a/Tests/WaxTests/WaxCoreDocsTests.swift
+++ b/Tests/WaxTests/WaxCoreDocsTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WaxCore
 
 @Test
 func waxCoreDocsDoNotAdvertisePackageOnlyWaxActorAsPublicAPI() throws {
@@ -92,11 +93,13 @@ func waxCoreDocCTopicsDoNotLinkPackageOnlySymbols() throws {
             contentsOf: repoRoot.appendingPathComponent(relativePath),
             encoding: .utf8
         )
-        #expect(source.contains("package actor \(symbol)")
-            || source.contains("package struct \(symbol)")
-            || source.contains("package enum \(symbol)")
-            || source.contains("package final class \(symbol)")
-            || source.contains("package protocol \(symbol)"))
+        // The guard is "not public API": package or internal declarations both satisfy
+        // it. Match the declaration with word boundaries so e.g. `WALRecord` does not
+        // match `WALRecordHeader`, and reject any `public` declaration of the symbol.
+        let anyDecl = try Regex(#"\b(?:package|public)?\s*(?:final\s+)?(?:actor|struct|enum|class|protocol)\s+"# + symbol + #"\b"#)
+        let publicDecl = try Regex(#"\bpublic\s+(?:final\s+)?(?:actor|struct|enum|class|protocol)\s+"# + symbol + #"\b"#)
+        #expect(source.contains(anyDecl), "\(symbol) declaration not found in \(relativePath)")
+        #expect(!source.contains(publicDecl), "\(symbol) in \(relativePath) must not be public API")
     }
 
     let doc = try String(


### PR DESCRIPTION
## Summary

Stacked on #79. Four hardening workstreams that close the remaining adoption-failure follow-ups:

- **Ghost-vector migration sweep** — `PhotoRAGOrchestrator.rebuildIndex()` / `VideoRAGOrchestrator.rebuildIndex()` now collect retired frame IDs (deleted frames, superseded roots, and their children/segments) and best-effort `removeVector` them after rebuilding live indexes. Stores written before vector cleanup existed stop serving ghost hits for retired frames. Sweep failures are logged via `WaxDiagnostics.logSwallowed` and never block store open/reindex.
- **Memory initializer consolidation** — embedder selection moves to `Memory.Config.embedding` (`EmbeddingSource.automatic` / `.builtIn(...)` / `.custom(...)`), collapsing the public surface to two initializers (`init(at:config:)` and `init(at:configure:)`). All call sites, README, DocC articles, and public skill templates updated.
- **Explicit public re-exports** — `@_exported import` removed from `PublicAliases.swift` in favor of documented typealiases (`WaxError`, `EmbeddingProvider`, `BatchEmbeddingProvider`, `EmbeddingIdentity`, `ProviderExecutionMode`). Hidden cross-module coupling fixed with explicit imports across Wax, WaxCLI, WaxCrashHarness, and tests; `WaxTextSearch` no longer leaks through `import Wax`.
- **WaxCore access audit + typed errors** — internal-only types demoted from `package` to `internal` (`WALRecord`, `CompressionKind`, `SegmentCatalog`, WAL ring types, …); new `WaxError` cases `featureDisabled(feature:)`, `invalidEmbedding(reason:)`, `missingEmbedder` replace misclassified `.io` errors in session/orchestrator/embedder paths.

## Test plan

- [x] New byte-level ghost-vector sweep tests (`photoRAGRebuildSweepsLegacyGhostVectorForSupersededTree`, `videoRAGRebuildSweepsLegacyGhostVectorForSupersededTree`) — proven RED with the sweep stashed, GREEN with it
- [x] New typed-error tests (`memoryOrchestratorStructuredMemoryDisabledThrowsFeatureDisabled`, `memoryOrchestratorVectorStoreWithoutEmbedderThrowsMissingEmbedder`)
- [x] DocC guardrail updated to reject `public` while accepting `package` **or** internal declarations (word-boundary matched)
- [x] Full suite: **1162 tests passed**
- [x] Public-repo hygiene guardrail clean (no tasks/marketing/scratch files staged)

Made with [Cursor](https://cursor.com)