### PR TITLE
[deslop] Phase 3 — Unify wax.embedding.* vs memvid.embedding.* keys

### DIFF
--- a/Sources/Wax/VectorSearchSession.swift
+++ b/Sources/Wax/VectorSearchSession.swift
@@ -71,10 +71,13 @@ package actor WaxVectorSearchSession {
                 throw WaxError.invalidEmbedding(reason: "dimension mismatch: expected \(expectedDims), got \(embedding.count)")
             }
             var metadata = merged.metadata ?? Metadata()
-            if let provider = identity.provider { metadata.entries["memvid.embedding.provider"] = provider }
-            if let model = identity.model { metadata.entries["memvid.embedding.model"] = model }
-            if let dims = identity.dimensions { metadata.entries["memvid.embedding.dimension"] = String(dims) }
-            if let normalized = identity.normalized { metadata.entries["memvid.embedding.normalized"] = String(normalized) }
+            EmbeddingIdentityMetadata.write(
+                into: &metadata.entries,
+                provider: identity.provider,
+                model: identity.model,
+                dimensions: identity.dimensions,
+                normalized: identity.normalized
+            )
             merged.metadata = metadata
         }
 
@@ -113,10 +116,13 @@ package actor WaxVectorSearchSession {
                     throw WaxError.invalidEmbedding(reason: "dimension mismatch: expected \(expectedDims), got \(embeddings[index].count)")
                 }
                 var metadata = mergedOptions[index].metadata ?? Metadata()
-                if let provider = identity.provider { metadata.entries["memvid.embedding.provider"] = provider }
-                if let model = identity.model { metadata.entries["memvid.embedding.model"] = model }
-                if let dims = identity.dimensions { metadata.entries["memvid.embedding.dimension"] = String(dims) }
-                if let normalized = identity.normalized { metadata.entries["memvid.embedding.normalized"] = String(normalized) }
+                EmbeddingIdentityMetadata.write(
+                    into: &metadata.entries,
+                    provider: identity.provider,
+                    model: identity.model,
+                    dimensions: identity.dimensions,
+                    normalized: identity.normalized
+                )
                 mergedOptions[index].metadata = metadata
             }
         }

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -583,10 +583,13 @@ package actor WaxSession {
 
         var merged = options
         var metadata = merged.metadata ?? Metadata()
-        if let provider = identity.provider { metadata.entries["wax.embedding.provider"] = provider }
-        if let model = identity.model { metadata.entries["wax.embedding.model"] = model }
-        if let dims = identity.dimensions { metadata.entries["wax.embedding.dimension"] = String(dims) }
-        if let normalized = identity.normalized { metadata.entries["wax.embedding.normalized"] = String(normalized) }
+        EmbeddingIdentityMetadata.write(
+            into: &metadata.entries,
+            provider: identity.provider,
+            model: identity.model,
+            dimensions: identity.dimensions,
+            normalized: identity.normalized
+        )
         merged.metadata = metadata
         return merged
     }

--- a/Sources/WaxCore/EmbeddingIdentityMetadata.swift
+++ b/Sources/WaxCore/EmbeddingIdentityMetadata.swift
@@ -23,6 +23,13 @@ package enum EmbeddingIdentityMetadata {
         dimensions: Int?,
         normalized: Bool?
     ) {
+        // Canonical writes must not leave conflicting legacy keys behind when
+        // callers merge identity onto metadata that already carried memvid.*.
+        entries.removeValue(forKey: legacyProviderKey)
+        entries.removeValue(forKey: legacyModelKey)
+        entries.removeValue(forKey: legacyDimensionKey)
+        entries.removeValue(forKey: legacyNormalizedKey)
+
         if let provider {
             entries[providerKey] = provider
         }

--- a/Sources/WaxCore/EmbeddingIdentityMetadata.swift
+++ b/Sources/WaxCore/EmbeddingIdentityMetadata.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Canonical embedding-identity metadata keys written onto frames.
+///
+/// Writers always persist ``wax.embedding.*``. Readers dual-read legacy
+/// ``memvid.embedding.*`` so stores written by older ``WaxVectorSearchSession``
+/// paths remain compatible with remember-dedup without rewriting existing data.
+package enum EmbeddingIdentityMetadata {
+    package static let providerKey = "wax.embedding.provider"
+    package static let modelKey = "wax.embedding.model"
+    package static let dimensionKey = "wax.embedding.dimension"
+    package static let normalizedKey = "wax.embedding.normalized"
+
+    package static let legacyProviderKey = "memvid.embedding.provider"
+    package static let legacyModelKey = "memvid.embedding.model"
+    package static let legacyDimensionKey = "memvid.embedding.dimension"
+    package static let legacyNormalizedKey = "memvid.embedding.normalized"
+
+    package static func write(
+        into entries: inout [String: String],
+        provider: String?,
+        model: String?,
+        dimensions: Int?,
+        normalized: Bool?
+    ) {
+        if let provider {
+            entries[providerKey] = provider
+        }
+        if let model {
+            entries[modelKey] = model
+        }
+        if let dimensions {
+            entries[dimensionKey] = String(dimensions)
+        }
+        if let normalized {
+            entries[normalizedKey] = String(normalized)
+        }
+    }
+
+    package static func provider(from entries: [String: String]) -> String? {
+        entries[providerKey] ?? entries[legacyProviderKey]
+    }
+
+    package static func model(from entries: [String: String]) -> String? {
+        entries[modelKey] ?? entries[legacyModelKey]
+    }
+
+    package static func dimension(from entries: [String: String]) -> String? {
+        entries[dimensionKey] ?? entries[legacyDimensionKey]
+    }
+
+    package static func normalized(from entries: [String: String]) -> String? {
+        entries[normalizedKey] ?? entries[legacyNormalizedKey]
+    }
+}

--- a/Sources/WaxCore/Wax.swift
+++ b/Sources/WaxCore/Wax.swift
@@ -106,17 +106,20 @@ package struct RememberDedupEmbeddingIdentity: Equatable, Sendable {
         self.normalized = normalized
     }
 
-    fileprivate func matches(metadataEntries: [String: String]) -> Bool {
-        if let provider, metadataEntries["wax.embedding.provider"] != provider {
+    /// Returns true when metadata carries a compatible embedding identity.
+    /// Canonical ``wax.embedding.*`` keys win; legacy ``memvid.embedding.*`` is
+    /// accepted when the canonical keys are absent.
+    package func matches(metadataEntries: [String: String]) -> Bool {
+        if let provider, EmbeddingIdentityMetadata.provider(from: metadataEntries) != provider {
             return false
         }
-        if let model, metadataEntries["wax.embedding.model"] != model {
+        if let model, EmbeddingIdentityMetadata.model(from: metadataEntries) != model {
             return false
         }
-        if let dimensions, metadataEntries["wax.embedding.dimension"] != String(dimensions) {
+        if let dimensions, EmbeddingIdentityMetadata.dimension(from: metadataEntries) != String(dimensions) {
             return false
         }
-        if let normalized, metadataEntries["wax.embedding.normalized"] != String(normalized) {
+        if let normalized, EmbeddingIdentityMetadata.normalized(from: metadataEntries) != String(normalized) {
             return false
         }
         return true

--- a/Tests/WaxCoreTests/EmbeddingIdentityMetadataTests.swift
+++ b/Tests/WaxCoreTests/EmbeddingIdentityMetadataTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import WaxCore
+
+@Test func embeddingIdentityMetadataWritesCanonicalWaxKeysOnly() {
+    var entries: [String: String] = [:]
+    EmbeddingIdentityMetadata.write(
+        into: &entries,
+        provider: "Wax",
+        model: "MiniLM",
+        dimensions: 384,
+        normalized: true
+    )
+
+    #expect(entries[EmbeddingIdentityMetadata.providerKey] == "Wax")
+    #expect(entries[EmbeddingIdentityMetadata.modelKey] == "MiniLM")
+    #expect(entries[EmbeddingIdentityMetadata.dimensionKey] == "384")
+    #expect(entries[EmbeddingIdentityMetadata.normalizedKey] == "true")
+    #expect(entries[EmbeddingIdentityMetadata.legacyProviderKey] == nil)
+    #expect(entries[EmbeddingIdentityMetadata.legacyModelKey] == nil)
+    #expect(entries[EmbeddingIdentityMetadata.legacyDimensionKey] == nil)
+    #expect(entries[EmbeddingIdentityMetadata.legacyNormalizedKey] == nil)
+}
+
+@Test func rememberDedupEmbeddingIdentityMatchesCanonicalWaxKeys() {
+    let identity = RememberDedupEmbeddingIdentity(
+        provider: "Wax",
+        model: "MiniLM",
+        dimensions: 384,
+        normalized: true
+    )
+    let entries = [
+        EmbeddingIdentityMetadata.providerKey: "Wax",
+        EmbeddingIdentityMetadata.modelKey: "MiniLM",
+        EmbeddingIdentityMetadata.dimensionKey: "384",
+        EmbeddingIdentityMetadata.normalizedKey: "true",
+    ]
+    #expect(identity.matches(metadataEntries: entries))
+}
+
+@Test func rememberDedupEmbeddingIdentityMatchesLegacyMemvidKeys() {
+    let identity = RememberDedupEmbeddingIdentity(
+        provider: "Wax",
+        model: "MiniLM",
+        dimensions: 384,
+        normalized: true
+    )
+    let entries = [
+        EmbeddingIdentityMetadata.legacyProviderKey: "Wax",
+        EmbeddingIdentityMetadata.legacyModelKey: "MiniLM",
+        EmbeddingIdentityMetadata.legacyDimensionKey: "384",
+        EmbeddingIdentityMetadata.legacyNormalizedKey: "true",
+    ]
+    #expect(identity.matches(metadataEntries: entries))
+}
+
+@Test func rememberDedupEmbeddingIdentityPrefersCanonicalOverLegacyMismatch() {
+    let identity = RememberDedupEmbeddingIdentity(provider: "Wax", model: "MiniLM")
+    let entries = [
+        EmbeddingIdentityMetadata.providerKey: "Wax",
+        EmbeddingIdentityMetadata.modelKey: "MiniLM",
+        EmbeddingIdentityMetadata.legacyProviderKey: "Other",
+        EmbeddingIdentityMetadata.legacyModelKey: "OtherModel",
+    ]
+    #expect(identity.matches(metadataEntries: entries))
+}
+
+@Test func rememberDedupEmbeddingIdentityRejectsMismatchOnEitherNamespace() {
+    let identity = RememberDedupEmbeddingIdentity(provider: "Wax", model: "MiniLM")
+    #expect(!identity.matches(metadataEntries: [
+        EmbeddingIdentityMetadata.providerKey: "Other",
+        EmbeddingIdentityMetadata.modelKey: "MiniLM",
+    ]))
+    #expect(!identity.matches(metadataEntries: [
+        EmbeddingIdentityMetadata.legacyProviderKey: "Other",
+        EmbeddingIdentityMetadata.legacyModelKey: "MiniLM",
+    ]))
+}

--- a/Tests/WaxCoreTests/EmbeddingIdentityMetadataTests.swift
+++ b/Tests/WaxCoreTests/EmbeddingIdentityMetadataTests.swift
@@ -3,7 +3,12 @@ import Testing
 @testable import WaxCore
 
 @Test func embeddingIdentityMetadataWritesCanonicalWaxKeysOnly() {
-    var entries: [String: String] = [:]
+    var entries: [String: String] = [
+        EmbeddingIdentityMetadata.legacyProviderKey: "Stale",
+        EmbeddingIdentityMetadata.legacyModelKey: "StaleModel",
+        EmbeddingIdentityMetadata.legacyDimensionKey: "1",
+        EmbeddingIdentityMetadata.legacyNormalizedKey: "false",
+    ]
     EmbeddingIdentityMetadata.write(
         into: &entries,
         provider: "Wax",

--- a/Tests/WaxIntegrationTests/DeduplicationTests.swift
+++ b/Tests/WaxIntegrationTests/DeduplicationTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-import Wax
+@testable import Wax
 import WaxCore
 
 @Test func rememberIdenticalContentTwiceIsIdempotent() async throws {
@@ -207,6 +207,190 @@ import WaxCore
 
         #expect(probe != nil)
         #expect(probe?.isComplete == false)
+        try await wax.close()
+    }
+}
+
+@Test func embeddingIdentityMetadataRoundTripsThroughWaxAndVectorSessions() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let identity = EmbeddingIdentity(
+            provider: "Wax",
+            model: "MiniLM",
+            dimensions: 2,
+            normalized: true
+        )
+
+        var sessionConfig = WaxSession.Config()
+        sessionConfig.enableTextSearch = false
+        sessionConfig.enableStructuredMemory = false
+        sessionConfig.enableVectorSearch = true
+        sessionConfig.vectorDimensions = 2
+        sessionConfig.vectorEnginePreference = .cpuOnly
+
+        let session = try await wax.openSession(.readWrite(.fail), config: sessionConfig)
+        let waxFrameId = try await session.put(
+            Data("wax-session-identity".utf8),
+            embedding: [1.0, 0.0],
+            identity: identity
+        )
+        try await session.commit()
+        await session.close()
+
+        let vector = try await wax.enableVectorSearch(dimensions: 2, preference: .cpuOnly)
+        let vectorFrameId = try await vector.putWithEmbedding(
+            Data("vector-session-identity".utf8),
+            embedding: [0.0, 1.0],
+            identity: identity
+        )
+        try await vector.commit()
+
+        let metas = await wax.frameMetasIncludingPending(frameIds: [waxFrameId, vectorFrameId])
+        let waxEntries = try #require(metas[waxFrameId]?.metadata?.entries)
+        let vectorEntries = try #require(metas[vectorFrameId]?.metadata?.entries)
+
+        for entries in [waxEntries, vectorEntries] {
+            #expect(entries[EmbeddingIdentityMetadata.providerKey] == "Wax")
+            #expect(entries[EmbeddingIdentityMetadata.modelKey] == "MiniLM")
+            #expect(entries[EmbeddingIdentityMetadata.dimensionKey] == "2")
+            #expect(entries[EmbeddingIdentityMetadata.normalizedKey] == "true")
+            #expect(entries[EmbeddingIdentityMetadata.legacyProviderKey] == nil)
+            #expect(entries[EmbeddingIdentityMetadata.legacyModelKey] == nil)
+            #expect(entries[EmbeddingIdentityMetadata.legacyDimensionKey] == nil)
+            #expect(entries[EmbeddingIdentityMetadata.legacyNormalizedKey] == nil)
+        }
+
+        try await wax.close()
+    }
+}
+
+@Test func rememberDedupProbeHonorsEmbeddingIdentityAcrossCanonicalAndLegacyKeys() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let content = "embedding identity dedup"
+        let docHash = ContentHasher.hash(Data(content.utf8)).hexString
+        let identity = RememberDedupEmbeddingIdentity(
+            provider: "Wax",
+            model: "MiniLM",
+            dimensions: 2,
+            normalized: true
+        )
+
+        let canonicalDocId = try await wax.put(
+            Data(content.utf8),
+            options: FrameMetaSubset(
+                role: .document,
+                metadata: Metadata([
+                    "scope": "canonical",
+                    "wax.content.hash": docHash,
+                ])
+            )
+        )
+        _ = try await wax.put(
+            Data("chunk-canonical".utf8),
+            options: FrameMetaSubset(
+                role: .chunk,
+                parentId: canonicalDocId,
+                chunkIndex: 0,
+                chunkCount: 1,
+                metadata: Metadata([
+                    EmbeddingIdentityMetadata.providerKey: "Wax",
+                    EmbeddingIdentityMetadata.modelKey: "MiniLM",
+                    EmbeddingIdentityMetadata.dimensionKey: "2",
+                    EmbeddingIdentityMetadata.normalizedKey: "true",
+                ])
+            )
+        )
+
+        let legacyDocId = try await wax.put(
+            Data(content.utf8),
+            options: FrameMetaSubset(
+                role: .document,
+                metadata: Metadata([
+                    "scope": "legacy",
+                    "wax.content.hash": docHash,
+                ])
+            )
+        )
+        _ = try await wax.put(
+            Data("chunk-legacy".utf8),
+            options: FrameMetaSubset(
+                role: .chunk,
+                parentId: legacyDocId,
+                chunkIndex: 0,
+                chunkCount: 1,
+                metadata: Metadata([
+                    EmbeddingIdentityMetadata.legacyProviderKey: "Wax",
+                    EmbeddingIdentityMetadata.legacyModelKey: "MiniLM",
+                    EmbeddingIdentityMetadata.legacyDimensionKey: "2",
+                    EmbeddingIdentityMetadata.legacyNormalizedKey: "true",
+                ])
+            )
+        )
+
+        let mismatchedDocId = try await wax.put(
+            Data(content.utf8),
+            options: FrameMetaSubset(
+                role: .document,
+                metadata: Metadata([
+                    "scope": "mismatch",
+                    "wax.content.hash": docHash,
+                ])
+            )
+        )
+        _ = try await wax.put(
+            Data("chunk-mismatch".utf8),
+            options: FrameMetaSubset(
+                role: .chunk,
+                parentId: mismatchedDocId,
+                chunkIndex: 0,
+                chunkCount: 1,
+                metadata: Metadata([
+                    EmbeddingIdentityMetadata.providerKey: "Other",
+                    EmbeddingIdentityMetadata.modelKey: "OtherModel",
+                    EmbeddingIdentityMetadata.dimensionKey: "2",
+                    EmbeddingIdentityMetadata.normalizedKey: "true",
+                ])
+            )
+        )
+        try await wax.commit()
+
+        let canonicalProbe = await wax.rememberDedupProbe(
+            contentHash: docHash,
+            metadata: [
+                "scope": "canonical",
+                "wax.content.hash": docHash,
+            ],
+            expectedChunkCount: 1,
+            embeddingIdentity: identity
+        )
+        #expect(canonicalProbe?.documentId == canonicalDocId)
+        #expect(canonicalProbe?.isComplete == true)
+
+        let legacyProbe = await wax.rememberDedupProbe(
+            contentHash: docHash,
+            metadata: [
+                "scope": "legacy",
+                "wax.content.hash": docHash,
+            ],
+            expectedChunkCount: 1,
+            embeddingIdentity: identity
+        )
+        #expect(legacyProbe?.documentId == legacyDocId)
+        #expect(legacyProbe?.isComplete == true)
+
+        let mismatchedProbe = await wax.rememberDedupProbe(
+            contentHash: docHash,
+            metadata: [
+                "scope": "mismatch",
+                "wax.content.hash": docHash,
+            ],
+            expectedChunkCount: 1,
+            embeddingIdentity: identity
+        )
+        #expect(mismatchedProbe?.documentId == mismatchedDocId)
+        #expect(mismatchedProbe?.isComplete == false)
+
         try await wax.close()
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase 3 deslop: unify embedding identity metadata to `wax.embedding.*` writes with dual-read of legacy `memvid.embedding.*`.
- Addresses #93 (part of #97).
- Adversarial review: **PASS** (branch tip `7aa27a87`; strip-on-write hardening for legacy keys).

## Test plan
- [x] `swift test --filter 'EmbeddingIdentityMetadata|embeddingIdentityMetadataRoundTrips|rememberDedupProbeHonorsEmbeddingIdentity'` (7/7)
- [ ] Confirm no remaining `memvid.embedding.*` writes
- [ ] Dedup still rejects identity mismatches

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a009ae-b3ae-7e50-b0a1-970b0c49f4fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a009ae-b3ae-7e50-b0a1-970b0c49f4fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

