### PR TITLE
[deslop] Phase 1 — Docs & skills truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,17 @@ Wax meets you where you are. Pick the path that matches what you're building:
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/christopherkarani/Wax.git", from: "0.1.8")
+    // Prefer branch `main` until a tagged release ships the current public
+    // Memory.Config.embedding / stats() / Foundation Models adapters surface.
+    // Tag `0.1.24` still keeps Foundation Models types package-only.
+    .package(url: "https://github.com/christopherkarani/Wax.git", branch: "main")
 ]
 ```
 
-Or in Xcode: **File → Add Package Dependencies →** `https://github.com/christopherkarani/Wax.git`
+Or in Xcode: **File → Add Package Dependencies →** `https://github.com/christopherkarani/Wax.git` (Dependency rule: **Branch** → `main`, or a release newer than `0.1.25` once published with the public adapters).
 
 > [!NOTE]
-> **Requirements:** Wax builds for iOS 17/macOS 14 and later. Built-in semantic embeddings (MiniLM) auto-configure on iOS 18/macOS 15+ when the default `MiniLMEmbeddings` package trait is enabled; on older OS versions, `Memory` runs text-only unless you pass a custom `EmbeddingProvider`. Foundation Models tools require iOS 26/macOS 26.
+> **Requirements:** Wax builds for iOS 17/macOS 14 and later. Built-in semantic embeddings (MiniLM) auto-configure on iOS 18/macOS 15+ when the default `MiniLMEmbeddings` package trait is enabled; on older OS versions, `Memory` runs text-only unless you pass a custom `EmbeddingProvider`. Foundation Models tools require iOS 26/macOS 26. Samples in this README match the **current `main` API** — pin to `main` (or a post-`0.1.25` tag) rather than older release tags if you need those APIs.
 
 ### 2. Copy-paste this into your app
 
@@ -271,7 +274,8 @@ This stages the Wax runtime locally, registers `wax-mcp` with Claude Code, and s
 **wax-mcp operator skill** under `~/.local/share/waxmcp/skills/wax-mcp` (then attempts
 `claude install-skill` when available). `npx` is only used for the one-time install.
 
-The MCP server also ships lifecycle instructions with every tools connection, so agents
+The MCP server also ships lifecycle instructions with every tools connection
+(`Sources/WaxMCPServer/AgentInstructions.swift` — source of truth), so agents
 receive the remember/recall/handoff playbook even without a separate skill install.
 
 ### 2. Install the wax-mcp skill (if install did not auto-register it)
@@ -300,7 +304,7 @@ Use the Wax MCP server for persistent memory in this repo.
 Workflow rules:
 - At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
 - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
+- Use `recall` for assembled context (preferred read path) and `search` for raw ranked hits.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.
@@ -423,7 +427,7 @@ npx -y waxmcp@latest mcp install --scope user
 
 For the recommended Claude Code prompt and setup flow, see [Resources/docs/wax-mcp-setup.md](Resources/docs/wax-mcp-setup.md).
 For the OpenClaw adapter verification pass used in this repo, run [`scripts/verify-openclaw-adapter.sh`](scripts/verify-openclaw-adapter.sh).
-For the native-memory operator guide, verifier, and benchmark sweep, see [docs/openclaw-native-memory.md](docs/openclaw-native-memory.md).
+OpenClaw plugin manifests live under [`Resources/openclaw/`](Resources/openclaw/) and [`Resources/npm/waxmcp/plugins/openclaw/`](Resources/npm/waxmcp/plugins/openclaw/).
 
 The MCP surface now supports managed Markdown round-trips with `markdown_export` / `markdown_sync`, including `MEMORY.md`, daily notes, and `DREAMS.md` promotion review. `markdown_sync` also supports `dry_run`, and OpenClaw-oriented promotion thresholds can be overridden on `session_synthesize` / `memory_promote` or via environment variables.
 

--- a/Resources/docs/wax-mcp-setup.md
+++ b/Resources/docs/wax-mcp-setup.md
@@ -19,21 +19,43 @@ This will:
 3. Configure default store paths under `~/.wax`
 4. Stage the **wax-mcp operator skill** under `~/.local/share/waxmcp/skills/wax-mcp`
 5. Attempt `claude install-skill` for that staged skill (best-effort)
-6. Print a pasteable `CLAUDE.md` / `AGENTS.md` project-rules block as fallback
+6. Print a pasteable project-rules block as fallback (same text as `Resources/skills/public/wax-mcp/references/project-rules.md`)
 
 Skip skill staging with `--skip-skill` if you only want the MCP server.
 
-## How agents learn the playbook
+## Operator playbook (single source of truth)
 
-Wax teaches agents at three layers:
+**Do not maintain a second conflicting essay of the session lifecycle.** The canonical
+host-facing playbook is embedded in MCP connections from:
+
+`Sources/WaxMCPServer/AgentInstructions.swift` (`MCPAgentInstructions`)
+
+That text is what every connected agent receives as server `instructions`. Expand or
+correct the lifecycle there first; then keep the skill and pasteable project-rules
+aligned with it.
 
 | Layer | When it applies | What it teaches |
 |-------|-----------------|-----------------|
-| MCP `instructions` + tool descriptions | Every connected host | Session lifecycle, anti-patterns |
-| `wax-mcp` skill | Hosts that load skills | Full operator playbook + install notes |
-| Project rules (`CLAUDE.md` / `AGENTS.md`) | Always-on project instructions | Same workflow rules as a paste block |
+| MCP `instructions` (`AgentInstructions.swift`) | Every connected host | **SoT** session lifecycle + tool selection |
+| `wax-mcp` skill | Hosts that load skills | Install notes + same playbook (must match SoT) |
+| Project rules paste block | Always-on project instructions | Same workflow rules for `CLAUDE.md` / app `AGENTS.md` |
 
-You usually only need step 1. Use the skill or project rules when the host ignores MCP instructions or you want stronger always-on enforcement.
+> Root repo `AGENTS.md` is for **public-repo hygiene** for contributors — do not overwrite
+> it with the memory operator playbook.
+
+You usually only need the MCP install. Use the skill or project rules when the host
+ignores MCP instructions or you want stronger always-on enforcement.
+
+### Intended primary search path
+
+Per `AgentInstructions.swift` and tool descriptions:
+
+- Prefer **`recall`** for assembled RAG context (default read path).
+- Use **`search`** for raw ranked hits; prefer `mode: "hybrid"` unless a lexical text search is requested.
+
+> Note: some wire paths currently default omitted `search` mode to `"text"`. Treat
+> **hybrid as the intended primary** when semantic recall helps; aligning code defaults
+> is tracked in Phase 4 ([#94](https://github.com/christopherkarani/Wax/issues/94)).
 
 ### Skill: agent operator vs Swift framework
 
@@ -56,28 +78,9 @@ The published `waxmcp` npm package also ships `skills/wax-mcp` so installs do no
 
 ## Recommended project rules
 
-Paste this into your repo prompt, `CLAUDE.md`, or `AGENTS.md` after installing Wax:
-
-```text
-Use the Wax MCP server for persistent memory in this repo.
-
-Workflow rules:
-- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
-- Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
-- Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
-- Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
-- Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.
-- Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
-- Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
-
-Behavior expectations:
-- Read existing handoffs and recall results before asking me to restate prior context.
-- Keep memory writes concise, factual, and scoped to the task.
-- When a cross-session result looks relevant, cite the provenance metadata so we know which session store it came from.
-```
-
-The same text ships in `Resources/skills/public/wax-mcp/references/project-rules.md`.
+Paste the block in `Resources/skills/public/wax-mcp/references/project-rules.md` into
+your repo prompt, `CLAUDE.md`, or app-level `AGENTS.md` after installing Wax. Keep that
+file aligned with `AgentInstructions.swift` — do not fork a third copy here.
 
 ## Run doctor
 
@@ -104,6 +107,8 @@ swift run --traits MCPServer wax-cli mcp serve
 
 ## MCP tool highlights
 
+Canonical list: `Sources/WaxMCPServer/ToolSchemas.swift` (no `photo_*` / `video_*` tools).
+
 - Session lifecycle: `session_start`, `session_end`
 - Session scoping on reads: `recall` and `search` accept `session_id`
 - Explicit session scoping on writes: `remember` and `handoff` accept `session_id`
@@ -113,7 +118,7 @@ swift run --traits MCPServer wax-cli mcp serve
 
 ## npx launcher
 
-The npm launcher is at `npm/waxmcp` (package name `waxmcp`).
+The npm launcher is at `Resources/npm/waxmcp` (package name `waxmcp`).
 
 ```bash
 npx -y waxmcp@latest mcp serve
@@ -133,9 +138,9 @@ Running `npx -y waxmcp@latest mcp install --scope user` stages those bundled art
 stable local runtime directory and registers the staged `wax-mcp` binary, so steady-state
 Claude/Codex sessions do not depend on raw `npx`.
 
-For local development:
+For local development from a Wax checkout:
 
 ```bash
-export WAX_CLI_BIN=/Users/chriskarani/CodingProjects/AIStack/Wax/.build/debug/wax-cli
-npx --yes /Users/chriskarani/CodingProjects/AIStack/Wax/npm/waxmcp mcp doctor
+export WAX_CLI_BIN="$(pwd)/.build/debug/wax-cli"
+npx --yes ./Resources/npm/waxmcp mcp doctor
 ```

--- a/Resources/npm/waxmcp/README.md
+++ b/Resources/npm/waxmcp/README.md
@@ -24,14 +24,15 @@ That install flow:
 4. Attempts `claude install-skill` when available and prints project-rules fallback text
 
 So regular MCP sessions do not keep launching through raw `npx`, and agents get a
-session lifecycle playbook (also embedded in MCP server instructions).
+session lifecycle playbook from MCP server `instructions`
+(`Sources/WaxMCPServer/AgentInstructions.swift` — source of truth; skill must match).
 
 ```bash
 # If skill auto-install did not run:
 claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
 ```
 
-> `wax-mcp` skill = agent operator playbook for MCP tools.
+> `wax-mcp` skill = agent operator playbook for MCP tools (defer to `AgentInstructions.swift`).
 > `wax` skill (separate, in the monorepo) = Swift framework integration guidance.
 
 > Note: the bundled npm runtime currently ships `darwin-arm64` and `darwin-x64` artifacts. The underlying

--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -17,34 +17,45 @@ Teach agents how to **use** the Wax MCP server correctly every session.
 This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 `wax` skill under `Resources/skills/public/wax`.
 
+## Source of truth
+
+The host-facing lifecycle playbook is defined in
+`Sources/WaxMCPServer/AgentInstructions.swift` (`MCPAgentInstructions`) and shipped
+as MCP server `instructions` on every tools connection. **Edit that file when the
+playbook changes.** This skill and `references/project-rules.md` must stay aligned
+with it — do not invent a conflicting second essay.
+
+Root repo `AGENTS.md` is contributor hygiene only; do not overwrite it with this
+memory playbook.
+
 ## Session Lifecycle (required)
 
-1. **Start**
-   - Call `handoff_latest` first (optionally with `project`) to load prior context.
-   - Call `session_start` once.
-   - Keep the returned `session_id` for the rest of the session.
-2. **Work**
-   - Before answering from memory, call `recall` (default) or `search` (raw hits).
-   - When you learn something durable, call `remember` with concise factual text.
-   - For session-scoped writes, pass `session_id` as a **top-level** argument.
-   - Never put `session_id` inside `metadata`.
-3. **End**
-   - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
-   - Call `session_end` (pass `session_id` when multiple sessions may be active).
+Matches `AgentInstructions.swift`:
 
-## Read Path
+1. Call `handoff_latest` first (optional `project`) to resume prior context.
+2. Call `session_start` once and keep the returned `session_id`.
+3. Before answering from memory, call `recall` (default) or `search` (raw ranked hits).
+4. When you learn durable facts, call `remember` with concise factual content. Pass
+   `session_id` as a **top-level** argument for session-scoped writes — never put
+   `session_id` inside `metadata`.
+5. Near session end, call `handoff` (`content`, optional `project` / `pending_tasks` /
+   `session_id`), then `session_end`.
 
-| Goal | Tool |
-|------|------|
-| Assembled RAG context for the current question | `recall` |
-| Raw ranked hits / debugging retrieval | `search` |
+## Intended primary search path
+
+| Goal | Tool / mode |
+|------|-------------|
+| Assembled RAG context (preferred read) | `recall` |
+| Raw ranked hits | `search` with `mode: "hybrid"` unless lexical-only is requested |
 | Cross-session history with provenance | `corpus_search` |
-| Health / embedder / store stats | `stats` |
+| Health / embedder / store | `stats` |
 
-Search mode guidance:
+> Code note: some `search` call paths still default omitted `mode` to `"text"`.
+> Prefer hybrid in agent calls; aligning wire defaults is Phase 4 (#94).
 
-- Prefer `mode: "hybrid"` when semantic recall helps.
-- Use `mode: "text"` for fast or deterministic lexical lookup.
+There are **no** `photo_*` or `video_*` MCP tools. Store transcript / photo-derived
+text with `remember` until multimodal MCP tools exist. Tool list:
+`Sources/WaxMCPServer/ToolSchemas.swift`.
 
 ## Write Path
 
@@ -80,8 +91,6 @@ Write quality rules:
 
 ## Install / Host Setup (for humans and setup agents)
 
-MCP server:
-
 ```bash
 npx -y waxmcp@latest mcp install --scope user
 ```
@@ -90,16 +99,15 @@ That command stages the runtime, registers the MCP server, and stages this skill
 under `~/.local/share/waxmcp/skills/wax-mcp` (or `$WAX_MCP_INSTALL_ROOT/../skills`
 when the install root is overridden).
 
-Skill install (Claude Code):
-
 ```bash
 claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
 # or from source
 claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax-mcp
 ```
 
-Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
-`AGENTS.md` when the host does not load skills automatically.
+Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or an
+**app** `AGENTS.md` when the host does not load skills automatically. Full setup:
+`Resources/docs/wax-mcp-setup.md`.
 
 ## Quick Tool Map
 
@@ -110,7 +118,7 @@ Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
 | `session_resume` | Resume a known session after restart |
 | `remember` | Store durable free-text memory |
 | `recall` | Default read / RAG assembly |
-| `search` | Raw ranked hits |
+| `search` | Raw ranked hits (prefer hybrid) |
 | `handoff` | End-of-session summary + pending tasks |
 | `corpus_search` | Cross-session search with provenance |
 | `stats` | Health check |
@@ -118,5 +126,6 @@ Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
 
 ## References
 
-- `references/project-rules.md` — pasteable project instruction block
+- SoT: `Sources/WaxMCPServer/AgentInstructions.swift`
+- `references/project-rules.md` — pasteable project instruction block (must match SoT)
 - Repo setup doc: `Resources/docs/wax-mcp-setup.md`

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -1,7 +1,14 @@
 # Wax MCP project rules
 
-Paste this block into `CLAUDE.md`, `AGENTS.md`, Cursor rules, or any host
+Paste this block into `CLAUDE.md`, an app-level `AGENTS.md`, Cursor rules, or any host
 always-on instruction file after installing the Wax MCP server.
+
+Keep this paste block aligned with the MCP server playbook SoT:
+`Sources/WaxMCPServer/AgentInstructions.swift`. Do not fork a conflicting essay.
+Do not replace the Wax repo root `AGENTS.md` (contributor hygiene) with this block.
+
+Intended primary read path: `recall`. For raw `search`, prefer `mode: "hybrid"` unless
+a lexical text lookup is requested (code default alignment is Phase 4 / #94).
 
 ```text
 Use the Wax MCP server for persistent memory in this repo.
@@ -9,7 +16,7 @@ Use the Wax MCP server for persistent memory in this repo.
 Workflow rules:
 - At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
 - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
+- Use `recall` for assembled context (preferred read path) and `search` for raw ranked hits.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -17,34 +17,45 @@ Teach agents how to **use** the Wax MCP server correctly every session.
 This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 `wax` skill under `Resources/skills/public/wax`.
 
+## Source of truth
+
+The host-facing lifecycle playbook is defined in
+`Sources/WaxMCPServer/AgentInstructions.swift` (`MCPAgentInstructions`) and shipped
+as MCP server `instructions` on every tools connection. **Edit that file when the
+playbook changes.** This skill and `references/project-rules.md` must stay aligned
+with it — do not invent a conflicting second essay.
+
+Root repo `AGENTS.md` is contributor hygiene only; do not overwrite it with this
+memory playbook.
+
 ## Session Lifecycle (required)
 
-1. **Start**
-   - Call `handoff_latest` first (optionally with `project`) to load prior context.
-   - Call `session_start` once.
-   - Keep the returned `session_id` for the rest of the session.
-2. **Work**
-   - Before answering from memory, call `recall` (default) or `search` (raw hits).
-   - When you learn something durable, call `remember` with concise factual text.
-   - For session-scoped writes, pass `session_id` as a **top-level** argument.
-   - Never put `session_id` inside `metadata`.
-3. **End**
-   - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
-   - Call `session_end` (pass `session_id` when multiple sessions may be active).
+Matches `AgentInstructions.swift`:
 
-## Read Path
+1. Call `handoff_latest` first (optional `project`) to resume prior context.
+2. Call `session_start` once and keep the returned `session_id`.
+3. Before answering from memory, call `recall` (default) or `search` (raw ranked hits).
+4. When you learn durable facts, call `remember` with concise factual content. Pass
+   `session_id` as a **top-level** argument for session-scoped writes — never put
+   `session_id` inside `metadata`.
+5. Near session end, call `handoff` (`content`, optional `project` / `pending_tasks` /
+   `session_id`), then `session_end`.
 
-| Goal | Tool |
-|------|------|
-| Assembled RAG context for the current question | `recall` |
-| Raw ranked hits / debugging retrieval | `search` |
+## Intended primary search path
+
+| Goal | Tool / mode |
+|------|-------------|
+| Assembled RAG context (preferred read) | `recall` |
+| Raw ranked hits | `search` with `mode: "hybrid"` unless lexical-only is requested |
 | Cross-session history with provenance | `corpus_search` |
-| Health / embedder / store stats | `stats` |
+| Health / embedder / store | `stats` |
 
-Search mode guidance:
+> Code note: some `search` call paths still default omitted `mode` to `"text"`.
+> Prefer hybrid in agent calls; aligning wire defaults is Phase 4 (#94).
 
-- Prefer `mode: "hybrid"` when semantic recall helps.
-- Use `mode: "text"` for fast or deterministic lexical lookup.
+There are **no** `photo_*` or `video_*` MCP tools. Store transcript / photo-derived
+text with `remember` until multimodal MCP tools exist. Tool list:
+`Sources/WaxMCPServer/ToolSchemas.swift`.
 
 ## Write Path
 
@@ -80,8 +91,6 @@ Write quality rules:
 
 ## Install / Host Setup (for humans and setup agents)
 
-MCP server:
-
 ```bash
 npx -y waxmcp@latest mcp install --scope user
 ```
@@ -90,16 +99,15 @@ That command stages the runtime, registers the MCP server, and stages this skill
 under `~/.local/share/waxmcp/skills/wax-mcp` (or `$WAX_MCP_INSTALL_ROOT/../skills`
 when the install root is overridden).
 
-Skill install (Claude Code):
-
 ```bash
 claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
 # or from source
 claude install-skill https://github.com/christopherkarani/Wax/tree/main/Resources/skills/public/wax-mcp
 ```
 
-Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
-`AGENTS.md` when the host does not load skills automatically.
+Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or an
+**app** `AGENTS.md` when the host does not load skills automatically. Full setup:
+`Resources/docs/wax-mcp-setup.md`.
 
 ## Quick Tool Map
 
@@ -110,7 +118,7 @@ Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
 | `session_resume` | Resume a known session after restart |
 | `remember` | Store durable free-text memory |
 | `recall` | Default read / RAG assembly |
-| `search` | Raw ranked hits |
+| `search` | Raw ranked hits (prefer hybrid) |
 | `handoff` | End-of-session summary + pending tasks |
 | `corpus_search` | Cross-session search with provenance |
 | `stats` | Health check |
@@ -118,5 +126,6 @@ Project rules fallback: paste `references/project-rules.md` into `CLAUDE.md` or
 
 ## References
 
-- `references/project-rules.md` — pasteable project instruction block
+- SoT: `Sources/WaxMCPServer/AgentInstructions.swift`
+- `references/project-rules.md` — pasteable project instruction block (must match SoT)
 - Repo setup doc: `Resources/docs/wax-mcp-setup.md`

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -1,7 +1,14 @@
 # Wax MCP project rules
 
-Paste this block into `CLAUDE.md`, `AGENTS.md`, Cursor rules, or any host
+Paste this block into `CLAUDE.md`, an app-level `AGENTS.md`, Cursor rules, or any host
 always-on instruction file after installing the Wax MCP server.
+
+Keep this paste block aligned with the MCP server playbook SoT:
+`Sources/WaxMCPServer/AgentInstructions.swift`. Do not fork a conflicting essay.
+Do not replace the Wax repo root `AGENTS.md` (contributor hygiene) with this block.
+
+Intended primary read path: `recall`. For raw `search`, prefer `mode: "hybrid"` unless
+a lexical text lookup is requested (code default alignment is Phase 4 / #94).
 
 ```text
 Use the Wax MCP server for persistent memory in this repo.
@@ -9,7 +16,7 @@ Use the Wax MCP server for persistent memory in this repo.
 Workflow rules:
 - At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
 - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
+- Use `recall` for assembled context (preferred read path) and `search` for raw ranked hits.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.

--- a/Resources/skills/public/wax-performance-audit/SKILL.md
+++ b/Resources/skills/public/wax-performance-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wax-performance-audit
-description: Benchmarking and performance auditing for the Wax repo. Use when running or interpreting Wax benchmarks, diagnosing CPU, memory, or I/O bottlenecks, or investigating Swift 6.2 concurrency issues such as Sendable, actor isolation, `@unchecked Sendable`, task-group fan-out, and data races.
+description: Benchmarking and performance auditing for the Wax repo. Use when running or interpreting Wax benchmarks, diagnosing CPU, memory, or I/O bottlenecks, or investigating Swift 6 concurrency issues such as Sendable, actor isolation, `@unchecked Sendable`, task-group fan-out, and data races.
 ---
 
 # Wax Performance Audit
@@ -9,7 +9,7 @@ description: Benchmarking and performance auditing for the Wax repo. Use when ru
 
 Use this skill to benchmark Wax changes, isolate the hottest code path, and separate real regressions from noisy samples.
 
-The repo builds with Swift 6.1 and `StrictConcurrency` enabled, so audit for Swift 6.2 concurrency risks without assuming 6.2-only language mode.
+The package uses `swift-tools-version: 6.1` with `StrictConcurrency` enabled. CI often builds with Swift 6.2 — audit for Swift 6 concurrency risks either way without assuming a 6.2-only language mode.
 
 ## Workflow
 
@@ -55,7 +55,7 @@ Prefer these repo entry points when they match the symptom:
 - Harness plumbing: `measureAsync` in `RAGBenchmarkSupport.swift` uses `DispatchSemaphore` plus `Task` because XCTest measurement is synchronous; do not confuse that with production concurrency.
 - ANE/GPU: CPU-only benchmark paths are intentional in some suites, and warm p95/p99 values can be noisy when `ANECompilerService` or similar background work is active.
 
-## Swift 6.2 Concurrency
+## Swift 6 Concurrency
 
 Use [`references/concurrency-checklist.md`](references/concurrency-checklist.md) when the change touches actors, task groups, `Sendable`, or `@unchecked Sendable`.
 

--- a/Resources/skills/public/wax-performance-audit/agents/openai.yaml
+++ b/Resources/skills/public/wax-performance-audit/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Wax Performance Audit"
   short_description: "Wax benchmarks, memory, concurrency"
-  default_prompt: "Use $wax-performance-audit to run Wax benchmarks and investigate CPU, memory, or Swift 6.2 concurrency bottlenecks."
+  default_prompt: "Use $wax-performance-audit to run Wax benchmarks and investigate CPU, memory, or Swift 6 concurrency bottlenecks."
 
 policy:
   allow_implicit_invocation: true

--- a/Resources/skills/public/wax-performance-audit/references/concurrency-checklist.md
+++ b/Resources/skills/public/wax-performance-audit/references/concurrency-checklist.md
@@ -1,6 +1,8 @@
 # Concurrency Checklist
 
-Use this guide when a change triggers Swift 6.2 warnings, actor-isolation failures, or suspicious parallelism.
+Use this guide when a change triggers Swift 6 concurrency warnings, actor-isolation failures, or suspicious parallelism.
+
+Wax packages with `swift-tools-version: 6.1` (`Package.swift`). CI commonly builds with Swift 6.2; treat Swift 6 concurrency rules as required either way.
 
 ## First Questions
 

--- a/Resources/skills/public/wax/SKILL.md
+++ b/Resources/skills/public/wax/SKILL.md
@@ -9,16 +9,17 @@ description: >
 # Wax (Swift Framework)
 
 ## Overview
-Use this skill to design and implement correct Wax-based on-device memory flows in Swift 6.2, emphasizing deterministic retrieval, single-file persistence, and safe concurrency.
+Use this skill to design and implement correct Wax-based on-device memory flows with Swift 6.1+ (`swift-tools-version: 6.1`; CI often builds with Swift 6.2), emphasizing deterministic retrieval, single-file persistence, and safe concurrency.
 
 If you need the agent memory operator playbook for MCP tools (`remember`, `recall`,
-`handoff`, `session_start`), use the `wax-mcp` skill instead of this one.
+`handoff`, `session_start`), use the `wax-mcp` skill instead of this one. That playbook’s
+source of truth is `Sources/WaxMCPServer/AgentInstructions.swift`.
 
 ## Choose The API Surface
 1. Use `Memory` (public actor) for all text memory and retrieval. It is the only supported entry point for apps.
 2. `MemoryOrchestrator`, `PhotoRAGOrchestrator`, `VideoRAGOrchestrator`, `Wax`, and `WaxSession` are **package-only internals** — downstream apps cannot import or construct them. Do not generate client code against them.
-3. Photo/video memory and structured memory (entities/facts) are exposed to agents through the Wax MCP server tools, not through `import Wax`.
-4. Import `Wax` to get the re-exported embedding protocols (`EmbeddingProvider`, `BatchEmbeddingProvider`, `EmbeddingIdentity`).
+3. Structured memory (entities/facts) is available to agents through Wax MCP tools (`entity_*`, `fact_*`). Photo/video pipelines are **package-only** today — there are no `photo_*` / `video_*` MCP tools. Swift apps store transcripts or photo-derived text via `Memory` until a public multimodal facade ships.
+4. Import `Wax` to get the re-exported embedding protocols (`EmbeddingProvider`, `BatchEmbeddingProvider`, `EmbeddingIdentity`). Apps select embedders through `Memory.Config.embedding` / `BuiltInEmbeddings` — do not construct `MiniLMEmbedder` from app code.
 
 ## Core Workflow
 1. Choose a `.wax` store URL.

--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -92,4 +92,8 @@ The following are `package`-access internals. They are used by Wax's own CLI/MCP
 - `WaxSession`, `Wax` actor, `SearchRequest`, `SearchResponse`, `FrameFilter`, structured-memory types (`EntityKey`, facts)
 - `MiniLMEmbedder` (use `BuiltInEmbeddings.make(.miniLM)` or `Memory.Config.embedding = .builtIn(.miniLM)` instead)
 
-Agent-facing access to structured memory, photo, and video memory is available through the Wax MCP server tools (`entity_upsert`, `fact_assert`, `facts_query`, `photo_*`, `video_*`), not through `import Wax`.
+Agent-facing structured memory is available through Wax MCP tools (`entity_upsert`,
+`fact_assert`, `facts_query`, `entity_resolve`, …), not through `import Wax`. Photo and
+video pipelines remain package-only; there are no `photo_*` / `video_*` MCP tools. Store
+transcripts or photo-derived text with MCP `remember` / `Memory.save` until a public
+multimodal surface exists. Canonical MCP tool list: `Sources/WaxMCPServer/ToolSchemas.swift`.

--- a/Resources/skills/public/wax/templates/video-rag-transcripts.md
+++ b/Resources/skills/public/wax/templates/video-rag-transcripts.md
@@ -5,11 +5,14 @@ The video RAG pipeline (`VideoRAGOrchestrator`, `VideoFile`, `VideoQuery`,
 `VideoTranscriptProvider`) is **package-only** in the current release: downstream Swift
 apps cannot import or construct it. Do not generate client code against it.
 
-Supported paths today:
-1. Agent workflows: use the Wax MCP server video tools (`video_*`), which run the
-   pipeline inside the Wax process. Host apps supply transcripts — Wax does not
-   transcribe in v1.
-2. Swift apps: store transcript text and metadata in `Memory` and search it with the
-   standard text/vector lanes.
+There are **no** Wax MCP `video_*` tools today (see `Sources/WaxMCPServer/ToolSchemas.swift`).
 
-A stable public video facade will be documented here when it ships.
+Supported path today:
+1. Host apps (or agents with transcript text) store transcript text and metadata in
+   `Memory` via `save` / MCP `remember`, then search with the standard text/vector lanes
+   (`Memory.search` or MCP `recall` / `search`). Wax does not transcribe in v1 — supply
+   transcripts yourself.
+2. Keep content concise and task-scoped; use metadata keys (for example `source=video`,
+   `asset_id`, timestamps) so later retrieval can filter or cite provenance.
+
+A stable public video facade and any MCP video tools will be documented here when they ship.

--- a/Resources/website/docs/mini-lm/mini-lm-embedder.md
+++ b/Resources/website/docs/mini-lm/mini-lm-embedder.md
@@ -1,147 +1,69 @@
 ---
 sidebar_position: 1
-title: "MiniLM Embedder"
-sidebar_label: "MiniLM Embedder"
+title: "MiniLM Embeddings"
+sidebar_label: "MiniLM Embeddings"
 ---
 
-Set up, configure, and optimize the on-device MiniLM embedding provider.
+:::warning App targets: use `Config.embedding` / `BuiltInEmbeddings`
+`MiniLMEmbedder` is **package-internal** (Swift `package` access). Downstream apps cannot construct `MiniLMEmbedder()`. Select the on-device MiniLM model through [`Memory.Config.embedding`](../ios/memory-api) or `BuiltInEmbeddings.make(.miniLM)`. This page documents the public app path first; package internals are noted for contributors.
+:::
 
-## Overview
+Set up and tune on-device MiniLM embeddings for Wax vector search.
 
-`MiniLMEmbedder` is an actor that implements both `EmbeddingProvider` and `BatchEmbeddingProvider`. It manages CoreML model loading, tokenization, and inference with automatic batch optimization.
+## App setup (public API)
 
-## Setup
-
-Create an embedder with default settings:
-
-```swift
-let embedder = try MiniLMEmbedder()
-```
-
-Or customize the batch size and CoreML configuration:
+On iOS 18 / macOS 15+ with the default `MiniLMEmbeddings` package trait, `Memory(at:)` wires MiniLM automatically via `Config.embedding = .automatic`:
 
 ```swift
-var config = MiniLMEmbedder.Config()
-config.batchSize = 128  // Default is 256
-
-let mlConfig = MLModelConfiguration()
-mlConfig.computeUnits = .cpuAndNeuralEngine
-
-config.modelConfiguration = mlConfig
-
-let embedder = try MiniLMEmbedder(config: config)
+let memory = try await Memory(at: storeURL)
 ```
 
-## Prewarming
-
-The first inference triggers JIT compilation of the CoreML model, which adds latency. Prewarm the model during app launch to avoid this:
+Force the built-in provider (throws if unavailable on this OS/build):
 
 ```swift
-try await embedder.prewarm(batchSize: 16)
+let memory = try await Memory(at: storeURL) { config in
+    config.embedding = .builtIn(.miniLM)
+}
 ```
 
-The batch size is clamped to 1...32 for prewarming.
-
-## Single vs. Batch Embedding
-
-For individual queries, use the single-text API:
+Or construct a provider and pass it as custom:
 
 ```swift
-let vector = try await embedder.embed("search query")
+let provider = try await BuiltInEmbeddings.make(.miniLM)
+let memory = try await Memory(at: storeURL) { config in
+    config.embedding = .custom(provider)
+}
 ```
 
-For bulk ingestion, batch embedding is significantly faster:
+Tune built-in construction with `BuiltInEmbeddingProviderOptions` (batch size, prewarm, compute-unit order, timeout):
 
 ```swift
-let texts = ["doc 1", "doc 2", /* ... thousands more ... */]
-let vectors = try await embedder.embed(batch: texts)
+var options = BuiltInEmbeddingProviderOptions.default
+options.batchSize = 128
+options.prewarmBatchSize = 16
+options.computeUnitsOrder = [.cpuAndNeuralEngine, .cpuOnly]
+
+let provider = try await BuiltInEmbeddings.make(.miniLM, options: options)
 ```
 
-### Batch Planning
+See [`Memory` API](../ios/memory-api) and `Sources/Wax/BuiltInEmbeddings.swift`.
 
-The embedder splits large batches into chunks based on the configured `batchSize` (default 256). Each chunk is processed as a single CoreML prediction with buffer reuse to minimize allocations.
+## What MiniLM provides
 
-For a batch of 1,000 texts with `batchSize = 256`:
-- 3 full batches of 256
-- 1 remainder batch of 232
-- Size-1 batches fall back to single-text inference
+The all-MiniLM-L6-v2 CoreML path implements `EmbeddingProvider` and `BatchEmbeddingProvider`: tokenization, inference, batch planning, and L2-normalized 384-d vectors. Apps reach that behavior only through `Config.embedding` / `BuiltInEmbeddings` — not by naming `MiniLMEmbedder`.
 
-## Tokenization
+## Contributor notes (package-only)
 
-Text is tokenized using the full BERT WordPiece pipeline:
+Inside the Wax package (CLI, MCP, tests), `MiniLMEmbedder` owns CoreML model loading and batch optimization. Do not generate app samples that call `MiniLMEmbedder()`.
 
-1. **Basic tokenization** — Whitespace/punctuation splitting, diacritic normalization, lowercasing
-2. **WordPiece tokenization** — Greedy longest-match subword splitting with `##` continuation prefix
-3. **Special token wrapping** — `[CLS]` prepended, `[SEP]` appended
-4. **Padding** — Zero-padded to the selected sequence length
+Characteristics useful when diagnosing contributor builds:
 
-### Sequence Length Optimization
+| Property | Value |
+|----------|-------|
+| Dimensions | 384 |
+| Normalization | L2 |
+| Max tokens | 512 (BERT limit) |
+| Default compute | `.cpuAndNeuralEngine` |
+| Output | Float16 → Float32 via Accelerate |
 
-Instead of always padding to 512 tokens, the tokenizer selects the smallest bucket that fits the longest text in each batch:
-
-| Bucket | Use Case |
-|--------|----------|
-| 32 | Short phrases |
-| 64 | Single sentences |
-| 128 | Short paragraphs |
-| 256 | Long paragraphs |
-| 384 | Multi-paragraph text |
-| 512 | Maximum (full BERT limit) |
-
-This reduces computation by 2-4x for typical inputs.
-
-## CoreML Integration
-
-### Compute Units
-
-The default compute unit configuration is `.cpuAndNeuralEngine`, which routes transformer attention operations to Apple's Neural Engine for optimal throughput. This is 1.5-2x faster than `.all` (which includes the GPU) because it avoids GPU dispatch overhead.
-
-### Diagnostics
-
-Check which compute hardware is being used:
-
-```swift
-let usesANE = try await embedder.isUsingANE()
-let units = try await embedder.currentComputeUnits()
-```
-
-### Model Output
-
-The CoreML model outputs Float16 embeddings, which are converted to Float32 using Accelerate's `vDSP.convertElements` (8-16x faster than scalar conversion). The vectors are L2-normalized before returning.
-
-## Performance Notes
-
-| Operation | Typical Latency |
-|-----------|----------------|
-| Single embed | ~50-100ms (ANE) |
-| Batch (256 texts) | ~2-4s (ANE) |
-| Prewarming | ~500ms-1s |
-| Model loading | ~200-500ms (cached after first load) |
-
-### Memory Profile
-
-| Component | Size |
-|-----------|------|
-| CoreML model | ~50 MiB |
-| Tokenizer vocab | ~200 KiB |
-| Batch buffers | ~1 MiB per 256-item batch |
-
-### Thread Safety
-
-`MiniLMEmbedder` is an actor, so all methods are safe to call concurrently from any context. The underlying CoreML model uses a thread-safe cache to prevent concurrent model loads (which can cause CoreML/Espresso deadlocks).
-
-## Embedding Identity
-
-The embedder reports its identity for provenance tracking:
-
-```swift
-embedder.identity
-// EmbeddingIdentity(
-//     provider: "Wax",
-//     model: "MiniLMAll",
-//     dimensions: 384,
-//     normalized: true
-// )
-```
-
-This identity is stored alongside vector indexes to detect embedding model changes between sessions.
+Sequence-length bucketing (32…512), batch splitting, and ANE diagnostics are package implementation details behind `BuiltInEmbeddings`.

--- a/Resources/website/docs/orchestrator/memory-orchestrator.md
+++ b/Resources/website/docs/orchestrator/memory-orchestrator.md
@@ -32,10 +32,11 @@ When you call `MemoryOrchestrator/remember(_:metadata:)`, the orchestrator:
 
 1. **Chunks** the text using the configured chunking strategy (default: token-count with 400 tokens and 40-token overlap)
 2. **Embeds** each chunk using the embedding provider (if provided), batching through `BatchEmbeddingProvider` when available
-3. **Writes** each chunk as a frame to the `.wax` file
+3. **Writes** each chunk as a frame to the `.wax` file's write-ahead log (WAL)
 4. **Indexes** each chunk's text in the FTS5 full-text search engine
-5. **Adds** each chunk's embedding to the vector search engine
-6. **Commits** all changes atomically
+5. **Adds** each chunk's embedding to the live vector search engine and the pending vector set
+
+Writes are **not** committed to the durable indexes on every `remember` call. Call `flush()` (or `close()`, which flushes) to commit the WAL, FTS index, and vector index atomically. In-process searches see pending vectors immediately; durability requires a commit. The public `Memory.save` / `Memory.flush` / `Memory.close` path mirrors this behavior.
 
 ### Batching
 
@@ -43,7 +44,7 @@ Ingestion respects two config parameters:
 
 | Parameter | Default | Purpose |
 |-----------|---------|---------|
-| `ingestBatchSize` | 32 | Chunks per commit batch |
+| `ingestBatchSize` | 32 | Chunks per ingest batch |
 | `ingestConcurrency` | 1 | Parallel embedding tasks |
 
 ### Embedding Cache

--- a/Resources/website/docs/orchestrator/memory-orchestrator.md
+++ b/Resources/website/docs/orchestrator/memory-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: "Memory Orchestrator"
+title: "Memory Orchestrator (internal)"
 sidebar_label: "Memory Orchestrator"
 ---
 

--- a/Resources/website/docs/orchestrator/rag-pipeline.md
+++ b/Resources/website/docs/orchestrator/rag-pipeline.md
@@ -1,14 +1,18 @@
 ---
 sidebar_position: 2
-title: "RAG Pipeline"
+title: "RAG Pipeline (internal)"
 sidebar_label: "RAG Pipeline"
 ---
 
-Understand the token-budget-aware context assembly with surrogate tiers and intent-aware reranking.
+:::warning App targets: use `Memory`
+`FastRAGContextBuilder`, `FastRAGConfig`, and the internal RAG assembly types are **package-internal**. Downstream apps should call [`Memory.search`](../ios/memory-api) (which returns a `RAGContext`). This page is contributor documentation for the assembly pipeline behind that facade.
+:::
+
+Understand the package-only token-budget-aware context assembly with surrogate tiers and intent-aware reranking.
 
 ## Overview
 
-The `FastRAGContextBuilder` assembles a `RAGContext` from search results within a configurable token budget. It uses a multi-stage pipeline: unified search, intent-aware reranking, expansion, surrogates, and snippets.
+The package-internal `FastRAGContextBuilder` assembles a `RAGContext` from search results within a configurable token budget. It uses a multi-stage pipeline: unified search, intent-aware reranking, expansion, surrogates, and snippets. App code does not construct these types — configure retrieval through `Memory.Config` / `Memory.SearchOptions` instead.
 
 ## Pipeline Stages
 
@@ -87,9 +91,9 @@ Remaining budget is filled with preview-based snippets from additional search re
 
 For certain query intents (location, date, ownership), snippets may be expanded to their full frame content if the preview appears to contain the answer.
 
-## Configuration
+## Configuration (package-internal)
 
-`FastRAGConfig` controls all pipeline parameters:
+`FastRAGConfig` controls pipeline parameters inside the Wax package (not a public app API):
 
 ```swift
 var config = FastRAGConfig()
@@ -141,3 +145,15 @@ public struct RAGContext {
 ```
 
 Each item has a `kind` (`.snippet`, `.expanded`, or `.surrogate`), the source `frameId`, a relevance `score`, and the assembled `text`.
+
+## Public Usage
+
+Apps receive assembled context through `Memory`:
+
+```swift
+let results = try await memory.search("quarterly roadmap")
+print(results.items.count)
+print(results.diagnostics?.effectiveMode as Any)
+```
+
+Do not construct `FastRAGContextBuilder` / `FastRAGConfig` from app targets.

--- a/Resources/website/docs/orchestrator/session-management.md
+++ b/Resources/website/docs/orchestrator/session-management.md
@@ -1,39 +1,45 @@
 ---
 sidebar_position: 4
-title: "Session Management"
+title: "Session Management (internal)"
 sidebar_label: "Session Management"
 ---
 
-Understand how public orchestrators manage persistence sessions.
+:::warning App targets: use `Memory`
+`WaxSession`, `MemoryOrchestrator`, `PhotoRAGOrchestrator`, and `VideoRAGOrchestrator` are **package-internal**. Downstream iOS/macOS apps cannot construct them. Use [`Memory`](../ios/memory-api) from `import Wax`. This page is contributor documentation for the code behind that facade.
+:::
+
+Understand how package-internal orchestrators manage persistence sessions.
 
 ## Overview
 
-`WaxSession` is a package-only implementation detail, not public API. Application code should use `MemoryOrchestrator` for text memory, `PhotoRAGOrchestrator` for photo RAG, or `VideoRAGOrchestrator` for video RAG.
+`WaxSession` is a package-only implementation detail, not public API. Application code should use `Memory`, which manages sessions internally.
 
-The orchestrators open, stage, commit, and close internal sessions as needed. They also coordinate writer access with the underlying WaxCore store so callers do not construct lower-level sessions directly.
+Package orchestrators open, stage, commit, and close internal sessions as needed. They also coordinate writer access with the underlying WaxCore store so callers do not construct lower-level sessions directly.
 
-## Public Lifecycle
+## App-facing lifecycle
 
-Create one orchestrator per store URL and close it when the store is no longer needed:
+Create one `Memory` per store URL and close it when the store is no longer needed:
 
 ```swift
-let memory = try await MemoryOrchestrator(at: storeURL)
-try await memory.remember("New content")
-let context = try await memory.recall(query: "content")
-_ = context.items
+let memory = try await Memory(at: storeURL)
+try await memory.save("New content")
+let results = try await memory.search("content")
+_ = results.items
 
 try await memory.close()
 ```
 
-Call `MemoryOrchestrator.flush()` when you need to force pending indexes and frame metadata to disk before process shutdown.
+Call `Memory.flush()` when you need to force pending indexes and frame metadata to disk before process shutdown. `close()` flushes automatically.
 
 ## Writer Behavior
 
-WaxCore allows multiple readers and one writer. Public orchestrators acquire and release writer access internally during write operations. If an application needs external coordination, serialize writes at the orchestrator boundary instead of constructing package-only session types.
+WaxCore allows multiple readers and one writer. `Memory` acquires and releases writer access internally during write operations. If an application needs external coordination, serialize writes at the `Memory` boundary instead of constructing package-only session types.
 
 ## Search Configuration
 
-Configure public search behavior through `OrchestratorConfig` and `FastRAGConfig`. For text-only usage, disable vector search. For semantic recall, provide an `EmbeddingProvider` and keep `OrchestratorConfig.enableVectorSearch` enabled.
+Configure search behavior through `Memory.Config`. For text-only usage, set `enableVectorSearch = false`. For semantic recall, keep `enableVectorSearch` enabled — the built-in MiniLM embedder is wired automatically on iOS 18/macOS 15+ (default `MiniLMEmbeddings` trait), or select a custom provider via `Memory.Config.embedding = .custom(...)` on `Memory(at:config:)` / `Memory(at:configure:)`.
+
+Use `Memory.stats()` and `RAGContext.diagnostics` to verify which retrieval lanes are actually active.
 
 ## Lower-Level Internals
 

--- a/Resources/website/docs/orchestrator/unified-search.md
+++ b/Resources/website/docs/orchestrator/unified-search.md
@@ -1,16 +1,20 @@
 ---
 sidebar_position: 3
-title: "Unified Search"
+title: "Unified Search (internal)"
 sidebar_label: "Unified Search"
 ---
+
+:::warning App targets: use `Memory`
+The unified search pipeline and `MemoryOrchestrator` are **package-internal**. Downstream apps should call [`Memory.search`](../ios/memory-api). This page is contributor documentation for the retrieval lanes behind that facade.
+:::
 
 Understand how Wax fuses BM25, vector, structured-memory, and timeline results.
 
 ## Overview
 
-Wax's unified search pipeline is a package-only implementation detail, not public API. Public callers should use orchestrator recall methods such as `MemoryOrchestrator.recall(query:)` and configure behavior through supported orchestrator entry points.
+Wax's unified search pipeline is a package-only implementation detail, not public API. Public callers should use `Memory.search(_:options:)` (or the configure overload) and configure behavior through `Memory.Config` / `Memory.SearchOptions`.
 
-Internally, the pipeline runs multiple retrieval lanes and combines their candidates with reciprocal rank fusion (RRF). This hybrid approach combines exact keyword matches with semantic and temporal recall while keeping the user-facing API focused on memory ingestion and recall.
+Internally, the pipeline runs multiple retrieval lanes and combines their candidates with reciprocal rank fusion (RRF). This hybrid approach combines exact keyword matches with semantic and temporal recall while keeping the user-facing API focused on memory ingestion and search.
 
 ## Search Lanes
 
@@ -29,7 +33,7 @@ The text lane runs an FTS5 MATCH query with BM25 scoring. If the primary query r
 
 ### Vector Lane
 
-The vector lane compares the query embedding with indexed frame embeddings. It is only active when the orchestrator has vector search enabled and an embedding provider is available.
+The vector lane compares the query embedding with indexed frame embeddings. It is only active when vector search is enabled and an embedding provider is available.
 
 ### Structured Memory Lane
 
@@ -70,13 +74,13 @@ Classification is fully offline. It does not call network services or external m
 
 ## Public Usage
 
-Use the memory orchestrator for supported recall:
+Use `Memory` for supported search:
 
 ```swift
-let context = try await memory.recall(query: "quarterly roadmap")
-for item in context.items {
+let results = try await memory.search("quarterly roadmap")
+for item in results.items {
     print(item.text)
 }
 ```
 
-The package-only request, response, filtering, and diagnostics types are intentionally omitted from the public documentation because downstream apps cannot construct or name them directly.
+The package-only request, response, filtering, and diagnostics types are intentionally omitted from the public documentation because downstream apps cannot construct or name them directly. Public callers see requested vs. effective mode via `RAGContext.diagnostics`.

--- a/Sources/Wax/Wax.docc/Articles/SessionManagement.md
+++ b/Sources/Wax/Wax.docc/Articles/SessionManagement.md
@@ -29,7 +29,7 @@ WaxCore allows multiple readers and one writer. ``Memory`` acquires and releases
 
 ## Search Configuration
 
-Configure search behavior through ``Memory/Config``. For text-only usage, set `enableVectorSearch = false`. For semantic recall, keep `enableVectorSearch` enabled — the built-in MiniLM embedder is wired automatically on iOS 18/macOS 15+ (default `MiniLMEmbeddings` trait), or pass a custom `EmbeddingProvider` to ``Memory/init(at:config:embedding:)``.
+Configure search behavior through ``Memory/Config``. For text-only usage, set `enableVectorSearch = false`. For semantic recall, keep `enableVectorSearch` enabled — the built-in MiniLM embedder is wired automatically on iOS 18/macOS 15+ (default `MiniLMEmbeddings` trait), or select a custom ``EmbeddingProvider`` via ``Memory/Config/embedding`` (``.custom``) on ``Memory/init(at:config:)`` / ``Memory/init(at:configure:)``.
 
 Use ``Memory/stats()`` and ``RAGContext/diagnostics`` to verify which retrieval lanes are actually active.
 

--- a/Sources/Wax/Wax.docc/Articles/SessionManagement.md
+++ b/Sources/Wax/Wax.docc/Articles/SessionManagement.md
@@ -8,7 +8,7 @@ Understand how Wax manages persistence sessions.
 
 The ``Memory`` actor opens, stages, commits, and closes internal sessions as needed. It also coordinates writer access with the underlying WaxCore store so callers do not construct lower-level sessions directly.
 
-## Public Lifecycle
+## App Lifecycle
 
 Create one ``Memory`` per store URL and close it when the store is no longer needed:
 

--- a/Sources/WaxVectorSearchMiniLM/WaxVectorSearchMiniLM.docc/Articles/MiniLMEmbedder.md
+++ b/Sources/WaxVectorSearchMiniLM/WaxVectorSearchMiniLM.docc/Articles/MiniLMEmbedder.md
@@ -1,143 +1,54 @@
-# MiniLM Embedder
+# MiniLM Embeddings
 
-Set up, configure, and optimize the on-device MiniLM embedding provider.
+Set up and tune on-device MiniLM embeddings for Wax vector search.
 
-## Overview
+## Status
 
-``MiniLMEmbedder`` is an actor that implements both `EmbeddingProvider` and `BatchEmbeddingProvider`. It manages CoreML model loading, tokenization, and inference with automatic batch optimization.
+``MiniLMEmbedder`` is package-only (`package` access). Application and downstream package consumers **cannot** construct it. Use ``Memory/Config/embedding`` or ``BuiltInEmbeddings`` instead (see <doc:GettingStarted>).
 
-## Setup
+This article documents the public app path first. Package-internal CoreML details are for Wax contributors.
 
-Create an embedder with default settings:
+## App setup (public API)
 
-```swift
-let embedder = try MiniLMEmbedder()
-```
-
-Or customize the batch size and CoreML configuration:
+On iOS 18 / macOS 15+ with the default `MiniLMEmbeddings` package trait, ``Memory`` wires MiniLM automatically via ``Memory/Config/embedding`` `.automatic`:
 
 ```swift
-var config = MiniLMEmbedder.Config()
-config.batchSize = 128  // Default is 256
-
-let mlConfig = MLModelConfiguration()
-mlConfig.computeUnits = .cpuAndNeuralEngine
-
-config.modelConfiguration = mlConfig
-
-let embedder = try MiniLMEmbedder(config: config)
+let memory = try await Memory(at: storeURL)
 ```
 
-## Prewarming
-
-The first inference triggers JIT compilation of the CoreML model, which adds latency. Prewarm the model during app launch to avoid this:
+Force the built-in provider (throws if unavailable):
 
 ```swift
-try await embedder.prewarm(batchSize: 16)
+let memory = try await Memory(at: storeURL) { config in
+    config.embedding = .builtIn(.miniLM)
+}
 ```
 
-The batch size is clamped to 1...32 for prewarming.
-
-## Single vs. Batch Embedding
-
-For individual queries, use the single-text API:
+Or construct via ``BuiltInEmbeddings``:
 
 ```swift
-let vector = try await embedder.embed("search query")
+let provider = try await BuiltInEmbeddings.make(.miniLM)
+let memory = try await Memory(at: storeURL) { config in
+    config.embedding = .custom(provider)
+}
 ```
 
-For bulk ingestion, batch embedding is significantly faster:
+Tune with ``BuiltInEmbeddingProviderOptions`` (batch size, prewarm, compute-unit order, timeout).
 
-```swift
-let texts = ["doc 1", "doc 2", /* ... thousands more ... */]
-let vectors = try await embedder.embed(batch: texts)
-```
+## What MiniLM provides
 
-### Batch Planning
+The all-MiniLM-L6-v2 CoreML path implements `EmbeddingProvider` and `BatchEmbeddingProvider`: tokenization, inference, batch planning, and L2-normalized 384-d vectors. Apps reach that behavior only through ``Memory/Config/embedding`` / ``BuiltInEmbeddings``.
 
-The embedder splits large batches into chunks based on the configured `batchSize` (default 256). Each chunk is processed as a single CoreML prediction with buffer reuse to minimize allocations.
+## Contributor notes (package-only)
 
-For a batch of 1,000 texts with `batchSize = 256`:
-- 3 full batches of 256
-- 1 remainder batch of 232
-- Size-1 batches fall back to single-text inference
+Inside the Wax package (CLI, MCP, tests), `MiniLMEmbedder` owns CoreML model loading and batch optimization. Do not publish app samples that call `MiniLMEmbedder()`.
 
-## Tokenization
+| Property | Value |
+|----------|-------|
+| Dimensions | 384 |
+| Normalization | L2 |
+| Max tokens | 512 (BERT limit) |
+| Default compute | `.cpuAndNeuralEngine` |
+| Output | Float16 → Float32 via Accelerate |
 
-Text is tokenized using the full BERT WordPiece pipeline:
-
-1. **Basic tokenization** — Whitespace/punctuation splitting, diacritic normalization, lowercasing
-2. **WordPiece tokenization** — Greedy longest-match subword splitting with `##` continuation prefix
-3. **Special token wrapping** — `[CLS]` prepended, `[SEP]` appended
-4. **Padding** — Zero-padded to the selected sequence length
-
-### Sequence Length Optimization
-
-Instead of always padding to 512 tokens, the tokenizer selects the smallest bucket that fits the longest text in each batch:
-
-| Bucket | Use Case |
-|--------|----------|
-| 32 | Short phrases |
-| 64 | Single sentences |
-| 128 | Short paragraphs |
-| 256 | Long paragraphs |
-| 384 | Multi-paragraph text |
-| 512 | Maximum (full BERT limit) |
-
-This reduces computation by 2-4x for typical inputs.
-
-## CoreML Integration
-
-### Compute Units
-
-The default compute unit configuration is `.cpuAndNeuralEngine`, which routes transformer attention operations to Apple's Neural Engine for optimal throughput. This is 1.5-2x faster than `.all` (which includes the GPU) because it avoids GPU dispatch overhead.
-
-### Diagnostics
-
-Check which compute hardware is being used:
-
-```swift
-let usesANE = try await embedder.isUsingANE()
-let units = try await embedder.currentComputeUnits()
-```
-
-### Model Output
-
-The CoreML model outputs Float16 embeddings, which are converted to Float32 using Accelerate's `vDSP.convertElements` (8-16x faster than scalar conversion). The vectors are L2-normalized before returning.
-
-## Performance Notes
-
-| Operation | Typical Latency |
-|-----------|----------------|
-| Single embed | ~50-100ms (ANE) |
-| Batch (256 texts) | ~2-4s (ANE) |
-| Prewarming | ~500ms-1s |
-| Model loading | ~200-500ms (cached after first load) |
-
-### Memory Profile
-
-| Component | Size |
-|-----------|------|
-| CoreML model | ~50 MiB |
-| Tokenizer vocab | ~200 KiB |
-| Batch buffers | ~1 MiB per 256-item batch |
-
-### Thread Safety
-
-``MiniLMEmbedder`` is an actor, so all methods are safe to call concurrently from any context. The underlying CoreML model uses a thread-safe cache to prevent concurrent model loads (which can cause CoreML/Espresso deadlocks).
-
-## Embedding Identity
-
-The embedder reports its identity for provenance tracking:
-
-```swift
-embedder.identity
-// EmbeddingIdentity(
-//     provider: "Wax",
-//     model: "MiniLMAll",
-//     dimensions: 384,
-//     normalized: true
-// )
-```
-
-This identity is stored alongside vector indexes to detect embedding model changes between sessions.
+Sequence-length bucketing, batch splitting, and ANE diagnostics remain package implementation details behind ``BuiltInEmbeddings``.

--- a/Sources/WaxVectorSearchMiniLM/WaxVectorSearchMiniLM.docc/Documentation.md
+++ b/Sources/WaxVectorSearchMiniLM/WaxVectorSearchMiniLM.docc/Documentation.md
@@ -4,26 +4,22 @@ On-device sentence embeddings via CoreML with the all-MiniLM-L6-v2 transformer m
 
 ## Overview
 
-WaxVectorSearchMiniLM provides a production-ready `EmbeddingProvider` that runs entirely on-device using Apple's Neural Engine. It produces 384-dimensional, L2-normalized embeddings optimized for semantic similarity search.
-
-The module wraps the [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) sentence transformer as a compiled CoreML model with a full BERT WordPiece tokenizer.
+WaxVectorSearchMiniLM provides the package-internal CoreML MiniLM stack used by Wax’s built-in embeddings. Application code should **not** import this module or construct ``MiniLMEmbedder``. Use the public Wax facade instead:
 
 ```swift
-import WaxVectorSearchMiniLM
+import Wax
 
-let embedder = try MiniLMEmbedder()
+// Automatic MiniLM on iOS 18/macOS 15+ (default MiniLMEmbeddings trait)
+let memory = try await Memory(at: storeURL)
 
-// Single embedding
-let vector = try await embedder.embed("What is Swift concurrency?")
-// vector.count == 384
-
-// Batch embedding (much faster for bulk ingestion)
-let vectors = try await embedder.embed(batch: [
-    "First document",
-    "Second document",
-    "Third document"
-])
+// Or force / customize via Config.embedding / BuiltInEmbeddings
+let memoryForced = try await Memory(at: storeURL) { config in
+    config.embedding = .builtIn(.miniLM)
+}
+let provider = try await BuiltInEmbeddings.make(.miniLM)
 ```
+
+The module wraps the [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) sentence transformer as a compiled CoreML model with a full BERT WordPiece tokenizer. It produces 384-dimensional, L2-normalized embeddings optimized for semantic similarity search.
 
 ### Key Characteristics
 
@@ -35,6 +31,7 @@ let vectors = try await embedder.embed(batch: [
 | Compute | Neural Engine + CPU (default) |
 | Quantization | Float16 output, converted to Float32 |
 | Execution mode | On-device only (no network) |
+| App access | Via ``Memory/Config/embedding`` / ``BuiltInEmbeddings`` only |
 
 This module is conditionally compiled via the `MiniLMEmbeddings` package trait, which is enabled by default.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase 1 deslop: docs/skills truth — remove ghost `photo_*`/`video_*` MCP claims, fix orchestrator/MiniLM samples, playbook fan-out, personal paths, broken links.
- Addresses #91 (part of #97).
- Adversarial review: **PASS** (follow-up fixes on branch tip `ae42aaed`).

## Test plan
- [ ] Spot-check ToolSchemas vs skills for no photo_/video_ claims
- [ ] App-facing docs use Memory / Config.embedding
- [ ] No `/Users/chriskarani` paths in setup docs
- [ ] Root AGENTS.md unchanged as memory playbook

## Residual risks
- Package-only APIs still shown under internal banners
- Playbook SoT is documented alignment, not codegen
- `search` wire default deferred to Phase 4 (#94)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a009ae-b3ae-7e50-b0a1-970b0c49f4fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a009ae-b3ae-7e50-b0a1-970b0c49f4fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

