### PR TITLE
fix: make MiniLM loading resilient on mobile and MCP

### DIFF
--- a/.github/workflows/release-waxmcp.yml
+++ b/.github/workflows/release-waxmcp.yml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-14
+          - runs-on: macos-15-intel
             platform: darwin-x64
             triple: x86_64-apple-macosx14.0
             source_build: true
-          - runs-on: macos-14
+          - runs-on: macos-15
             platform: darwin-arm64
             triple: arm64-apple-macosx14.0
             source_build: true
@@ -100,6 +100,20 @@ jobs:
         run: |
           set -euo pipefail
           Resources/npm/waxmcp/dist/${{ matrix.platform }}/wax-cli mcp serve --help
+
+      - name: Run packaged MiniLM inference gate
+        if: ${{ matrix.source_build }}
+        timeout-minutes: 8
+        run: |
+          set -euo pipefail
+          STORE_PATH="${RUNNER_TEMP}/waxmcp-release-vector-health.wax"
+          Resources/npm/waxmcp/dist/${{ matrix.platform }}/wax-cli vector-health \
+            --store-path "$STORE_PATH" \
+            --direct-store \
+            --embedder minilm \
+            --require-vector \
+            --format json \
+            --embedder-timeout-secs 300
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-waxmcp.yml
+++ b/.github/workflows/release-waxmcp.yml
@@ -88,6 +88,8 @@ jobs:
           fi
           test -d "$PLATFORM_DIR/Wax_WaxVectorSearchMiniLM.bundle"
           echo "MiniLM bundle present"
+          test -d "$PLATFORM_DIR/Wax_WaxVectorSearchArctic.bundle"
+          echo "Arctic bundle present"
 
       - name: Smoke check MCP server
         if: ${{ matrix.source_build }}

--- a/Resources/npm/waxmcp/bin/waxmcp.js
+++ b/Resources/npm/waxmcp/bin/waxmcp.js
@@ -334,9 +334,7 @@ while (i < forwardedArgs.length) {
 
 // Auto-detect if we should add default embedder
 if (!mcpFlags.includes("--no-embedder") && !mcpFlags.some(f => f.startsWith("--embedder"))) {
-  // Default to arctic (most reliable across builds)
-  // MiniLM can produce non-finite embeddings in some release builds
-  mcpFlags.unshift("--embedder", "arctic");
+  mcpFlags.unshift("--embedder", "minilm");
 }
 
 runBinary("wax-mcp", mcpFlags);

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -14,11 +14,6 @@ class Wax < Formula
     # validation succeeds.
     mkdir_p "Tests/WaxTests"
 
-    # CoreML on-device ANE compilation can hang in CLI contexts; default to CPU-only for reliability.
-    inreplace "Sources/WaxVectorSearchMiniLM/MiniLMEmbedder.swift",
-      "computeUnitsOrder: [MLComputeUnits] = [.cpuAndNeuralEngine, .all, .cpuOnly]",
-      "computeUnitsOrder: [MLComputeUnits] = [.cpuOnly]"
-
     system "swift", "build", "--disable-sandbox", "-c", "release",
            "--product", "wax-cli", "--traits", "default,MCPServer"
     system "swift", "build", "--disable-sandbox", "-c", "release",

--- a/Resources/npm/waxmcp/scripts/verify-dist.mjs
+++ b/Resources/npm/waxmcp/scripts/verify-dist.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import fs from "node:fs";
+import crypto from "node:crypto";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -9,36 +11,108 @@ const root = process.env.WAXMCP_PACKAGE_DIR
   ? path.resolve(process.env.WAXMCP_PACKAGE_DIR)
   : path.resolve(__dirname, "..");
 
-const platforms = ["darwin-arm64", "darwin-x64"];
+const platforms = new Map([
+  ["darwin-arm64", 0x0100000c],
+  ["darwin-x64", 0x01000007],
+]);
 const binaries = ["wax-cli", "wax-mcp"];
-const missing = [];
+const failures = [];
+const packageVersion = JSON.parse(
+  fs.readFileSync(path.join(root, "package.json"), "utf8"),
+).version;
 
-for (const platform of platforms) {
+for (const [platform, expectedCpuType] of platforms) {
   const dir = path.join(root, "dist", platform);
   for (const binary of binaries) {
     const binaryPath = path.join(dir, binary);
     const checksumPath = `${binaryPath}.sha256`;
     if (!fs.existsSync(binaryPath)) {
-      missing.push(path.relative(root, binaryPath));
+      failures.push(path.relative(root, binaryPath));
       continue;
     }
     try {
       fs.accessSync(binaryPath, fs.constants.X_OK);
     } catch {
-      missing.push(`${path.relative(root, binaryPath)} (not executable)`);
+      failures.push(`${path.relative(root, binaryPath)} (not executable)`);
     }
     if (!fs.existsSync(checksumPath)) {
-      missing.push(path.relative(root, checksumPath));
+      failures.push(path.relative(root, checksumPath));
+    } else {
+      const expectedChecksum = fs
+        .readFileSync(checksumPath, "utf8")
+        .trim()
+        .split(/\s+/)[0];
+      const actualChecksum = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(binaryPath))
+        .digest("hex");
+      if (actualChecksum !== expectedChecksum) {
+        failures.push(`${path.relative(root, binaryPath)} (checksum mismatch)`);
+      }
+    }
+
+    const bytes = fs.readFileSync(binaryPath);
+    if (bytes.length < 8 || bytes.readUInt32LE(0) !== 0xfeedfacf) {
+      failures.push(`${path.relative(root, binaryPath)} (not a thin 64-bit Mach-O binary)`);
+    } else if (bytes.readUInt32LE(4) !== expectedCpuType) {
+      failures.push(`${path.relative(root, binaryPath)} (wrong CPU architecture)`);
+    }
+  }
+
+  const miniLMRoot = path.join(
+    dir,
+    "Wax_WaxVectorSearchMiniLM.bundle",
+    "all-MiniLM-L6-v2.mlmodelc",
+  );
+  for (const required of [
+    "model.mil",
+    "coremldata.bin",
+    path.join("weights", "weight.bin"),
+  ]) {
+    const modelFile = path.join(miniLMRoot, required);
+    if (!fs.existsSync(modelFile) || fs.statSync(modelFile).size === 0) {
+      failures.push(`${path.relative(root, modelFile)} (missing or empty)`);
+    }
+  }
+
+  const vocab = path.join(
+    dir,
+    "Wax_WaxBertTokenizer.bundle",
+    "bert_tokenizer_vocab.txt",
+  );
+  if (!fs.existsSync(vocab) || fs.statSync(vocab).size === 0) {
+    failures.push(`${path.relative(root, vocab)} (missing or empty)`);
+  }
+}
+
+const executablePlatform = process.env.WAXMCP_VERIFY_EXECUTABLE_PLATFORM;
+if (executablePlatform) {
+  if (!platforms.has(executablePlatform)) {
+    failures.push(`unknown executable verification platform: ${executablePlatform}`);
+  } else {
+    const mcpPath = path.join(root, "dist", executablePlatform, "wax-mcp");
+    try {
+      const output = execFileSync(mcpPath, ["--version"], {
+        encoding: "utf8",
+        timeout: 10_000,
+      }).trim();
+      if (!output.includes(packageVersion)) {
+        failures.push(
+          `${path.relative(root, mcpPath)} (reports '${output}', expected ${packageVersion})`,
+        );
+      }
+    } catch (error) {
+      failures.push(`${path.relative(root, mcpPath)} (--version failed: ${error.message})`);
     }
   }
 }
 
-if (missing.length > 0) {
-  console.error("waxmcp package is missing required dist artifacts:");
-  for (const item of missing) {
+if (failures.length > 0) {
+  console.error("waxmcp package integrity verification failed:");
+  for (const item of failures) {
     console.error(`  - ${item}`);
   }
   process.exit(1);
 }
 
-console.log("waxmcp dist artifacts verified.");
+console.log("waxmcp dist architecture, checksums, model resources, and version verified.");

--- a/Resources/npm/waxmcp/scripts/verify-dist.mjs
+++ b/Resources/npm/waxmcp/scripts/verify-dist.mjs
@@ -59,19 +59,30 @@ for (const [platform, expectedCpuType] of platforms) {
     }
   }
 
-  const miniLMRoot = path.join(
-    dir,
-    "Wax_WaxVectorSearchMiniLM.bundle",
-    "all-MiniLM-L6-v2.mlmodelc",
-  );
-  for (const required of [
-    "model.mil",
-    "coremldata.bin",
-    path.join("weights", "weight.bin"),
-  ]) {
-    const modelFile = path.join(miniLMRoot, required);
-    if (!fs.existsSync(modelFile) || fs.statSync(modelFile).size === 0) {
-      failures.push(`${path.relative(root, modelFile)} (missing or empty)`);
+  const compiledModels = [
+    path.join(
+      dir,
+      "Wax_WaxVectorSearchMiniLM.bundle",
+      "all-MiniLM-L6-v2.mlmodelc",
+    ),
+    path.join(
+      dir,
+      "Wax_WaxVectorSearchArctic.bundle",
+      "snowflake-arctic-embed-s.mlmodelc",
+    ),
+  ];
+  for (const modelRoot of compiledModels) {
+    for (const required of [
+      "model.mil",
+      "coremldata.bin",
+      "metadata.json",
+      path.join("analytics", "coremldata.bin"),
+      path.join("weights", "weight.bin"),
+    ]) {
+      const modelFile = path.join(modelRoot, required);
+      if (!fs.existsSync(modelFile) || fs.statSync(modelFile).size === 0) {
+        failures.push(`${path.relative(root, modelFile)} (missing or empty)`);
+      }
     }
   }
 

--- a/Resources/scripts/build-waxmcp-binaries.sh
+++ b/Resources/scripts/build-waxmcp-binaries.sh
@@ -87,6 +87,44 @@ if [[ -f "$MCP_BIN_PATH" ]]; then
   echo "Created $MCP_BIN_PATH"
 fi
 
+# Reject mislabeled artifacts before checksums make them look trustworthy.
+case "$PLATFORM" in
+  darwin-arm64)
+    EXPECTED_FILE_ARCH="arm64"
+    EXPECTED_HOST_ARCH="arm64"
+    ;;
+  darwin-x64)
+    EXPECTED_FILE_ARCH="x86_64"
+    EXPECTED_HOST_ARCH="x86_64"
+    ;;
+  *)
+    echo "ERROR: unsupported distribution platform '$PLATFORM'." >&2
+    exit 1
+    ;;
+esac
+
+for bin in "$CLI_BIN_PATH" "$MCP_BIN_PATH"; do
+  [[ -f "$bin" ]] || continue
+  binary_description="$(file -b "$bin")"
+  if [[ "$binary_description" != *"$EXPECTED_FILE_ARCH"* ]]; then
+    echo "ERROR: $(basename "$bin") for $PLATFORM has wrong architecture: $binary_description" >&2
+    exit 1
+  fi
+done
+
+if [[ -f "$MCP_BIN_PATH" && "$(uname -m)" == "$EXPECTED_HOST_ARCH" ]]; then
+  if ! command -v node >/dev/null 2>&1; then
+    echo "ERROR: node is required for wax-mcp version verification." >&2
+    exit 1
+  fi
+  EXPECTED_VERSION="$(node -p "require('$PROJECT_ROOT/Resources/npm/waxmcp/package.json').version")"
+  REPORTED_VERSION="$("$MCP_BIN_PATH" --version)"
+  if [[ "$REPORTED_VERSION" != *"$EXPECTED_VERSION"* ]]; then
+    echo "ERROR: wax-mcp reports '$REPORTED_VERSION', expected version $EXPECTED_VERSION." >&2
+    exit 1
+  fi
+fi
+
 # Generate checksums
 for bin in "$CLI_BIN_PATH" "$MCP_BIN_PATH"; do
   if [[ -f "$bin" ]]; then

--- a/Resources/scripts/build-waxmcp-binaries.sh
+++ b/Resources/scripts/build-waxmcp-binaries.sh
@@ -59,6 +59,7 @@ if [[ -n "$TRIPLE" ]]; then
   # Copy resource bundles required for vector search and runtime.
   # Scan both bin paths defensively (they're usually identical but may diverge).
   echo "Copying resource bundles..."
+  rm -rf "$DIST_DIR"/*.bundle
   for dir in "$LOCAL_BIN_PATH" "$MCP_LOCAL_BIN_PATH"; do
     for bundle in "$dir"/*.bundle; do
       [[ -d "$bundle" ]] || continue

--- a/Resources/scripts/quality/package_artifact_tests.sh
+++ b/Resources/scripts/quality/package_artifact_tests.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 WAXMCP_PACKAGE="$ROOT_DIR/Resources/npm/waxmcp/package.json"
 WAXMCP_VERIFY="$ROOT_DIR/Resources/npm/waxmcp/scripts/verify-dist.mjs"
+WAXMCP_LAUNCHER="$ROOT_DIR/Resources/npm/waxmcp/bin/waxmcp.js"
+WAX_HOMEBREW_FORMULA="$ROOT_DIR/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb"
 OPENCLAW_PACKAGE="$ROOT_DIR/Resources/openclaw/wax-memory-plugin/package.json"
 OPENCLAW_PLUGIN="$ROOT_DIR/Resources/openclaw/wax-memory-plugin/openclaw.plugin.json"
 OPENCLAW_DIST="$ROOT_DIR/Resources/openclaw/wax-memory-plugin/dist/index.js"
@@ -22,6 +24,13 @@ if (pkg.scripts?.prepack !== "node scripts/verify-dist.mjs") process.exit(1);
 [[ -f "$WAXMCP_VERIFY" ]] || fail "waxmcp dist verifier is missing"
 grep -Fq 'darwin-arm64' "$WAXMCP_VERIFY" || fail "waxmcp verifier must check darwin-arm64"
 grep -Fq 'darwin-x64' "$WAXMCP_VERIFY" || fail "waxmcp verifier must check darwin-x64"
+grep -Fq 'Wax_WaxVectorSearchArctic.bundle' "$WAXMCP_VERIFY" \
+  || fail "waxmcp verifier must require the Arctic model bundle"
+grep -Fq 'mcpFlags.unshift("--embedder", "minilm")' "$WAXMCP_LAUNCHER" \
+  || fail "waxmcp launcher must default to the repaired MiniLM provider"
+if grep -Fq '.cpuOnly' "$WAX_HOMEBREW_FORMULA"; then
+  fail "Homebrew formula must not rewrite MiniLM to the known-broken cpuOnly path"
+fi
 
 node -e '
 const fs = require("fs");

--- a/Resources/scripts/quality/release_workflow_tests.sh
+++ b/Resources/scripts/quality/release_workflow_tests.sh
@@ -51,6 +51,12 @@ build_line="$(grep -n 'name: Build binaries' "$WORKFLOW" | head -n 1 | cut -d: -
 
 grep -Fq './Resources/scripts/sync-waxmcp-version.sh' "$WORKFLOW" \
   || fail "release workflow must use the shared waxmcp version sync helper"
+grep -Fq 'Wax_WaxVectorSearchArctic.bundle' "$WORKFLOW" \
+  || fail "release workflow must require the Arctic model bundle"
+grep -Fq 'wax-cli vector-health' "$WORKFLOW" \
+  || fail "release workflow must run packaged MiniLM inference"
+grep -Fq 'macos-15-intel' "$WORKFLOW" \
+  || fail "release workflow must build x64 artifacts on a native Intel runner"
 
 grep -Fq 'Resources/scripts/sync-waxmcp-version.sh' "$CANONICAL_RELEASE_SCRIPT" \
   || fail "canonical release script must use the shared waxmcp version sync helper"

--- a/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
+++ b/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
@@ -163,44 +163,32 @@ private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmb
         kind: Kind,
         tuning: CommandLineEmbedderRuntimeTuning
     ) async -> (any EmbeddingProvider)? {
-        await withTaskGroup(of: (any EmbeddingProvider)?.self) { group in
-            group.addTask {
-                do {
-                    switch kind {
-                    case .minilm:
-                        #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
-                        return try await MiniLMEmbedder.makeCommandLineEmbedder(
-                            prewarmBatchSize: tuning.prewarmBatchSize,
-                            skipPrewarm: true,
-                            tuning: tuning
-                        )
-                        #else
-                        return nil
-                        #endif
-                    case .arctic:
-                        #if ArcticEmbeddings && canImport(WaxVectorSearchArctic) && canImport(CoreML)
-                        return try await ArcticEmbedder.makeCommandLineEmbedder(
-                            prewarmBatchSize: tuning.prewarmBatchSize,
-                            skipPrewarm: true,
-                            tuning: tuning
-                        )
-                        #else
-                        return nil
-                        #endif
-                    }
-                } catch {
-                    brokerWriteStderr("Embedder load failed: \(error.localizedDescription)")
-                    return nil
-                }
-            }
-            group.addTask {
-                try? await Task.sleep(for: tuning.timeoutDuration)
+        do {
+            switch kind {
+            case .minilm:
+                #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
+                return try await MiniLMEmbedder.makeCommandLineEmbedder(
+                    prewarmBatchSize: tuning.prewarmBatchSize,
+                    skipPrewarm: true,
+                    tuning: tuning
+                )
+                #else
                 return nil
+                #endif
+            case .arctic:
+                #if ArcticEmbeddings && canImport(WaxVectorSearchArctic) && canImport(CoreML)
+                return try await ArcticEmbedder.makeCommandLineEmbedder(
+                    prewarmBatchSize: tuning.prewarmBatchSize,
+                    skipPrewarm: true,
+                    tuning: tuning
+                )
+                #else
+                return nil
+                #endif
             }
-
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first
+        } catch {
+            brokerWriteStderr("Embedder load failed: \(error.localizedDescription)")
+            return nil
         }
     }
 }

--- a/Sources/Wax/BuiltInEmbeddings.swift
+++ b/Sources/Wax/BuiltInEmbeddings.swift
@@ -54,7 +54,6 @@ public struct BuiltInEmbeddingProviderOptions: Sendable, Equatable, Codable {
         timeoutSeconds: Double = 120.0,
         computeUnitsOrder: [BuiltInEmbeddingComputeUnit] = [
             .cpuAndNeuralEngine,
-            .cpuOnly,
             .cpuAndGPU,
             .all,
         ]
@@ -64,7 +63,7 @@ public struct BuiltInEmbeddingProviderOptions: Sendable, Equatable, Codable {
         self.allowLowPrecisionGPU = allowLowPrecisionGPU
         self.timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 120.0
         self.computeUnitsOrder = computeUnitsOrder.isEmpty
-            ? [.cpuAndNeuralEngine, .cpuOnly, .cpuAndGPU, .all]
+            ? [.cpuAndNeuralEngine, .cpuAndGPU, .all]
             : computeUnitsOrder
     }
 
@@ -85,6 +84,8 @@ public struct BuiltInEmbeddingProviderOptions: Sendable, Equatable, Codable {
 public enum BuiltInEmbeddingProviderError: LocalizedError, Sendable, Equatable {
     /// The requested provider is unavailable in the current build or platform.
     case unavailable(BuiltInEmbeddingProvider)
+    /// The caller's wait budget elapsed. The shared model load continues in the background.
+    case timedOut(BuiltInEmbeddingProvider, seconds: Double)
 
     public var errorDescription: String? {
         switch self {
@@ -96,12 +97,16 @@ public enum BuiltInEmbeddingProviderError: LocalizedError, Sendable, Equatable {
                 "requires iOS 18/macOS 15 or later and the `ArcticEmbeddings` package trait"
             }
             return "\(provider.rawValue) embeddings are unavailable: \(requirement). On older OS versions, pass a custom EmbeddingProvider or use text-only search."
+        case .timedOut(let provider, let seconds):
+            return "\(provider.rawValue) embedding setup exceeded \(seconds) seconds; loading continues in the background."
         }
     }
 }
 
 /// Factory for Wax's built-in embedding providers.
 public enum BuiltInEmbeddings {
+    private static let loadCoordinator = EmbeddingLoadCoordinator()
+
     /// Construct a built-in embedding provider using Wax's on-device CoreML runtime.
     ///
     /// The returned provider is eagerly probed so cold CoreML compilation happens here
@@ -110,6 +115,36 @@ public enum BuiltInEmbeddings {
     public static func make(
         _ provider: BuiltInEmbeddingProvider,
         options: BuiltInEmbeddingProviderOptions = .default
+    ) async throws -> any EmbeddingProvider {
+        do {
+            return try await loadCoordinator.provider(
+                for: loadKey(provider, options: options),
+                timeout: .milliseconds(Int64(options.timeoutSeconds * 1_000))
+            ) {
+                try await loadProvider(provider, options: options)
+            }
+        } catch EmbeddingLoadCoordinator.WaitError.timedOut {
+            throw BuiltInEmbeddingProviderError.timedOut(
+                provider,
+                seconds: options.timeoutSeconds
+            )
+        }
+    }
+
+    package static func loadWithoutWaitLimit(
+        _ provider: BuiltInEmbeddingProvider,
+        options: BuiltInEmbeddingProviderOptions = .default
+    ) async throws -> any EmbeddingProvider {
+        try await loadCoordinator.provider(
+            for: loadKey(provider, options: options)
+        ) {
+            try await loadProvider(provider, options: options)
+        }
+    }
+
+    private static func loadProvider(
+        _ provider: BuiltInEmbeddingProvider,
+        options: BuiltInEmbeddingProviderOptions
     ) async throws -> any EmbeddingProvider {
         guard let embedder = try await CommandLineEmbedderFactory.buildEmbedder(
             noEmbedder: false,
@@ -121,5 +156,15 @@ public enum BuiltInEmbeddings {
         // Materialize deferred CLI embedders and verify finite output before handoff.
         _ = try await embedder.embed("wax")
         return embedder
+    }
+
+    private static func loadKey(
+        _ provider: BuiltInEmbeddingProvider,
+        options: BuiltInEmbeddingProviderOptions
+    ) -> EmbeddingLoadKey {
+        EmbeddingLoadKey(
+            provider: provider.rawValue,
+            configuration: options.tuning.brokerCacheKey
+        )
     }
 }

--- a/Sources/Wax/EmbeddingLoadCoordinator.swift
+++ b/Sources/Wax/EmbeddingLoadCoordinator.swift
@@ -1,0 +1,69 @@
+import Foundation
+import WaxCore
+
+package struct EmbeddingLoadKey: Hashable, Sendable {
+    package let provider: String
+    package let configuration: String
+
+    package init(provider: String, configuration: String) {
+        self.provider = provider
+        self.configuration = configuration
+    }
+}
+
+/// Retains expensive model-load work independently from any one caller's wait budget.
+///
+/// Core ML compilation is not reliably cancellable. Keeping the unstructured load task
+/// here means a timed-out request can return while a later request reuses the same work.
+package actor EmbeddingLoadCoordinator {
+    package enum WaitError: Error, Sendable, Equatable {
+        case timedOut
+    }
+
+    private struct Entry: Sendable {
+        let id: UUID
+        let task: Task<any EmbeddingProvider, any Error>
+    }
+
+    private var tasks: [EmbeddingLoadKey: Entry] = [:]
+
+    package init() {}
+
+    package func provider(
+        for key: EmbeddingLoadKey,
+        timeout: Duration? = nil,
+        factory: @escaping @Sendable () async throws -> any EmbeddingProvider
+    ) async throws -> any EmbeddingProvider {
+        let entry: Entry
+        if let existing = tasks[key] {
+            entry = existing
+        } else {
+            let created = Task { try await factory() }
+            let newEntry = Entry(id: UUID(), task: created)
+            tasks[key] = newEntry
+            entry = newEntry
+        }
+
+        do {
+            let provider: any EmbeddingProvider
+            if let timeout {
+                provider = try await AsyncTimeout.run(
+                    timeout: timeout,
+                    operation: "embedding provider load"
+                ) {
+                    try await entry.task.value
+                }
+            } else {
+                provider = try await entry.task.value
+            }
+            return provider
+        } catch is AsyncTimeout.TimeoutError {
+            throw WaitError.timedOut
+        } catch {
+            if tasks[key]?.id == entry.id {
+                tasks[key] = nil
+            }
+            throw error
+        }
+    }
+}

--- a/Sources/Wax/EmbeddingStatus.swift
+++ b/Sources/Wax/EmbeddingStatus.swift
@@ -1,0 +1,13 @@
+/// Runtime state of the embedding provider attached to a ``Memory`` store.
+public enum EmbeddingStatus: Sendable, Equatable {
+    /// Vector search was explicitly disabled.
+    case disabled
+    /// A provider is loading while text operations remain available.
+    case loading
+    /// Vector ingestion and query embedding are ready.
+    case active(EmbeddingIdentity?)
+    /// The provider is ready, but some previously saved text could not be backfilled.
+    case degraded(EmbeddingIdentity?, reason: String)
+    /// No provider could be activated.
+    case unavailable(reason: String)
+}

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -41,11 +41,12 @@ public actor Memory {
 
     /// Selects the embedding provider that backs vector search for a ``Memory`` store.
     public enum EmbeddingSource: Sendable {
-        /// Wire the built-in MiniLM embedder automatically on iOS 18/macOS 15+ when Wax
-        /// is built with the default `MiniLMEmbeddings` trait. On older OS versions, or
-        /// if the model is unavailable, the store falls back to text-only search;
-        /// inspect ``RAGContext/diagnostics`` on search results or ``Memory/stats()``
-        /// to see which mode is actually in effect.
+        /// Start loading the built-in MiniLM embedder in the background on iOS 18/macOS
+        /// 15+ when Wax is built with the default `MiniLMEmbeddings` trait. Text saves
+        /// and searches remain available during a cold Core ML load; text saved in that
+        /// window is backfilled when the provider becomes ready. On unsupported systems
+        /// the store remains text-only. Inspect ``Memory/stats()`` or await
+        /// ``Memory/prepareEmbeddings()`` for the current state.
         case automatic
         /// Use one of Wax's built-in embedding providers. Store creation throws if the
         /// provider cannot be constructed (trait compiled out, model missing, or
@@ -107,11 +108,16 @@ public actor Memory {
     public typealias Results = RAGContext
     public typealias Error = WaxError
 
-    private let orchestrator: MemoryOrchestrator
+    private var orchestrator: MemoryOrchestrator
+    private var embeddingStatus: EmbeddingStatus
+    private var activationTask: Task<Void, Never>?
+    private var isClosed = false
 
     /// Package-visible wrap of an existing orchestrator for in-module adapters.
     package init(orchestrator: MemoryOrchestrator) {
         self.orchestrator = orchestrator
+        self.embeddingStatus = .disabled
+        self.activationTask = nil
     }
 
     /// Create or open a memory store at the given URL.
@@ -123,11 +129,57 @@ public actor Memory {
     /// text-only search; inspect ``RAGContext/diagnostics`` on search results or
     /// ``stats()`` to see which mode is actually in effect.
     public init(at url: URL, config: Config = .default) async throws {
-        self.orchestrator = try await MemoryOrchestrator(
+        try await self.init(
+            at: url,
+            config: config,
+            automaticEmbeddingLoader: {
+                try await BuiltInEmbeddings.loadWithoutWaitLimit(.miniLM)
+            }
+        )
+    }
+
+    package init(
+        at url: URL,
+        config: Config,
+        automaticEmbeddingLoader: @escaping @Sendable () async throws -> any EmbeddingProvider
+    ) async throws {
+        activationTask = nil
+
+        if config.enableVectorSearch, case .automatic = config.embedding {
+            var initialConfig = Self.makeOrchestratorConfig(config)
+            initialConfig.enableVectorSearch = false
+            orchestrator = try await MemoryOrchestrator(
+                at: url,
+                config: initialConfig,
+                embedder: nil
+            )
+            embeddingStatus = .loading
+            activationTask = Task { [weak self] in
+                do {
+                    let provider = try await automaticEmbeddingLoader()
+                    guard !Task.isCancelled else { return }
+                    await self?.finishAutomaticEmbeddingActivation(provider)
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    await self?.finishAutomaticEmbeddingFailure(error)
+                }
+            }
+            return
+        }
+
+        let embedder = try await Self.makeEmbedder(for: config)
+        orchestrator = try await MemoryOrchestrator(
             at: url,
             config: Self.makeOrchestratorConfig(config),
-            embedder: try await Self.makeEmbedder(for: config)
+            embedder: embedder
         )
+        if !config.enableVectorSearch {
+            embeddingStatus = .disabled
+        } else if let embedder {
+            embeddingStatus = .active(embedder.identity)
+        } else {
+            embeddingStatus = .unavailable(reason: "Embedding provider is unavailable.")
+        }
     }
 
     /// Create or open a memory store at the given URL with inline configuration.
@@ -228,8 +280,28 @@ public actor Memory {
         try await orchestrator.flush()
     }
 
+    /// Wait for background automatic embedding setup and return its final state.
+    ///
+    /// Explicit custom and built-in providers are already ready when ``Memory`` opens,
+    /// so this returns immediately for those configurations.
+    public func prepareEmbeddings() async -> EmbeddingStatus {
+        if let activationTask {
+            await activationTask.value
+        }
+        if case .disabled = embeddingStatus {
+            let runtime = await orchestrator.runtimeStats()
+            if runtime.queryEmbedderConfigured {
+                embeddingStatus = .active(runtime.embedderIdentity)
+            }
+        }
+        return embeddingStatus
+    }
+
     /// Close the memory handle and release resources.
     public func close() async throws {
+        isClosed = true
+        activationTask?.cancel()
+        activationTask = nil
         try await orchestrator.close()
     }
 
@@ -247,6 +319,8 @@ public actor Memory {
         public var queryEmbeddingCircuitOpen: Bool
         /// Identity of the configured embedding provider, if any.
         public var embedderIdentity: EmbeddingIdentity?
+        /// Lifecycle state of automatic or explicitly configured embeddings.
+        public var embeddingStatus: EmbeddingStatus
 
         public init(
             frameCount: UInt64,
@@ -254,7 +328,8 @@ public actor Memory {
             vectorSearchEnabled: Bool,
             queryEmbedderConfigured: Bool,
             queryEmbeddingCircuitOpen: Bool,
-            embedderIdentity: EmbeddingIdentity?
+            embedderIdentity: EmbeddingIdentity?,
+            embeddingStatus: EmbeddingStatus = .disabled
         ) {
             self.frameCount = frameCount
             self.pendingFrames = pendingFrames
@@ -262,6 +337,7 @@ public actor Memory {
             self.queryEmbedderConfigured = queryEmbedderConfigured
             self.queryEmbeddingCircuitOpen = queryEmbeddingCircuitOpen
             self.embedderIdentity = embedderIdentity
+            self.embeddingStatus = embeddingStatus
         }
     }
 
@@ -271,14 +347,64 @@ public actor Memory {
     /// opening a store on a platform where the built-in embedder is unavailable.
     public func stats() async -> Stats {
         let runtime = await orchestrator.runtimeStats()
+        let resolvedEmbeddingStatus: EmbeddingStatus
+        if case .disabled = embeddingStatus, runtime.queryEmbedderConfigured {
+            resolvedEmbeddingStatus = .active(runtime.embedderIdentity)
+        } else {
+            resolvedEmbeddingStatus = embeddingStatus
+        }
         return Stats(
             frameCount: runtime.frameCount,
             pendingFrames: runtime.pendingFrames,
             vectorSearchEnabled: runtime.vectorSearchEnabled,
             queryEmbedderConfigured: runtime.queryEmbedderConfigured,
             queryEmbeddingCircuitOpen: runtime.queryEmbeddingCircuitOpen,
-            embedderIdentity: runtime.embedderIdentity
+            embedderIdentity: runtime.embedderIdentity,
+            embeddingStatus: resolvedEmbeddingStatus
         )
+    }
+
+    private func finishAutomaticEmbeddingActivation(_ provider: any EmbeddingProvider) async {
+        guard !isClosed else { return }
+        do {
+            try await orchestrator.activateEmbedder(provider)
+            guard !isClosed else { return }
+            do {
+                _ = try await orchestrator.backfillMissingEmbeddings()
+                guard !isClosed else { return }
+                try await orchestrator.flush()
+                guard !isClosed else { return }
+                embeddingStatus = .active(provider.identity)
+            } catch {
+                guard !isClosed else { return }
+                WaxDiagnostics.logSwallowed(
+                    error,
+                    context: "automatic embedding backfill",
+                    fallback: "new text is vector-enabled; previously saved text may remain text-only"
+                )
+                embeddingStatus = .degraded(provider.identity, reason: error.localizedDescription)
+            }
+        } catch {
+            guard !isClosed else { return }
+            WaxDiagnostics.logSwallowed(
+                error,
+                context: "automatic embedding activation",
+                fallback: "text-only search"
+            )
+            embeddingStatus = .unavailable(reason: error.localizedDescription)
+        }
+        activationTask = nil
+    }
+
+    private func finishAutomaticEmbeddingFailure(_ error: any Swift.Error) {
+        guard !isClosed else { return }
+        WaxDiagnostics.logSwallowed(
+            error,
+            context: "automatic MiniLM embedder setup",
+            fallback: "text-only search"
+        )
+        embeddingStatus = .unavailable(reason: error.localizedDescription)
+        activationTask = nil
     }
 
     /// Resolves the embedder for ``Config/embedding``. `.automatic` returns nil

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -189,12 +189,12 @@ package actor MemoryOrchestrator {
     private static let contentHashMetadataKey = "wax.content.hash"
 
     let wax: Wax
-    let config: OrchestratorConfig
+    private(set) var config: OrchestratorConfig
     private let ragBuilder: FastRAGContextBuilder
 
     let session: WaxSession
-    private let embedder: (any EmbeddingProvider)?
-    private let embeddingCache: EmbeddingMemoizer?
+    private var embedder: (any EmbeddingProvider)?
+    private var embeddingCache: EmbeddingMemoizer?
     private let enrichmentPipeline: EnrichmentPipeline?
     private let accessStatsManager = AccessStatsManager()
     private var accessStatsFrameId: UInt64?
@@ -266,7 +266,7 @@ package actor MemoryOrchestrator {
         // work out-of-the-box with text-only search instead of throwing an error.
         var resolvedConfig = config
         let existingMemoryBinding = await wax.memoryBinding()
-        if resolvedConfig.enableVectorSearch, embedder == nil, await wax.committedVecIndexManifest() == nil {
+        if resolvedConfig.enableVectorSearch, embedder == nil {
             resolvedConfig.enableVectorSearch = false
             WaxDiagnostics.logSwallowed(
                 WaxError.io("vector search requested but no EmbeddingProvider configured"),
@@ -320,6 +320,106 @@ package actor MemoryOrchestrator {
         if resolvedConfig.enableAccessStatsScoring {
             try await loadPersistedAccessStatsIfNeeded()
         }
+    }
+
+    /// Activates a provider after the text store has already opened.
+    ///
+    /// The session's vector engine is prepared before the provider becomes visible to
+    /// ingestion or queries, so callers never observe a partially activated state.
+    package func activateEmbedder(_ provider: any EmbeddingProvider) async throws {
+        if config.requireOnDeviceProviders {
+            try ProviderValidation.validateOnDevice(
+                [.init(name: "embedding provider", executionMode: provider.executionMode)],
+                orchestratorName: "MemoryOrchestrator"
+            )
+        }
+        if let binding = await wax.memoryBinding(),
+           let identity = provider.identity,
+           !MemoryBindingCompatibility.isCompatible(binding, with: identity) {
+            let mismatch = MemoryBindingCompatibility.mismatchReason(binding, with: identity) ?? "unknown mismatch"
+            throw WaxError.io("memory binding mismatch with embedder identity (\(mismatch))")
+        }
+
+        try await session.activateVectorSearch(
+            dimensions: provider.dimensions,
+            preference: config.vectorEnginePreference
+        )
+        embedder = provider
+        embeddingCache = EmbeddingMemoizer.fromConfig(
+            capacity: config.embeddingCacheCapacity,
+            enabled: true
+        )
+        config.enableVectorSearch = true
+        queryEmbeddingCircuitOpenedAt = nil
+    }
+
+    /// Embeds live text chunks that were persisted before a provider became ready.
+    ///
+    /// Existing vector rows are skipped, making this safe to retry after interruption.
+    @discardableResult
+    package func backfillMissingEmbeddings() async throws -> Int {
+        guard config.enableVectorSearch, let embedder else {
+            throw WaxError.missingEmbedder
+        }
+
+        let existingFrameIds = try await frameIdsWithEmbeddings()
+        let candidates = await wax.frameMetasIncludingPending().filter { frame in
+            frame.role == .chunk
+                && frame.status == .active
+                && frame.supersededBy == nil
+                && frame.searchText?.isEmpty == false
+                && !existingFrameIds.contains(frame.id)
+        }
+        guard !candidates.isEmpty else { return 0 }
+
+        let batchSize = max(1, config.ingestBatchSize)
+        let cache = embeddingCache
+        for start in stride(from: 0, to: candidates.count, by: batchSize) {
+            let end = min(start + batchSize, candidates.count)
+            let batch = Array(candidates[start..<end])
+            let texts = batch.compactMap(\.searchText)
+            let prepared = try await Self.prepareEmbeddings(
+                chunks: texts,
+                embedder: embedder,
+                cache: cache
+            )
+            let vectors = try texts.indices.map { index -> [Float] in
+                guard let vector = prepared[index] else {
+                    throw WaxError.invalidEmbedding(reason: "backfill did not produce vector at index \(index)")
+                }
+                try VectorValidation.validate(vector, dimensions: embedder.dimensions)
+                return vector
+            }
+            try await session.addEmbeddingBatch(
+                frameIds: batch.map(\.id),
+                vectors: vectors
+            )
+        }
+
+        if let identity = embedder.identity {
+            try await ensureMemoryBindingIfNeeded(MemoryBindingCompatibility.binding(from: identity))
+        }
+        return candidates.count
+    }
+
+    private func frameIdsWithEmbeddings() async throws -> Set<UInt64> {
+        var frameIds = Set<UInt64>()
+        let segmentBytes: Data?
+        if let staged = await wax.readStagedVecIndexBytes() {
+            segmentBytes = staged.bytes
+        } else {
+            segmentBytes = try await wax.readCommittedVecIndexBytes()
+        }
+        if let segmentBytes {
+            let payload = try VectorSerializer.decodeVecSegment(from: segmentBytes)
+            switch payload {
+            case .metal(_, _, let persistedFrameIds):
+                frameIds.formUnion(persistedFrameIds)
+            }
+        }
+        let pending = await wax.pendingEmbeddingMutations(since: nil)
+        frameIds.formUnion(pending.embeddings.map(\.frameId))
+        return frameIds
     }
 
 

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -5,6 +5,12 @@ import WaxVectorSearch
 
 package actor WaxSession {
     private typealias ConcreteVectorEngine = LoadedVectorSearchEngine
+    private struct VectorActivation: Sendable {
+        let id: UUID
+        let dimensions: Int
+        let preference: VectorEnginePreference
+        let task: Task<ConcreteVectorEngine, any Error>
+    }
 
     package enum Mode: Sendable, Equatable {
         case readOnly
@@ -46,11 +52,12 @@ package actor WaxSession {
 
     package let wax: Wax
     package let mode: Mode
-    package let config: Config
+    package private(set) var config: Config
 
     private let textEngine: FTS5SearchEngine?
-    private let vectorEngine: (any VectorSearchEngine)?
-    private let concreteVectorEngine: ConcreteVectorEngine?
+    private var vectorEngine: (any VectorSearchEngine)?
+    private var concreteVectorEngine: ConcreteVectorEngine?
+    private var vectorActivation: VectorActivation?
     private var lastPendingEmbeddingSequence: UInt64?
     /// Frame IDs removed from the vector index that must be re-applied after syncing pending embeddings.
     /// Mirrors ``WaxVectorSearchSession`` so pending putEmbedding + remove does not re-stage ghosts.
@@ -195,6 +202,105 @@ package actor WaxSession {
             return
         }
         try await concreteVectorEngine.remove(frameId: frameId)
+    }
+
+    /// Enables vector search on an already-open writable session.
+    ///
+    /// This supports model providers whose cold Core ML setup finishes after the text
+    /// store is usable. Existing vector data is loaded before the session is published
+    /// as vector-enabled.
+    package func activateVectorSearch(
+        dimensions: Int,
+        preference: VectorEnginePreference
+    ) async throws {
+        try ensureWritable()
+        guard dimensions > 0 else {
+            throw WaxError.invalidEmbedding(reason: "embedding dimensions must be greater than zero")
+        }
+        if let configuredDimensions = config.vectorDimensions,
+           configuredDimensions != dimensions {
+            throw WaxError.invalidEmbedding(
+                reason: "dimension mismatch: expected \(configuredDimensions), got \(dimensions)"
+            )
+        }
+        if config.enableVectorSearch, concreteVectorEngine != nil {
+            return
+        }
+
+        let activation: VectorActivation
+        if let existing = vectorActivation {
+            guard existing.dimensions == dimensions else {
+                throw WaxError.invalidEmbedding(
+                    reason: "vector activation dimension mismatch: expected \(existing.dimensions), got \(dimensions)"
+                )
+            }
+            activation = existing
+        } else {
+            let wax = self.wax
+            let metric = config.vectorMetric
+            let task = Task {
+                try await Self.loadVectorEngine(
+                    wax: wax,
+                    metric: metric,
+                    dimensions: dimensions,
+                    preference: preference
+                )
+            }
+            let created = VectorActivation(
+                id: UUID(),
+                dimensions: dimensions,
+                preference: preference,
+                task: task
+            )
+            vectorActivation = created
+            activation = created
+        }
+
+        let loaded: ConcreteVectorEngine
+        do {
+            loaded = try await activation.task.value
+        } catch {
+            if vectorActivation?.id == activation.id {
+                vectorActivation = nil
+            }
+            throw error
+        }
+        if vectorActivation?.id == activation.id {
+            vectorActivation = nil
+        }
+        try ensureWritable()
+        if concreteVectorEngine != nil {
+            return
+        }
+        let snapshot = await wax.pendingEmbeddingMutations(since: nil)
+        try ensureWritable()
+
+        concreteVectorEngine = loaded
+        vectorEngine = loaded.erased
+        lastPendingEmbeddingSequence = snapshot.latestSequence
+        config.enableVectorSearch = true
+        config.vectorDimensions = dimensions
+        config.vectorEnginePreference = activation.preference
+    }
+
+    package func addEmbeddingBatch(
+        frameIds: [UInt64],
+        vectors: [[Float]]
+    ) async throws {
+        try ensureWritable()
+        guard config.enableVectorSearch, let concreteVectorEngine else {
+            throw WaxError.featureDisabled(feature: "vector search")
+        }
+        guard frameIds.count == vectors.count else {
+            throw WaxError.encodingError(reason: "addEmbeddingBatch: frameIds.count != vectors.count")
+        }
+        guard !frameIds.isEmpty else { return }
+
+        try await wax.putEmbeddingBatch(frameIds: frameIds, vectors: vectors)
+        try await syncPendingEmbeddings(into: concreteVectorEngine)
+        for frameId in frameIds {
+            pendingRemovedFrameIds.remove(frameId)
+        }
     }
 
     // MARK: - Structured Memory

--- a/Sources/WaxCore/Runtime/CommandLineEmbedderRuntimeTuning.swift
+++ b/Sources/WaxCore/Runtime/CommandLineEmbedderRuntimeTuning.swift
@@ -31,11 +31,10 @@ package struct CommandLineEmbedderRuntimeTuning: Sendable, Equatable, Codable {
     package static let defaultAllowLowPrecisionGPU = true
     /// Cold CoreML compilation of MiniLM/Arctic can exceed 60s on first process load.
     package static let defaultTimeoutSeconds = 120.0
-    /// Prefer ANE (matching MiniLMEmbeddings' own default). Plain `cpuOnly` has been
-    /// observed to emit non-finite vectors on some Apple Silicon CoreML builds.
+    /// Prefer ANE (matching MiniLMEmbeddings' own default). Plain `cpuOnly` is excluded
+    /// because it has emitted non-finite vectors on some Apple Silicon Core ML builds.
     package static let defaultComputeUnitsOrder: [CommandLineEmbedderComputeUnit] = [
         .cpuAndNeuralEngine,
-        .cpuOnly,
         .cpuAndGPU,
         .all,
     ]

--- a/Sources/WaxMCPServer/CorpusStore.swift
+++ b/Sources/WaxMCPServer/CorpusStore.swift
@@ -1,6 +1,7 @@
 #if MCPServer
 import Foundation
 import Wax
+import WaxCore
 
 enum CorpusMetadataKeys {
     static let origin = "wax.corpus.origin"

--- a/Sources/WaxMCPServer/MCPMemoryFactory.swift
+++ b/Sources/WaxMCPServer/MCPMemoryFactory.swift
@@ -3,6 +3,7 @@ import Foundation
 import MCP
 import Wax
 import WaxCore
+import WaxVectorSearch
 
 #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
 import WaxVectorSearchMiniLM
@@ -344,13 +345,12 @@ private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmb
         guard provider == nil, providerTask == nil else { return }
 
         let kind = self.kind
-        let timeout = self.timeout
         let tuning = self.tuning
         let token = UUID()
         writeStderr("Scheduling \(kind.displayName) embedder background warmup...")
 
         let task = Task<any EmbeddingProvider, Error> {
-            try await Self.makeProvider(kind: kind, timeout: timeout, skipPrewarm: true, tuning: tuning)
+            try await Self.makeProvider(kind: kind, skipPrewarm: true, tuning: tuning)
         }
         providerTask = task
         providerTaskToken = token
@@ -370,7 +370,7 @@ private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmb
             return provider
         }
         if let providerTask {
-            let provider = try await providerTask.value
+            let provider = try await waitForProvider(providerTask)
             self.provider = provider
             self.providerTask = nil
             self.providerTaskToken = nil
@@ -378,25 +378,38 @@ private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmb
         }
 
         let kind = self.kind
-        let timeout = self.timeout
         let tuning = self.tuning
         writeStderr("Loading \(kind.displayName) embedder on first vector request...")
         let task = Task<any EmbeddingProvider, Error> {
-            try await Self.makeProvider(kind: kind, timeout: timeout, skipPrewarm: true, tuning: tuning)
+            try await Self.makeProvider(kind: kind, skipPrewarm: true, tuning: tuning)
         }
         providerTask = task
         providerTaskToken = nil
 
         do {
-            let provider = try await task.value
+            let provider = try await waitForProvider(task)
             self.provider = provider
             self.providerTask = nil
             self.providerTaskToken = nil
             return provider
+        } catch let error as AsyncTimeout.TimeoutError {
+            // Keep the non-cancellable Core ML load alive for the next request.
+            throw error
         } catch {
             self.providerTask = nil
             self.providerTaskToken = nil
             throw error
+        }
+    }
+
+    private func waitForProvider(
+        _ task: Task<any EmbeddingProvider, Error>
+    ) async throws -> any EmbeddingProvider {
+        try await AsyncTimeout.run(
+            timeout: timeout,
+            operation: "MCP embedding provider load"
+        ) {
+            try await task.value
         }
     }
 
@@ -422,32 +435,27 @@ private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmb
 
     private static func makeProvider(
         kind: Kind,
-        timeout: Duration,
         skipPrewarm: Bool,
         tuning: CommandLineEmbedderRuntimeTuning
     ) async throws -> any EmbeddingProvider {
         switch kind {
         case .minilm:
             #if MiniLMEmbeddings && canImport(WaxVectorSearchMiniLM) && canImport(CoreML)
-            return try await AsyncTimeout.run(timeout: timeout, operation: "MiniLM embedder init") {
-                try await MiniLMEmbedder.makeCommandLineEmbedder(
-                    prewarmBatchSize: tuning.prewarmBatchSize,
-                    skipPrewarm: skipPrewarm,
-                    tuning: tuning
-                )
-            }
+            return try await MiniLMEmbedder.makeCommandLineEmbedder(
+                prewarmBatchSize: tuning.prewarmBatchSize,
+                skipPrewarm: skipPrewarm,
+                tuning: tuning
+            )
             #else
             throw WaxError.io("MiniLM embeddings are not available in this build.")
             #endif
         case .arctic:
             #if ArcticEmbeddings && canImport(WaxVectorSearchArctic) && canImport(CoreML)
-            return try await AsyncTimeout.run(timeout: timeout, operation: "Arctic embedder init") {
-                try await ArcticEmbedder.makeCommandLineEmbedder(
-                    prewarmBatchSize: tuning.prewarmBatchSize,
-                    skipPrewarm: skipPrewarm,
-                    tuning: tuning
-                )
-            }
+            return try await ArcticEmbedder.makeCommandLineEmbedder(
+                prewarmBatchSize: tuning.prewarmBatchSize,
+                skipPrewarm: skipPrewarm,
+                tuning: tuning
+            )
             #else
             throw WaxError.io("Arctic embeddings are not available in this build.")
             #endif

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -2,6 +2,7 @@
 import Foundation
 import MCP
 import Wax
+import WaxCore
 
 enum WaxMCPTools {
     static func register(

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -30,7 +30,8 @@ enum WaxMCPServerMetadata {
 struct WaxMCPServerCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wax-mcp",
-        abstract: "MCP server exposing Wax memory tools over stdio or HTTP."
+        abstract: "MCP server exposing Wax memory tools over stdio or HTTP.",
+        version: WaxMCPServerMetadata.version
     )
 
     @Option(name: .customLong("store-path"), help: "Path to the Wax memory store (.wax)")

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -1067,7 +1067,19 @@ struct WaxCLIMemoryTests {
         let fixtureRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("wax-build-checksums-\(UUID().uuidString)", isDirectory: true)
         let scriptsDir = fixtureRoot.appendingPathComponent("Resources/scripts", isDirectory: true)
-        let distDir = fixtureRoot.appendingPathComponent("Resources/npm/waxmcp/dist/darwin-arm64", isDirectory: true)
+        // Use the non-native architecture so the helper validates the Mach-O header
+        // without trying to execute this deliberately minimal fixture.
+        #if arch(arm64)
+        let fixturePlatform = "darwin-x64"
+        let fixtureCPUType: UInt32 = 0x01000007
+        #else
+        let fixturePlatform = "darwin-arm64"
+        let fixtureCPUType: UInt32 = 0x0100000c
+        #endif
+        let distDir = fixtureRoot.appendingPathComponent(
+            "Resources/npm/waxmcp/dist/\(fixturePlatform)",
+            isDirectory: true
+        )
         defer { try? FileManager.default.removeItem(at: fixtureRoot) }
 
         try FileManager.default.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
@@ -1078,12 +1090,12 @@ struct WaxCLIMemoryTests {
             to: scriptURL
         )
         try setExecutable(scriptURL)
-        try makeExecutableStub(at: distDir.appendingPathComponent("wax-cli"))
-        try makeExecutableStub(at: distDir.appendingPathComponent("wax-mcp"))
+        try makeMachOStub(at: distDir.appendingPathComponent("wax-cli"), cpuType: fixtureCPUType)
+        try makeMachOStub(at: distDir.appendingPathComponent("wax-mcp"), cpuType: fixtureCPUType)
 
         let output = try runProcess(
             executableURL: scriptURL,
-            arguments: ["darwin-arm64"],
+            arguments: [fixturePlatform],
             currentDirectoryURL: fixtureRoot,
             timeout: 10
         )
@@ -1271,6 +1283,25 @@ struct WaxCLIMemoryTests {
 
     private func makeExecutableStub(at url: URL) throws {
         try "#!/bin/sh\nexit 0\n".write(to: url, atomically: true, encoding: .utf8)
+        try setExecutable(url)
+    }
+
+    private func makeMachOStub(at url: URL, cpuType: UInt32) throws {
+        var data = Data()
+        for value: UInt32 in [
+            0xfeedfacf,
+            cpuType,
+            3,
+            2,
+            0,
+            0,
+            0,
+            0,
+        ] {
+            var littleEndian = value.littleEndian
+            withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+        }
+        try data.write(to: url)
         try setExecutable(url)
     }
 

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorErrorTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorErrorTests.swift
@@ -110,7 +110,7 @@ func memoryOrchestratorStructuredMemoryDisabledThrowsFeatureDisabled() async thr
 }
 
 @Test
-func memoryOrchestratorVectorStoreWithoutEmbedderThrowsMissingEmbedder() async throws {
+func memoryOrchestratorVectorStoreWithoutEmbedderDegradesToTextOnly() async throws {
     try await TempFiles.withTempFile { url in
         let config = TestHelpers.defaultMemoryConfig(vector: true)
         let seeded = try await MemoryOrchestrator(
@@ -121,20 +121,13 @@ func memoryOrchestratorVectorStoreWithoutEmbedderThrowsMissingEmbedder() async t
         try await seeded.remember("Seeded vector store phrase.")
         try await seeded.close()
 
-        // Reopening a store that already has a committed vector index keeps vector
-        // search enabled; writing without an embedder must fail with a typed error.
+        // Reopening without a provider must keep text writes available while making
+        // the disabled vector lane explicit in runtime health.
         let reopened = try await MemoryOrchestrator(at: url, config: config)
-        do {
-            try await reopened.remember("This write needs an embedder but none is configured.")
-            #expect(Bool(false), "remember without embedder on a vector store must throw")
-        } catch let error as WaxError {
-            guard case .missingEmbedder = error else {
-                #expect(Bool(false), "expected WaxError.missingEmbedder, got \(error)")
-                return
-            }
-        } catch {
-            #expect(Bool(false))
-        }
+        try await reopened.remember("This write remains available in text-only mode.")
+        let runtime = await reopened.runtimeStats()
+        #expect(!runtime.vectorSearchEnabled)
+        #expect(!runtime.queryEmbedderConfigured)
         try await reopened.close()
     }
 }

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
@@ -298,7 +298,7 @@ func memoryOrchestratorNonBatchEmbedderDoesNotReceiveConcurrentEmbedCalls() asyn
 }
 
 @Test
-func memoryOrchestratorRememberRequiresEmbedderWhenVectorSearchEnabledAfterReopen() async throws {
+func memoryOrchestratorReopenWithoutEmbedderRemainsWritableInTextOnlyMode() async throws {
     try await TempFiles.withTempFile { url in
         var config = OrchestratorConfig.default
         config.enableVectorSearch = true
@@ -314,17 +314,15 @@ func memoryOrchestratorRememberRequiresEmbedderWhenVectorSearchEnabledAfterReope
         try await waxBefore.close()
 
         let reopened = try await MemoryOrchestrator(at: url, config: config, embedder: nil)
-        do {
-            try await reopened.remember("This should fail without an embedder.")
-            #expect(Bool(false))
-        } catch {
-            #expect(Bool(true))
-        }
+        try await reopened.remember("This remains writable without an embedder.")
+        let runtime = await reopened.runtimeStats()
+        #expect(!runtime.vectorSearchEnabled)
+        #expect(!runtime.queryEmbedderConfigured)
         try await reopened.close()
 
         let waxAfter = try await Wax.open(at: url)
         let afterCount = await waxAfter.stats().frameCount
-        #expect(afterCount == beforeCount)
+        #expect(afterCount > beforeCount)
         try await waxAfter.close()
     }
 }

--- a/Tests/WaxIntegrationTests/MiniLMLifecycleRegressionTests.swift
+++ b/Tests/WaxIntegrationTests/MiniLMLifecycleRegressionTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+import Wax
+import WaxCore
+
+@Test
+func embeddingLoadCoordinatorRetainsColdLoadAfterFirstWaiterTimesOut() async throws {
+    let counter = EmbeddingFactoryCounter()
+    let coordinator = EmbeddingLoadCoordinator()
+    let key = EmbeddingLoadKey(provider: "minilm", configuration: "default")
+
+    await #expect(throws: EmbeddingLoadCoordinator.WaitError.timedOut) {
+        _ = try await coordinator.provider(
+            for: key,
+            timeout: .milliseconds(10)
+        ) {
+            await counter.increment()
+            try await Task.sleep(for: .milliseconds(100))
+            return DeterministicTextEmbedder()
+        }
+    }
+
+    let provider = try await coordinator.provider(
+        for: key,
+        timeout: .seconds(1)
+    ) {
+        await counter.increment()
+        return DeterministicTextEmbedder(dimensions: 4)
+    }
+
+    #expect(provider.dimensions == 2)
+    #expect(await counter.value == 1)
+}
+
+@Test
+func memoryAutomaticEmbeddingLoadsInBackgroundAndBackfillsEarlyText() async throws {
+    try await TempFiles.withTempFile { url in
+        let memory = try await Memory(
+            at: url,
+            config: .init(enableVectorSearch: true, embedding: .automatic)
+        ) {
+            try await Task.sleep(for: .milliseconds(150))
+            return DeterministicTextEmbedder()
+        }
+
+        let loading = await memory.stats()
+        #expect(loading.embeddingStatus == .loading)
+        #expect(!loading.vectorSearchEnabled)
+        try await memory.save("The recovery phrase is silver-comet.")
+
+        let status = await memory.prepareEmbeddings()
+        guard case .active = status else {
+            Issue.record("Expected active embeddings, got \(status)")
+            return
+        }
+
+        let active = await memory.stats()
+        #expect(active.vectorSearchEnabled)
+        #expect(active.queryEmbedderConfigured)
+        #expect(active.embeddingStatus == .active(DeterministicTextEmbedder().identity))
+
+        let result = try await memory.search(
+            "The recovery phrase is silver-comet.",
+            options: .init(topK: 1, mode: .vectorOnly)
+        )
+        #expect(result.items.first?.text.contains("silver-comet") == true)
+        try await memory.close()
+    }
+}
+
+@Test
+func memoryCloseDuringAutomaticBackfillDoesNotResumeWorkOnClosedStore() async throws {
+    try await TempFiles.withTempFile { url in
+        let embedder = HangingCountingEmbedder()
+        let memory = try await Memory(
+            at: url,
+            config: .init(enableVectorSearch: true, embedding: .automatic)
+        ) {
+            try await Task.sleep(for: .milliseconds(250))
+            return embedder
+        }
+        try await memory.save("Text queued before the model is ready.")
+
+        for _ in 0..<100 {
+            if await embedder.callCount() > 0 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await embedder.callCount() == 1)
+
+        try await AsyncTimeout.run(timeout: .seconds(1), operation: "memory close") {
+            try await memory.close()
+        }
+    }
+}
+
+@Test
+func memoryOrchestratorCanActivateEmbedderAndBackfillTextSavedWhileLoading() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = TestHelpers.defaultMemoryConfig(vector: true)
+        config.chunking = .tokenCount(targetTokens: 128, overlapTokens: 0)
+
+        let orchestrator = try await MemoryOrchestrator(
+            at: url,
+            config: config,
+            embedder: nil
+        )
+
+        try await orchestrator.remember("The launch code is violet-orchid.")
+
+        let before = await orchestrator.runtimeStats()
+        #expect(!before.vectorSearchEnabled)
+        #expect(!before.queryEmbedderConfigured)
+
+        let embedder = DeterministicTextEmbedder()
+        try await orchestrator.activateEmbedder(embedder)
+        let backfilled = try await orchestrator.backfillMissingEmbeddings()
+        try await orchestrator.flush()
+
+        #expect(backfilled == 1)
+
+        let after = await orchestrator.runtimeStats()
+        #expect(after.vectorSearchEnabled)
+        #expect(after.queryEmbedderConfigured)
+        #expect(after.embedderIdentity == embedder.identity)
+
+        let embedding = try await embedder.embed("The launch code is violet-orchid.")
+        let context = try await orchestrator.recall(
+            query: "launch code",
+            embedding: embedding
+        )
+        #expect(context.items.first?.text.contains("violet-orchid") == true)
+
+        try await orchestrator.close()
+    }
+}
+
+@Test
+func memoryWrapperReportsActiveOrchestratorEmbeddingStatus() async throws {
+    try await TempFiles.withTempFile { url in
+        let embedder = DeterministicTextEmbedder()
+        let orchestrator = try await MemoryOrchestrator(
+            at: url,
+            config: TestHelpers.defaultMemoryConfig(vector: true),
+            embedder: embedder
+        )
+        let memory = Memory(orchestrator: orchestrator)
+
+        #expect(await memory.stats().embeddingStatus == .active(embedder.identity))
+        #expect(await memory.prepareEmbeddings() == .active(embedder.identity))
+        try await memory.close()
+    }
+}
+
+@Test
+func reopeningVectorStoreWithoutEmbedderDegradesToWritableTextOnlyMode() async throws {
+    try await TempFiles.withTempFile { url in
+        let embedder = DeterministicTextEmbedder()
+        let config = TestHelpers.defaultMemoryConfig(vector: true)
+
+        do {
+            let seeded = try await MemoryOrchestrator(
+                at: url,
+                config: config,
+                embedder: embedder
+            )
+            try await seeded.remember("A vector-backed memory.")
+            try await seeded.close()
+        }
+
+        let reopened = try await MemoryOrchestrator(
+            at: url,
+            config: config,
+            embedder: nil
+        )
+        try await reopened.remember("Text remains writable while the model is unavailable.")
+
+        let stats = await reopened.runtimeStats()
+        #expect(!stats.vectorSearchEnabled)
+        #expect(!stats.queryEmbedderConfigured)
+        try await reopened.close()
+    }
+}
+
+private actor EmbeddingFactoryCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}
+
+@Test
+func builtInEmbeddingDefaultsExcludeKnownBrokenCpuOnlyPath() {
+    #expect(!BuiltInEmbeddingProviderOptions.default.computeUnitsOrder.contains(.cpuOnly))
+}

--- a/Tests/WaxIntegrationTests/SemanticRetrievalGateTests.swift
+++ b/Tests/WaxIntegrationTests/SemanticRetrievalGateTests.swift
@@ -23,6 +23,11 @@ func memoryDefaultInitAutoWiresBuiltInEmbedderAndRetrievesParaphrase() async thr
         // auto-wire the built-in MiniLM embedder.
         let memory = try await Memory(at: url)
 
+        let embeddingStatus = await memory.prepareEmbeddings()
+        guard case .active = embeddingStatus else {
+            Issue.record("default Memory(at:) did not activate MiniLM: \(embeddingStatus)")
+            return
+        }
         let stats = await memory.stats()
         #expect(
             stats.queryEmbedderConfigured,

--- a/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
@@ -160,7 +160,9 @@ func memoryOrchestratorQueryEmbeddingCircuitHalfOpensAfterCooldown() async throw
 
         var config = TestHelpers.defaultMemoryConfig(vector: true)
         config.queryEmbeddingTimeout = .milliseconds(25)
-        config.queryEmbeddingCircuitCooldown = .milliseconds(150)
+        // Keep the window comfortably above scheduler delays in the fully parallel
+        // package suite; the test controls expiry explicitly below.
+        config.queryEmbeddingCircuitCooldown = .seconds(3)
 
         let orchestrator = try await MemoryOrchestrator(at: url, config: config, embedder: embedder)
 
@@ -188,7 +190,7 @@ func memoryOrchestratorQueryEmbeddingCircuitHalfOpensAfterCooldown() async throw
 
         // After the cooldown the breaker half-opens and retries instead of latching
         // permanently. (The hanging embedder times out again and re-opens the circuit.)
-        try await Task.sleep(for: .milliseconds(300))
+        try await Task.sleep(for: .milliseconds(3_200))
         let exec3 = try await orchestrator.searchExecution(
             query: "Swift concurrency",
             mode: .hybrid(alpha: 0.5),


### PR DESCRIPTION
## Summary
- keep cold Core ML model loads alive across request timeouts and expose honest loading, active, degraded, and unavailable states
- open automatic `Memory` instances immediately in text mode, activate vector search in place, and backfill text saved before MiniLM becomes ready
- remove the broken CPU-only default, fix MCP's duplicate timeout path, and make vector-store fallback writable without an embedder
- harden waxmcp releases with native Intel/ARM runners, binary architecture/version checks, model resource validation, and packaged MiniLM inference gates

## Test plan
- [x] `swift test --no-parallel` (1,169 tests)
- [x] focused MiniLM lifecycle, close-race, backfill, and packaging regression tests
- [x] `swift run --traits 'MCPServer,MiniLMEmbeddings,ArcticEmbeddings' wax-mcp --version`
- [x] shell and Node release-script syntax checks
- [x] independent Swift concurrency and code-quality review with all medium-or-higher findings resolved

Made with [Cursor](https://cursor.com)