### PR TITLE
[deslop] Phase 5 — Deduplicate Photo/Video/search helpers

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -2273,6 +2273,9 @@ extension AgentBrokerService {
         let summary: AgentBrokerValue
     }
 
+    // Intentionally not shared with WaxMCPTools.compatParseSearchFilters:
+    // BrokerArguments / BrokerValidationError / AgentBrokerValue diverge from the
+    // MCP Compat* types, and MCP injects session_id into metadata filters.
     func parseSearchFilters(_ args: BrokerArguments) throws -> ParsedSearchFilters {
         let sessionID = try parseOptionalSessionID(args)
         let filters = try args.optionalObject("filters")

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -923,7 +923,7 @@ package actor MemoryOrchestrator {
             var item = item
             let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[item.frameId]).reasons
             if !accessReasons.isEmpty {
-                item.explanations = dedupedExplanations(item.explanations + accessReasons)
+                item.explanations = SearchExplanationDeduper.dedupedExplanations(item.explanations + accessReasons)
             }
             return item
         }
@@ -1023,7 +1023,7 @@ package actor MemoryOrchestrator {
                 previewText: result.previewText,
                 sources: result.sources,
                 metadata: result.metadata,
-                explanations: dedupedExplanations(result.explanations + accessReasons)
+                explanations: SearchExplanationDeduper.dedupedExplanations(result.explanations + accessReasons)
             )
         }
         await recordAccessesIfEnabled(frameIds: hits.map(\.frameId))
@@ -1058,18 +1058,6 @@ package actor MemoryOrchestrator {
 
     package func accessStatsSnapshot() async -> [UInt64: FrameAccessStats] {
         await accessStatsManager.snapshot()
-    }
-
-    private func dedupedExplanations(_ reasons: [String]) -> [String] {
-        var seen = Set<String>()
-        var ordered: [String] = []
-        ordered.reserveCapacity(reasons.count)
-        for reason in reasons {
-            let normalized = reason.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
-            ordered.append(normalized)
-        }
-        return ordered
     }
 
     package func sessionRuntimeStats() async throws -> SessionRuntimeStats {

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -275,7 +275,7 @@ package actor PhotoRAGOrchestrator {
             }
         }()
 
-        let timeRange = Self.toWaxTimeRange(query.timeRange)
+        let timeRange = SearchTimeRange.fromClosedDateRange(query.timeRange)
 
         let locationAllowlist = query.location.flatMap { buildLocationAllowlist(location: $0) }
         let assetAllowlist = buildAssetAllowlist(assetIDs: query.filters.assetIDs)
@@ -367,7 +367,6 @@ package actor PhotoRAGOrchestrator {
                 candidates[rootId] = entry
             }
 
-            // Build summary text for the top candidates, then apply budgets.
             let sorted = candidates.values.sorted { a, b in
                 if a.score != b.score { return a.score > b.score }
                 return a.rootId < b.rootId
@@ -381,7 +380,6 @@ package actor PhotoRAGOrchestrator {
         }
         let rootIdsPicked = picked.map(\.rootId)
 
-        // Resolve asset IDs and derived frame refs.
         var assetIdByRoot: [UInt64: String] = [:]
         assetIdByRoot.reserveCapacity(rootIdsPicked.count)
         for rootId in rootIdsPicked {
@@ -396,7 +394,6 @@ package actor PhotoRAGOrchestrator {
             }
         }
 
-        // Load derived texts in a single batch.
         var derivedFrameIds: [UInt64] = []
         derivedFrameIds.reserveCapacity(rootIdsPicked.count * 3)
         for rootId in rootIdsPicked {
@@ -447,7 +444,6 @@ package actor PhotoRAGOrchestrator {
             )
         }
 
-        // Apply text budget.
         let perItemCap = max(1, query.contextBudget.maxTextTokens / max(1, items.count))
         let processed = await tokenCounter.countAndTruncateBatch(items.map(\.summaryText), maxTokens: perItemCap)
         assert(processed.count == items.count, "countAndTruncateBatch must return exactly one result per input")
@@ -464,7 +460,7 @@ package actor PhotoRAGOrchestrator {
             budgetedItems.append(updated)
         }
 
-        // Optionally attach thumbnails and region crops (offline-only, Photos-backed).
+        // Offline-only, Photos-backed thumbnails / region crops.
         let itemsWithPixels = try await attachPixels(
             items: budgetedItems,
             rootCandidates: picked,
@@ -576,7 +572,6 @@ package actor PhotoRAGOrchestrator {
         let previousRoot = index.rootByAssetID[assetID]
 
         if !isLocal {
-            // Metadata-only ingest
             let options = FrameMetaSubset(
                 kind: FrameKind.root,
                 metadata: baseMeta
@@ -614,7 +609,6 @@ package actor PhotoRAGOrchestrator {
         let embedImage = try Self.decodeThumbnail(from: imageData, maxPixelSize: config.embedMaxPixelSize)
         let ocrImage = try Self.decodeThumbnail(from: imageData, maxPixelSize: config.ocrMaxPixelSize)
 
-        // Global embedding
         var globalEmbedding = try await embedder.embed(image: embedImage)
         if embedder.normalize, !globalEmbedding.isEmpty {
             globalEmbedding = VectorMath.normalizeL2(globalEmbedding)
@@ -623,7 +617,6 @@ package actor PhotoRAGOrchestrator {
             throw WaxError.invalidEmbedding(reason: "embedder produced \(globalEmbedding.count) dims for image, expected \(embedder.dimensions)")
         }
 
-        // Root frame
         let rootOptions = FrameMetaSubset(
             kind: FrameKind.root,
             metadata: baseMeta
@@ -638,13 +631,11 @@ package actor PhotoRAGOrchestrator {
             timestampMs: frameTimestampMs
         )
 
-        // OCR
         var ocrBlocks: [RecognizedTextBlock] = []
         if config.enableOCR, let ocr = ocr ?? Self.defaultOCRProvider() {
             ocrBlocks = try await ocr.recognizeText(in: ocrImage)
         }
 
-        // Caption
         let captionText: String?
         if let captioner {
             do {
@@ -663,7 +654,7 @@ package actor PhotoRAGOrchestrator {
 
         let derivedTagsText = Self.buildPhotoTags(from: metadata, captionText: captionText)
 
-        // Derived frames to write (non-embedded)
+        // Derived frames (non-embedded payloads + optional text index).
         var derivedContents: [Data] = []
         var derivedOptions: [FrameMetaSubset] = []
         var derivedTextsForIndex: [(frameIndex: Int, text: String)] = []
@@ -689,13 +680,11 @@ package actor PhotoRAGOrchestrator {
 
         // OCR block frames (not indexed) + one summary frame (indexed)
         if !ocrBlocks.isEmpty {
-            // Summary
             let summary = Self.buildOCRSummary(ocrBlocks, maxLines: config.maxOCRSummaryLines)
             if !summary.isEmpty {
                 addDerived(kind: FrameKind.ocrSummary, text: summary, searchable: true)
             }
 
-            // Blocks
             for block in ocrBlocks.prefix(config.maxOCRBlocksPerPhoto) {
                 var meta = baseMeta
                 Self.writeBBox(into: &meta, rect: block.bbox)
@@ -718,7 +707,6 @@ package actor PhotoRAGOrchestrator {
             timestampsMs: Array(repeating: frameTimestampMs, count: derivedContents.count)
         )
 
-        // Index searchable derived frames.
         if !derivedTextsForIndex.isEmpty {
             var frameIds: [UInt64] = []
             var texts: [String] = []
@@ -731,11 +719,9 @@ package actor PhotoRAGOrchestrator {
             try await session.indexTextBatch(frameIds: frameIds, texts: texts)
         }
 
-        // Regions (OCR-driven and/or grid)
         if config.enableRegionEmbeddings, config.maxRegionsPerPhoto > 0 {
             let regions = Self.proposeRegions(from: ocrBlocks, maxRegions: config.maxRegionsPerPhoto)
             if !regions.isEmpty {
-                // Collect all crops first
                 var crops: [(index: Int, crop: CGImage, region: ProposedRegion)] = []
                 crops.reserveCapacity(regions.count)
                 for region in regions {
@@ -744,7 +730,7 @@ package actor PhotoRAGOrchestrator {
                 }
 
                 if !crops.isEmpty {
-                    // Embed in parallel with bounded concurrency (4 concurrent tasks)
+                    // Bounded concurrent region embeds (see regionEmbeddingConcurrency).
                     var regionEmbeddings: [[Float]] = []
                     var regionContents: [Data] = []
                     var regionOptions: [FrameMetaSubset] = []
@@ -757,7 +743,6 @@ package actor PhotoRAGOrchestrator {
                         let maxConcurrency = self.config.regionEmbeddingConcurrency
                         var cropIterator = crops.makeIterator()
 
-                        // Start initial batch
                         while activeCount < maxConcurrency, let item = cropIterator.next() {
                             let (index, crop, _) = item
                             group.addTask {
@@ -773,7 +758,6 @@ package actor PhotoRAGOrchestrator {
                             activeCount += 1
                         }
 
-                        // Collect results and spawn new tasks
                         var results: [(Int, [Float])] = []
                         results.reserveCapacity(crops.count)
                         for try await result in group {
@@ -793,10 +777,9 @@ package actor PhotoRAGOrchestrator {
                             }
                         }
 
-                        // Sort results by index to maintain deterministic ordering
+                        // Deterministic region write order.
                         results.sort { $0.0 < $1.0 }
 
-                        // Build final arrays in correct order
                         for (index, vec) in results {
                             let (_, _, region) = crops[index]
                             regionEmbeddings.append(vec)
@@ -1159,26 +1142,7 @@ package actor PhotoRAGOrchestrator {
         }
 
         index = next
-        await sweepRetiredVectors(retiredVectorIds)
-    }
-
-    /// Removes vectors for frames outside the live index (superseded trees, deleted
-    /// frames). Stores written before vector cleanup existed can otherwise keep serving
-    /// ghost hits for retired frames. Best-effort: a sweep failure must not block
-    /// opening or reindexing the store.
-    private func sweepRetiredVectors(_ frameIds: Set<UInt64>) async {
-        guard !frameIds.isEmpty else { return }
-        for frameId in frameIds {
-            do {
-                try await session.removeVector(frameId: frameId)
-            } catch {
-                WaxDiagnostics.logSwallowed(
-                    error,
-                    context: "PhotoRAG retired-vector sweep",
-                    fallback: "stale vector may remain in the committed index"
-                )
-            }
-        }
+        await session.sweepRetiredVectors(retiredVectorIds, context: "PhotoRAG retired-vector sweep")
     }
 
     private static func isSearchablePhotoKind(_ kind: String) -> Bool {
@@ -1407,7 +1371,6 @@ package actor PhotoRAGOrchestrator {
 
         var updated = items
 
-        // Thumbnails for the first N items.
         let thumbCount = min(maxImages, updated.count)
         if config.includeThumbnailsInContext, thumbCount > 0 {
             for index in 0..<thumbCount {
@@ -1418,7 +1381,7 @@ package actor PhotoRAGOrchestrator {
             }
         }
 
-        // Region crops: take the highest-scoring matched regions first.
+        // Highest-scoring matched regions first.
         if config.includeRegionCropsInContext, maxRegions > 0 {
             var remaining = maxRegions
             for index in 0..<updated.count where remaining > 0 {
@@ -1675,22 +1638,6 @@ package actor PhotoRAGOrchestrator {
               let h = Double(entries[MetaKey.bboxH] ?? "")
         else { return nil }
         return PhotoNormalizedRect(x: x, y: y, width: w, height: h)
-    }
-
-    private static func toWaxTimeRange(_ range: ClosedRange<Date>?) -> SearchTimeRange? {
-        guard let range else { return nil }
-        let after = Int64(range.lowerBound.timeIntervalSince1970 * 1000)
-        let beforeInclusive = Int64(range.upperBound.timeIntervalSince1970 * 1000)
-        
-        // Handle unbounded ranges (e.g., Date...Date.distantFuture)
-        // Check for very large dates that represent "no upper bound"
-        let beforeExclusive: Int64
-        if beforeInclusive > Int64.max - 1 {
-            beforeExclusive = Int64.max
-        } else {
-            beforeExclusive = beforeInclusive + 1
-        }
-        return SearchTimeRange(after: after, before: beforeExclusive)
     }
 
     private static func buildSummaryText(

--- a/Sources/Wax/StoreLockProbe.swift
+++ b/Sources/Wax/StoreLockProbe.swift
@@ -20,19 +20,10 @@ package enum StoreLockProbe {
             return error
         }
 
-        let timeoutLabel = timeout.map(formatDuration(_:)) ?? "the configured timeout"
+        let timeoutLabel = timeout.map(DurationFormatting.format(_:)) ?? "the configured timeout"
         return WaxError.lockUnavailable(
             "\(details). Wax \(operation) failed fast after \(timeoutLabel) because another process is already using \(url.path). " +
                 "Use a unique --store-path per client or agent, or stop the existing Wax process before retrying."
         )
-    }
-
-    private static func formatDuration(_ duration: Duration) -> String {
-        let components = duration.components
-        let seconds = Double(components.seconds) + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
-        if seconds == 0 {
-            return "0s"
-        }
-        return String(format: "%.2fs", seconds)
     }
 }

--- a/Sources/Wax/UnifiedSearch/SearchRequest.swift
+++ b/Sources/Wax/UnifiedSearch/SearchRequest.swift
@@ -108,6 +108,18 @@ package struct SearchTimeRange: Sendable, Equatable {
         if let before, timestamp >= before { return false }
         return true
     }
+
+    /// Converts an inclusive `Date` closed range into a `SearchTimeRange`.
+    ///
+    /// Upper bounds that saturate `Int64` (ms since epoch) become `before: nil`
+    /// (unbounded) instead of an `Int64.max` exclusive sentinel.
+    package static func fromClosedDateRange(_ range: ClosedRange<Date>?) -> SearchTimeRange? {
+        guard let range else { return nil }
+        let after = Int64(range.lowerBound.timeIntervalSince1970 * 1000)
+        let beforeInclusive = Int64(range.upperBound.timeIntervalSince1970 * 1000)
+        let beforeExclusive: Int64? = beforeInclusive == Int64.max ? nil : beforeInclusive + 1
+        return SearchTimeRange(after: after, before: beforeExclusive)
+    }
 }
 
 /// Frame filter predicate.

--- a/Sources/Wax/UnifiedSearch/SearchRequest.swift
+++ b/Sources/Wax/UnifiedSearch/SearchRequest.swift
@@ -111,12 +111,22 @@ package struct SearchTimeRange: Sendable, Equatable {
 
     /// Converts an inclusive `Date` closed range into a `SearchTimeRange`.
     ///
-    /// Upper bounds that saturate `Int64` (ms since epoch) become `before: nil`
-    /// (unbounded) instead of an `Int64.max` exclusive sentinel.
+    /// Ordinary dates (including `Date.distantFuture`) keep a finite exclusive
+    /// `before`. Only an inclusive upper bound that already equals `Int64.max`
+    /// becomes `before: nil` (unbounded) instead of the old exclusive
+    /// `Int64.max` sentinel, which excluded `timestamp == Int64.max`.
     package static func fromClosedDateRange(_ range: ClosedRange<Date>?) -> SearchTimeRange? {
         guard let range else { return nil }
         let after = Int64(range.lowerBound.timeIntervalSince1970 * 1000)
         let beforeInclusive = Int64(range.upperBound.timeIntervalSince1970 * 1000)
+        return fromClosedMillisecondBounds(after: after, beforeInclusive: beforeInclusive)
+    }
+
+    /// Millisecond form of ``fromClosedDateRange(_:)`` (testable saturation path).
+    static func fromClosedMillisecondBounds(
+        after: Int64,
+        beforeInclusive: Int64
+    ) -> SearchTimeRange {
         let beforeExclusive: Int64? = beforeInclusive == Int64.max ? nil : beforeInclusive + 1
         return SearchTimeRange(after: after, before: beforeExclusive)
     }

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -616,7 +616,7 @@ extension Wax {
             guard semantic.adjustment > -9.5 else { return nil }
             var updated = result
             if !semantic.reasons.isEmpty {
-                updated.explanations = dedupedExplanations(result.explanations + semantic.reasons)
+                updated.explanations = SearchExplanationDeduper.dedupedExplanations(result.explanations + semantic.reasons)
             }
             return (index: index, composite: result.score + semantic.adjustment, adjustment: semantic.adjustment, result: updated)
         }
@@ -687,19 +687,7 @@ extension Wax {
             nowMs: nowMs
         )
         reasons.append(contentsOf: semantic.reasons)
-        return dedupedExplanations(reasons)
-    }
-
-    private static func dedupedExplanations(_ reasons: [String]) -> [String] {
-        var seen = Set<String>()
-        var ordered: [String] = []
-        ordered.reserveCapacity(reasons.count)
-        for reason in reasons {
-            let normalized = reason.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
-            ordered.append(normalized)
-        }
-        return ordered
+        return SearchExplanationDeduper.dedupedExplanations(reasons)
     }
 
     private static func orExpandedQuery(from query: String, maxTokens: Int = 16) -> String? {
@@ -1117,8 +1105,6 @@ extension Wax {
             || text.contains("pending approval")
     }
 
-    // containsTentativeLaunchLanguage → RerankingHelpers (shared with FastRAGContextBuilder)
-
     private static let movedToLocationRegex = try? NSRegularExpression(
         pattern: #"\b(?:moved|move)\s+to\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?\b"#
     )
@@ -1128,8 +1114,6 @@ extension Wax {
         let range = NSRange(location: 0, length: text.utf16.count)
         return regex.firstMatch(in: text, range: range) != nil
     }
-
-    // containsDateLiteral → use analyzer.containsDateLiteral() directly (avoids throwaway QueryAnalyzer)
 
     private static func isDigitsOnly(_ text: String) -> Bool {
         !text.isEmpty && text.unicodeScalars.allSatisfy { CharacterSet.decimalDigits.contains($0) }

--- a/Sources/Wax/Utilities/SearchExplanationDeduper.swift
+++ b/Sources/Wax/Utilities/SearchExplanationDeduper.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Shared explanation-list dedupe for search/orchestrator result assembly.
+enum SearchExplanationDeduper {
+    static func dedupedExplanations(_ reasons: [String]) -> [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        ordered.reserveCapacity(reasons.count)
+        for reason in reasons {
+            let normalized = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
+            ordered.append(normalized)
+        }
+        return ordered
+    }
+}

--- a/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
+++ b/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
@@ -224,7 +224,7 @@ package actor VideoRAGOrchestrator {
             }
         }()
 
-        let timeRange = Self.toWaxTimeRange(query.timeRange)
+        let timeRange = SearchTimeRange.fromClosedDateRange(query.timeRange)
 
         let frameFilter: FrameFilter? = {
             // Constraint-only queries use timeline fallback; filter to roots to avoid returning all segment frames.
@@ -392,7 +392,6 @@ package actor VideoRAGOrchestrator {
         let picked = Array(sorted.prefix(query.resultLimit))
         let rootIdsPicked = picked.map(\.rootId)
 
-        // Parse root -> videoID.
         func videoID(from rootMeta: FrameMeta) -> VideoID? {
             guard let entries = rootMeta.metadata?.entries else { return nil }
             guard let source = entries[MetaKey.source],
@@ -402,7 +401,6 @@ package actor VideoRAGOrchestrator {
             return VideoID(source: src, id: sourceID)
         }
 
-        // Load segment transcripts for selected segments (batch).
         var selectedSegmentFrameIds: [UInt64] = []
         selectedSegmentFrameIds.reserveCapacity(picked.count * max(1, query.segmentLimitPerVideo))
         for root in picked {
@@ -478,7 +476,7 @@ package actor VideoRAGOrchestrator {
             )
         }
 
-        // Apply text budget deterministically.
+        // Text budget is applied deterministically (stable order, first-fit).
         let counter = try await TokenCounter.shared()
         let perItemCap = max(1, query.contextBudget.maxTextTokens / max(1, items.count))
         let processed = await counter.countAndTruncateBatch(items.map(\.summaryText), maxTokens: perItemCap)
@@ -584,7 +582,6 @@ package actor VideoRAGOrchestrator {
         let rootOptions = FrameMetaSubset(kind: FrameKind.root, metadata: rootMeta)
         let rootId = try await session.put(Data(), options: rootOptions, compression: .plain, timestampMs: captureMs)
 
-        // Segment frames (embedded + optional transcript payload)
         try await writeSegments(
             rootId: rootId,
             videoID: videoID,
@@ -741,7 +738,6 @@ package actor VideoRAGOrchestrator {
             allFrameIds.append(contentsOf: batchFrameIds)
         }
 
-        // Index segments that have transcript text.
         var textFrameIds: [UInt64] = []
         var texts: [String] = []
         textFrameIds.reserveCapacity(allFrameIds.count)
@@ -817,26 +813,7 @@ package actor VideoRAGOrchestrator {
         }
 
         index = next
-        await sweepRetiredVectors(retiredVectorIds)
-    }
-
-    /// Removes vectors for frames outside the live index (superseded trees, deleted
-    /// frames). Stores written before vector cleanup existed can otherwise keep serving
-    /// ghost hits for retired frames. Best-effort: a sweep failure must not block
-    /// opening or reindexing the store.
-    private func sweepRetiredVectors(_ frameIds: Set<UInt64>) async {
-        guard !frameIds.isEmpty else { return }
-        for frameId in frameIds {
-            do {
-                try await session.removeVector(frameId: frameId)
-            } catch {
-                WaxDiagnostics.logSwallowed(
-                    error,
-                    context: "VideoRAG retired-vector sweep",
-                    fallback: "stale vector may remain in the committed index"
-                )
-            }
-        }
+        await session.sweepRetiredVectors(retiredVectorIds, context: "VideoRAG retired-vector sweep")
     }
 
     private func isDegraded(videoID: VideoID) -> Bool {
@@ -1020,7 +997,6 @@ package actor VideoRAGOrchestrator {
                   let url = URL(string: fileURLString)
             else { continue }
 
-            // Attach thumbnails to the first N segments, in existing order.
             for segIndex in updated[itemIndex].segments.indices where remaining > 0 {
                 let startMs = updated[itemIndex].segments[segIndex].startMs
                 let endMs = updated[itemIndex].segments[segIndex].endMs
@@ -1118,22 +1094,6 @@ package actor VideoRAGOrchestrator {
             unique.append(file)
         }
         return unique
-    }
-
-    private static func toWaxTimeRange(_ range: ClosedRange<Date>?) -> SearchTimeRange? {
-        guard let range else { return nil }
-        let after = Int64(range.lowerBound.timeIntervalSince1970 * 1000)
-        let beforeInclusive = Int64(range.upperBound.timeIntervalSince1970 * 1000)
-        
-        // Handle unbounded ranges (e.g., Date...Date.distantFuture)
-        // Check for very large dates that represent "no upper bound"
-        let beforeExclusive: Int64
-        if beforeInclusive > Int64.max - 1 {
-            beforeExclusive = Int64.max
-        } else {
-            beforeExclusive = beforeInclusive + 1
-        }
-        return SearchTimeRange(after: after, before: beforeExclusive)
     }
 
     private static func makeSegments(

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -197,6 +197,25 @@ package actor WaxSession {
         try await concreteVectorEngine.remove(frameId: frameId)
     }
 
+    /// Removes vectors for frames outside the live index (superseded trees, deleted
+    /// frames). Stores written before vector cleanup existed can otherwise keep serving
+    /// ghost hits for retired frames. Best-effort: a sweep failure must not block
+    /// opening or reindexing the store.
+    package func sweepRetiredVectors(_ frameIds: Set<UInt64>, context: StaticString) async {
+        guard !frameIds.isEmpty else { return }
+        for frameId in frameIds {
+            do {
+                try await removeVector(frameId: frameId)
+            } catch {
+                WaxDiagnostics.logSwallowed(
+                    error,
+                    context: context,
+                    fallback: "stale vector may remain in the committed index"
+                )
+            }
+        }
+    }
+
     // MARK: - Structured Memory
 
     package func upsertEntity(
@@ -352,29 +371,14 @@ package actor WaxSession {
         options: [FrameMetaSubset],
         compression: CanonicalEncoding = .plain
     ) async throws -> [UInt64] {
-        try ensureWritable()
-        guard contents.count == embeddings.count else {
-            throw WaxError.encodingError(reason: "putBatch: contents.count != embeddings.count")
-        }
-        guard contents.count == options.count else {
-            throw WaxError.encodingError(reason: "putBatch: contents.count != options.count")
-        }
-        var mergedOptions = options
-        if let identity {
-            for (index, embedding) in embeddings.enumerated() {
-                mergedOptions[index] = try mergeOptions(
-                    mergedOptions[index],
-                    identity: identity,
-                    embeddingCount: embedding.count
-                )
-            }
-        }
-        let frameIds = try await wax.putBatch(contents, options: mergedOptions, compression: compression)
-        guard frameIds.count == embeddings.count else {
-            throw WaxError.encodingError(reason: "putBatch: embeddings.count != frameIds.count")
-        }
-        try await wax.putEmbeddingBatch(frameIds: frameIds, vectors: embeddings)
-        return frameIds
+        try await putBatchWithOptionalTimestamps(
+            contents: contents,
+            embeddings: embeddings,
+            identity: identity,
+            options: options,
+            timestampsMs: nil,
+            compression: compression
+        )
     }
 
     package func putBatch(
@@ -385,6 +389,24 @@ package actor WaxSession {
         timestampsMs: [Int64],
         compression: CanonicalEncoding = .plain
     ) async throws -> [UInt64] {
+        try await putBatchWithOptionalTimestamps(
+            contents: contents,
+            embeddings: embeddings,
+            identity: identity,
+            options: options,
+            timestampsMs: timestampsMs,
+            compression: compression
+        )
+    }
+
+    private func putBatchWithOptionalTimestamps(
+        contents: [Data],
+        embeddings: [[Float]],
+        identity: EmbeddingIdentity?,
+        options: [FrameMetaSubset],
+        timestampsMs: [Int64]?,
+        compression: CanonicalEncoding
+    ) async throws -> [UInt64] {
         try ensureWritable()
         guard contents.count == embeddings.count else {
             throw WaxError.encodingError(reason: "putBatch: contents.count != embeddings.count")
@@ -392,8 +414,10 @@ package actor WaxSession {
         guard contents.count == options.count else {
             throw WaxError.encodingError(reason: "putBatch: contents.count != options.count")
         }
-        guard contents.count == timestampsMs.count else {
-            throw WaxError.encodingError(reason: "putBatch: contents.count != timestampsMs.count")
+        if let timestampsMs {
+            guard contents.count == timestampsMs.count else {
+                throw WaxError.encodingError(reason: "putBatch: contents.count != timestampsMs.count")
+            }
         }
 
         var mergedOptions = options
@@ -406,7 +430,17 @@ package actor WaxSession {
                 )
             }
         }
-        let frameIds = try await wax.putBatch(contents, options: mergedOptions, compression: compression, timestampsMs: timestampsMs)
+        let frameIds: [UInt64]
+        if let timestampsMs {
+            frameIds = try await wax.putBatch(
+                contents,
+                options: mergedOptions,
+                compression: compression,
+                timestampsMs: timestampsMs
+            )
+        } else {
+            frameIds = try await wax.putBatch(contents, options: mergedOptions, compression: compression)
+        }
         guard frameIds.count == embeddings.count else {
             throw WaxError.encodingError(reason: "putBatch: embeddings.count != frameIds.count")
         }

--- a/Sources/WaxCore/IO/DurationFormatting.swift
+++ b/Sources/WaxCore/IO/DurationFormatting.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Shared human-readable formatting for lock-timeout labels.
+package enum DurationFormatting {
+    package static func format(_ duration: Duration) -> String {
+        let components = duration.components
+        let seconds = Double(components.seconds) + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
+        if seconds == 0 {
+            return "0s"
+        }
+        return String(format: "%.2fs", seconds)
+    }
+}

--- a/Sources/WaxCore/IO/FileLock.swift
+++ b/Sources/WaxCore/IO/FileLock.swift
@@ -207,17 +207,8 @@ package final class FileLock {
         case .exclusive: "exclusive"
         }
         let target = url?.path ?? "<unknown>"
-        let timeoutLabel = timeout.map(formatDuration(_:)) ?? "the configured timeout"
+        let timeoutLabel = timeout.map(DurationFormatting.format(_:)) ?? "the configured timeout"
         return "timed out waiting for \(modeLabel) lock on \(target) after \(timeoutLabel)"
-    }
-
-    private static func formatDuration(_ duration: Duration) -> String {
-        let components = duration.components
-        let seconds = Double(components.seconds) + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
-        if seconds == 0 {
-            return "0s"
-        }
-        return String(format: "%.2fs", seconds)
     }
 
     private func ensureActive() throws {

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -700,6 +700,9 @@ private extension WaxMCPTools {
         ]
     }
 
+    // Intentionally not shared with AgentBrokerService.parseSearchFilters:
+    // CompatArguments / ToolValidationError diverge from broker types, and this
+    // path injects session_id into metadata filters for MCP session scoping.
     static func compatParseSearchFilters(_ args: CompatArguments) throws -> CompatParsedFilters {
         let sessionID = try compatParseSessionID(args)
         let filters = try args.optionalObject("filters")

--- a/Tests/WaxCoreTests/DurationFormattingTests.swift
+++ b/Tests/WaxCoreTests/DurationFormattingTests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Testing
+import WaxCore
+
+@Test func durationFormattingZeroIsExactLabel() {
+    #expect(DurationFormatting.format(.zero) == "0s")
+}
+
+@Test func durationFormattingUsesFixedFractionalSeconds() {
+    #expect(DurationFormatting.format(.milliseconds(1500)) == "1.50s")
+    #expect(DurationFormatting.format(.milliseconds(10)) == "0.01s")
+}

--- a/Tests/WaxIntegrationTests/SearchTimeRangeClosedDateRangeTests.swift
+++ b/Tests/WaxIntegrationTests/SearchTimeRangeClosedDateRangeTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test func fromClosedDateRangeNilPassthrough() {
+    #expect(SearchTimeRange.fromClosedDateRange(nil) == nil)
+}
+
+@Test func fromClosedDateRangeConvertsInclusiveBoundsToExclusiveBefore() {
+    let start = Date(timeIntervalSince1970: 1_700_000_000)
+    let end = Date(timeIntervalSince1970: 1_700_000_100)
+    let range = try #require(SearchTimeRange.fromClosedDateRange(start...end))
+
+    #expect(range.after == 1_700_000_000_000)
+    #expect(range.before == 1_700_000_100_000 + 1)
+    #expect(range.contains(1_700_000_000_000))
+    #expect(range.contains(1_700_000_100_000))
+    #expect(!range.contains(1_700_000_100_000 + 1))
+}
+
+@Test func fromClosedDateRangeDistantFutureKeepsFiniteExclusiveBefore() {
+    let start = Date(timeIntervalSince1970: 0)
+    let range = try #require(SearchTimeRange.fromClosedDateRange(start...Date.distantFuture))
+    let beforeInclusive = Int64(Date.distantFuture.timeIntervalSince1970 * 1000)
+
+    #expect(range.after == 0)
+    #expect(beforeInclusive < Int64.max)
+    #expect(range.before == beforeInclusive + 1)
+}
+
+@Test func fromClosedMillisecondBoundsSaturatedUpperBoundIsUnbounded() {
+    let range = SearchTimeRange.fromClosedMillisecondBounds(
+        after: 1_700_000_000_000,
+        beforeInclusive: Int64.max
+    )
+    #expect(range.before == nil)
+    #expect(range.contains(Int64.max))
+    // Old Int64.max exclusive sentinel excluded the saturated timestamp itself.
+    #expect(SearchTimeRange(after: 0, before: Int64.max).contains(Int64.max) == false)
+}

--- a/Tests/WaxIntegrationTests/SearchTimeRangeClosedDateRangeTests.swift
+++ b/Tests/WaxIntegrationTests/SearchTimeRangeClosedDateRangeTests.swift
@@ -6,7 +6,7 @@ import Testing
     #expect(SearchTimeRange.fromClosedDateRange(nil) == nil)
 }
 
-@Test func fromClosedDateRangeConvertsInclusiveBoundsToExclusiveBefore() {
+@Test func fromClosedDateRangeConvertsInclusiveBoundsToExclusiveBefore() throws {
     let start = Date(timeIntervalSince1970: 1_700_000_000)
     let end = Date(timeIntervalSince1970: 1_700_000_100)
     let range = try #require(SearchTimeRange.fromClosedDateRange(start...end))
@@ -18,7 +18,7 @@ import Testing
     #expect(!range.contains(1_700_000_100_000 + 1))
 }
 
-@Test func fromClosedDateRangeDistantFutureKeepsFiniteExclusiveBefore() {
+@Test func fromClosedDateRangeDistantFutureKeepsFiniteExclusiveBefore() throws {
     let start = Date(timeIntervalSince1970: 0)
     let range = try #require(SearchTimeRange.fromClosedDateRange(start...Date.distantFuture))
     let beforeInclusive = Int64(Date.distantFuture.timeIntervalSince1970 * 1000)

--- a/Tests/WaxIntegrationTests/SearchTimeRangeClosedDateRangeTests.swift
+++ b/Tests/WaxIntegrationTests/SearchTimeRangeClosedDateRangeTests.swift
@@ -12,7 +12,7 @@ import Testing
     let range = try #require(SearchTimeRange.fromClosedDateRange(start...end))
 
     #expect(range.after == 1_700_000_000_000)
-    #expect(range.before == 1_700_000_100_000 + 1)
+    #expect(range.before == Optional(1_700_000_100_000 + 1))
     #expect(range.contains(1_700_000_000_000))
     #expect(range.contains(1_700_000_100_000))
     #expect(!range.contains(1_700_000_100_000 + 1))
@@ -25,7 +25,7 @@ import Testing
 
     #expect(range.after == 0)
     #expect(beforeInclusive < Int64.max)
-    #expect(range.before == beforeInclusive + 1)
+    #expect(range.before == Optional(beforeInclusive + 1))
 }
 
 @Test func fromClosedMillisecondBoundsSaturatedUpperBoundIsUnbounded() {

--- a/Tests/WaxTests/Phase5DedupeSurfaceTests.swift
+++ b/Tests/WaxTests/Phase5DedupeSurfaceTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+/// Source-level locks that Phase 5 shared helpers replaced private clones.
+@Test func phase5SharedHelpersHaveNoPrivateClones() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    let photo = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift"),
+        encoding: .utf8
+    )
+    let video = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift"),
+        encoding: .utf8
+    )
+    let memory = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Orchestrator/MemoryOrchestrator.swift"),
+        encoding: .utf8
+    )
+    let unified = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/UnifiedSearch/UnifiedSearch.swift"),
+        encoding: .utf8
+    )
+    let session = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/WaxSession.swift"),
+        encoding: .utf8
+    )
+    let fileLock = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/WaxCore/IO/FileLock.swift"),
+        encoding: .utf8
+    )
+    let storeProbe = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/StoreLockProbe.swift"),
+        encoding: .utf8
+    )
+    let searchRequest = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/UnifiedSearch/SearchRequest.swift"),
+        encoding: .utf8
+    )
+
+    #expect(searchRequest.contains("fromClosedDateRange"))
+    #expect(photo.contains("SearchTimeRange.fromClosedDateRange"))
+    #expect(video.contains("SearchTimeRange.fromClosedDateRange"))
+    #expect(!photo.contains("private static func toWaxTimeRange"))
+    #expect(!video.contains("private static func toWaxTimeRange"))
+
+    #expect(session.contains("func sweepRetiredVectors"))
+    #expect(photo.contains("session.sweepRetiredVectors"))
+    #expect(video.contains("session.sweepRetiredVectors"))
+    #expect(!photo.contains("private func sweepRetiredVectors"))
+    #expect(!video.contains("private func sweepRetiredVectors"))
+
+    #expect(memory.contains("SearchExplanationDeduper.dedupedExplanations"))
+    #expect(unified.contains("SearchExplanationDeduper.dedupedExplanations"))
+    #expect(!memory.contains("private func dedupedExplanations"))
+    #expect(!unified.contains("private static func dedupedExplanations"))
+
+    #expect(fileLock.contains("DurationFormatting.format"))
+    #expect(storeProbe.contains("DurationFormatting.format"))
+    #expect(!fileLock.contains("private static func formatDuration"))
+    #expect(!storeProbe.contains("private static func formatDuration"))
+
+    #expect(session.contains("putBatchWithOptionalTimestamps"))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase 5 deslop: extract shared Photo/Video/search helpers; collapse WaxSession putBatch near-copies.
- Addresses #95 (part of #97).
- Adversarial review: **PASS** (branch tip `5c4d2320`; added shared-helper tests + clone guards).

## Shared
- `SearchTimeRange.fromClosedDateRange` / `fromClosedMillisecondBounds`
- `WaxSession.sweepRetiredVectors`
- `SearchExplanationDeduper`
- `DurationFormatting` (WaxCore)
- `putBatchWithOptionalTimestamps`

## Intentionally not shared
- Broker ↔ MCP filter parse (divergent enums/errors/`session_id` injection)

## Test plan
- [ ] `swift test --filter 'UnifiedSearch|PhotoRAG|VideoRAG|MemoryOrchestrator|WaxSession|FileLock|StoreLock|TimestampOverride|SearchTimeRange|DurationFormatting|Phase5'` (macOS)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a009ae-b3ae-7e50-b0a1-970b0c49f4fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a009ae-b3ae-7e50-b0a1-970b0c49f4fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

