### PR TITLE
fix(search): keep hybrid from burying exact lexical canaries

### DIFF
--- a/Sources/Wax/UnifiedSearch/HybridSearch.swift
+++ b/Sources/Wax/UnifiedSearch/HybridSearch.swift
@@ -9,7 +9,8 @@ package enum HybridSearch {
         textResults: [(UInt64, Float)],
         vectorResults: [(UInt64, Float)],
         k: Int = 60,
-        alpha: Float = 0.5
+        alpha: Float = 0.5,
+        applyFloor: Bool = false
     ) -> [(UInt64, Float)] {
         let clampedAlpha = min(1, max(0, alpha))
         var merged = rrfFusion(
@@ -23,34 +24,49 @@ package enum HybridSearch {
             merged: &merged,
             textFrameIds: textResults.map(\.0),
             vectorFrameIds: vectorResults.map(\.0),
-            alpha: clampedAlpha
+            applyFloor: applyFloor
         )
         return merged
     }
 
-    /// Default hybrid (alpha >= 0.5): exclusive text rank-1 cannot lose to an
+    /// Factual identifier queries: exclusive text rank-1 cannot lose to an
     /// exclusive vector-only neighbor. Ranking order only; score scale unchanged
     /// except a `nextUp` bump so later score-sorts keep the same order.
+    /// Semantic / exploratory callers must pass `applyFloor: false`.
     package static func applyExclusiveTextRank1Floor(
         merged: inout [(UInt64, Float)],
         textFrameIds: [UInt64],
         vectorFrameIds: [UInt64],
-        alpha: Float
+        applyFloor: Bool
     ) {
-        let clampedAlpha = min(1, max(0, alpha))
-        guard clampedAlpha >= 0.5,
-              let textTop = textFrameIds.first,
+        guard applyFloor,
+              let lift = exclusiveTextRank1FloorIndices(
+                  mergedFrameIds: merged.map(\.0),
+                  textFrameIds: textFrameIds,
+                  vectorFrameIds: vectorFrameIds
+              )
+        else { return }
+
+        let lifted = (merged[lift.textIndex].0, merged[lift.vectorIndex].1.nextUp)
+        merged.remove(at: lift.textIndex)
+        merged.insert(lifted, at: lift.vectorIndex)
+    }
+
+    /// Location of an exclusive text rank-1 buried under exclusive vector rank-1.
+    package static func exclusiveTextRank1FloorIndices(
+        mergedFrameIds: [UInt64],
+        textFrameIds: [UInt64],
+        vectorFrameIds: [UInt64]
+    ) -> (textIndex: Int, vectorIndex: Int)? {
+        guard let textTop = textFrameIds.first,
               let vectorTop = vectorFrameIds.first,
               !vectorFrameIds.contains(textTop),
               !textFrameIds.contains(vectorTop),
-              let textIndex = merged.firstIndex(where: { $0.0 == textTop }),
-              let vectorIndex = merged.firstIndex(where: { $0.0 == vectorTop }),
+              let textIndex = mergedFrameIds.firstIndex(of: textTop),
+              let vectorIndex = mergedFrameIds.firstIndex(of: vectorTop),
               textIndex > vectorIndex
-        else { return }
-
-        let lifted = (textTop, merged[vectorIndex].1.nextUp)
-        merged.remove(at: textIndex)
-        merged.insert(lifted, at: vectorIndex)
+        else { return nil }
+        return (textIndex, vectorIndex)
     }
 
     /// Multi-list weighted RRF (e.g., text + vector + timeline).

--- a/Sources/Wax/UnifiedSearch/HybridSearch.swift
+++ b/Sources/Wax/UnifiedSearch/HybridSearch.swift
@@ -12,13 +12,45 @@ package enum HybridSearch {
         alpha: Float = 0.5
     ) -> [(UInt64, Float)] {
         let clampedAlpha = min(1, max(0, alpha))
-        return rrfFusion(
+        var merged = rrfFusion(
             lists: [
                 (weight: clampedAlpha, frameIds: textResults.map(\.0)),
                 (weight: 1 - clampedAlpha, frameIds: vectorResults.map(\.0)),
             ],
             k: k
         )
+        applyExclusiveTextRank1Floor(
+            merged: &merged,
+            textFrameIds: textResults.map(\.0),
+            vectorFrameIds: vectorResults.map(\.0),
+            alpha: clampedAlpha
+        )
+        return merged
+    }
+
+    /// Default hybrid (alpha >= 0.5): exclusive text rank-1 cannot lose to an
+    /// exclusive vector-only neighbor. Ranking order only; score scale unchanged
+    /// except a `nextUp` bump so later score-sorts keep the same order.
+    package static func applyExclusiveTextRank1Floor(
+        merged: inout [(UInt64, Float)],
+        textFrameIds: [UInt64],
+        vectorFrameIds: [UInt64],
+        alpha: Float
+    ) {
+        let clampedAlpha = min(1, max(0, alpha))
+        guard clampedAlpha >= 0.5,
+              let textTop = textFrameIds.first,
+              let vectorTop = vectorFrameIds.first,
+              !vectorFrameIds.contains(textTop),
+              !textFrameIds.contains(vectorTop),
+              let textIndex = merged.firstIndex(where: { $0.0 == textTop }),
+              let vectorIndex = merged.firstIndex(where: { $0.0 == vectorTop }),
+              textIndex > vectorIndex
+        else { return }
+
+        let lifted = (textTop, merged[vectorIndex].1.nextUp)
+        merged.remove(at: textIndex)
+        merged.insert(lifted, at: vectorIndex)
     }
 
     /// Multi-list weighted RRF (e.g., text + vector + timeline).

--- a/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
+++ b/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
@@ -67,8 +67,9 @@ package enum RuleBasedQueryClassifier {
             return true
         }
 
-        // Hex-only tokens such as `7f3a91` / `DEADBEEF`. Length avoids `cafe` / `dead`.
-        return token.count >= 6 && token.unicodeScalars.allSatisfy { hexScalars.contains($0) }
+        // Letter-only hex such as `DEADBEEF`. Digit hex (`7f3a91`) already matched.
+        // Length 8 avoids English hex-words (`facade`, `decade`).
+        return token.count >= 8 && token.unicodeScalars.allSatisfy { hexScalars.contains($0) }
     }
 }
 

--- a/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
+++ b/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Heuristic query classifier for adaptive fusion (v1).
 ///
 /// This is intentionally deterministic and offline:
@@ -6,7 +8,8 @@
 /// - no model downloads
 package enum RuleBasedQueryClassifier {
     package static func classify(_ query: String) -> QueryType {
-        let q = query.lowercased()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let q = trimmed.lowercased()
 
         if q.contains("when")
             || q.contains("yesterday")
@@ -38,7 +41,34 @@ package enum RuleBasedQueryClassifier {
             return .semantic
         }
 
+        // Identifier / hex / single-token canaries are lexical lookups, not exploration.
+        if isLexicalIdentifierQuery(trimmed) {
+            return .factual
+        }
+
         return .exploratory
+    }
+
+    private static let hexScalars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+
+    /// Single-token hex / identifier canaries (not ordinary English words).
+    private static func isLexicalIdentifierQuery(_ query: String) -> Bool {
+        let tokens = query.split { $0.isWhitespace || $0.isNewline }
+        guard tokens.count == 1 else { return false }
+        let token = tokens[0]
+        guard !token.isEmpty else { return false }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        guard token.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return false }
+
+        let identifierPunctuation = CharacterSet(charactersIn: "-_.")
+        let hasDigit = token.unicodeScalars.contains { CharacterSet.decimalDigits.contains($0) }
+        let hasIdentifierPunctuation = token.unicodeScalars.contains { identifierPunctuation.contains($0) }
+        if hasDigit || hasIdentifierPunctuation {
+            return true
+        }
+
+        // Hex-only tokens such as `7f3a91` / `DEADBEEF`. Length avoids `cafe` / `dead`.
+        return token.count >= 6 && token.unicodeScalars.allSatisfy { hexScalars.contains($0) }
     }
 }
 

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -358,12 +358,28 @@ extension Wax {
             if weights.temporal > 0, !timelineIds.isEmpty { lists.append((source: .timeline, weight: weights.temporal, frameIds: timelineIds)) }
             if structuredWeight > 0, !structuredIds.isEmpty { lists.append((source: .structuredMemory, weight: structuredWeight, frameIds: structuredIds)) }
 
-            let fused = Self.rrfFusionResults(
+            var fused = Self.rrfFusionResults(
                 lists: lists,
                 k: request.rrfK,
                 includeDiagnostics: diagnosticsEnabled,
                 diagnosticsTopK: diagnosticsTopK
             )
+
+            // Lexical exclusive rank-1 floor: default hybrid must not bury an
+            // exclusive FTS hit under an exclusive vector neighbor.
+            var fusedPairs = fused.map { ($0.frameId, $0.score) }
+            HybridSearch.applyExclusiveTextRank1Floor(
+                merged: &fusedPairs,
+                textFrameIds: textIds,
+                vectorFrameIds: vectorIds,
+                alpha: clampedAlpha
+            )
+            let fusedById = Dictionary(uniqueKeysWithValues: fused.map { ($0.frameId, $0) })
+            fused = fusedPairs.compactMap { pair in
+                guard var entry = fusedById[pair.0] else { return nil }
+                entry.score = pair.1
+                return entry
+            }
 
             let timelineSet = Set(timelineIds)
             let structuredSet = Set(structuredIds)

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -365,20 +365,49 @@ extension Wax {
                 diagnosticsTopK: diagnosticsTopK
             )
 
-            // Lexical exclusive rank-1 floor: default hybrid must not bury an
-            // exclusive FTS hit under an exclusive vector neighbor.
-            var fusedPairs = fused.map { ($0.frameId, $0.score) }
-            HybridSearch.applyExclusiveTextRank1Floor(
-                merged: &fusedPairs,
-                textFrameIds: textIds,
-                vectorFrameIds: vectorIds,
-                alpha: clampedAlpha
-            )
-            let fusedById = Dictionary(uniqueKeysWithValues: fused.map { ($0.frameId, $0) })
-            fused = fusedPairs.compactMap { pair in
-                guard var entry = fusedById[pair.0] else { return nil }
-                entry.score = pair.1
-                return entry
+            // Factual identifier path only: exclusive FTS rank-1 must not lose
+            // to an exclusive vector neighbor. Semantic/exploratory keep AdaptiveFusion.
+            if queryType == .factual,
+               let lift = HybridSearch.exclusiveTextRank1FloorIndices(
+                   mergedFrameIds: fused.map(\.frameId),
+                   textFrameIds: textIds,
+                   vectorFrameIds: vectorIds
+               ) {
+                let textEntry = fused[lift.textIndex]
+                let vectorEntry = fused[lift.vectorIndex]
+                fused.remove(at: lift.textIndex)
+                let liftedDiagnostics = textEntry.diagnostics.map { diag in
+                    SearchResponse.RankingDiagnostics(
+                        bestLaneRank: diag.bestLaneRank,
+                        laneContributions: diag.laneContributions,
+                        tieBreakReason: .topResult
+                    )
+                }
+                fused.insert(
+                    (
+                        frameId: textEntry.frameId,
+                        score: vectorEntry.score.nextUp,
+                        sources: textEntry.sources,
+                        diagnostics: liftedDiagnostics
+                    ),
+                    at: lift.vectorIndex
+                )
+                let displacedIndex = lift.vectorIndex + 1
+                if displacedIndex < fused.count,
+                   let diag = fused[displacedIndex].diagnostics,
+                   diag.tieBreakReason == .topResult {
+                    let displaced = fused[displacedIndex]
+                    fused[displacedIndex] = (
+                        frameId: displaced.frameId,
+                        score: displaced.score,
+                        sources: displaced.sources,
+                        diagnostics: SearchResponse.RankingDiagnostics(
+                            bestLaneRank: diag.bestLaneRank,
+                            laneContributions: diag.laneContributions,
+                            tieBreakReason: .fusedScore
+                        )
+                    )
+                }
             }
 
             let timelineSet = Set(timelineIds)

--- a/Tests/WaxIntegrationTests/AdaptiveFusionTests.swift
+++ b/Tests/WaxIntegrationTests/AdaptiveFusionTests.swift
@@ -21,3 +21,18 @@ import Wax
     #expect(abs(weights.bm25 - weights.vector) <= 0.1)
 }
 
+@Test func identifierQueryUsesLexicalFirstWeights() {
+    let queryType = RuleBasedQueryClassifier.classify("7f3a91")
+    let weights = AdaptiveFusionConfig.default.weights(for: queryType)
+    #expect(queryType != .exploratory)
+    #expect(weights.bm25 > weights.vector)
+}
+
+@Test func factualHybridLaneWeightsKeepExclusiveTextAheadOfExclusiveVector() {
+    let weights = AdaptiveFusionConfig.default.weights(for: .factual)
+    let alpha: Float = 0.5
+    let textWeight = weights.bm25 * alpha
+    let vectorWeight = weights.vector * (1 - alpha)
+    #expect(textWeight > vectorWeight)
+}
+

--- a/Tests/WaxIntegrationTests/AdaptiveFusionTests.swift
+++ b/Tests/WaxIntegrationTests/AdaptiveFusionTests.swift
@@ -28,11 +28,3 @@ import Wax
     #expect(weights.bm25 > weights.vector)
 }
 
-@Test func factualHybridLaneWeightsKeepExclusiveTextAheadOfExclusiveVector() {
-    let weights = AdaptiveFusionConfig.default.weights(for: .factual)
-    let alpha: Float = 0.5
-    let textWeight = weights.bm25 * alpha
-    let vectorWeight = weights.vector * (1 - alpha)
-    #expect(textWeight > vectorWeight)
-}
-

--- a/Tests/WaxIntegrationTests/HybridSearchTests.swift
+++ b/Tests/WaxIntegrationTests/HybridSearchTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Testing
 import Wax
 
@@ -91,10 +90,50 @@ import Wax
         textResults: [(textCanary, 0.9)],
         vectorResults: [(vectorNeighbor, 0.95)],
         k: 60,
-        alpha: 0.5
+        alpha: 0.5,
+        applyFloor: true
     )
 
     #expect(merged.first?.0 == textCanary)
+}
+
+@Test func rrfSemanticExclusiveVectorRank1StaysAheadOfExclusiveTextAtDefaultAlpha() {
+    // Semantic path must not run the exclusive-text floor. Equal-weight RRF at
+    // alpha 0.5 then keeps the lower-id exclusive vector neighbor ahead.
+    let textCanary: UInt64 = 1706
+    let vectorNeighbor: UInt64 = 1
+    let merged = HybridSearch.rrfFusion(
+        textResults: [(textCanary, 0.9)],
+        vectorResults: [(vectorNeighbor, 0.95)],
+        k: 60,
+        alpha: 0.5,
+        applyFloor: false
+    )
+
+    #expect(merged.first?.0 == vectorNeighbor)
+}
+
+@Test func rrfFactualExclusiveListsPromoteTextRank1() {
+    // Exclusive lists: text top absent from vector, vector top absent from text.
+    var merged: [(UInt64, Float)] = [(1, 0.02), (1706, 0.019), (2, 0.01)]
+    HybridSearch.applyExclusiveTextRank1Floor(
+        merged: &merged,
+        textFrameIds: [1706, 99],
+        vectorFrameIds: [1, 2],
+        applyFloor: true
+    )
+    #expect(merged.map(\.0) == [1706, 1, 2])
+}
+
+@Test func rrfSemanticExclusiveListsKeepVectorRank1() {
+    var merged: [(UInt64, Float)] = [(1, 0.02), (1706, 0.019), (2, 0.01)]
+    HybridSearch.applyExclusiveTextRank1Floor(
+        merged: &merged,
+        textFrameIds: [1706, 99],
+        vectorFrameIds: [1, 2],
+        applyFloor: false
+    )
+    #expect(merged.map(\.0) == [1, 1706, 2])
 }
 
 @Test func hybridSearchRanksUniqueLexicalCanaryAboveVectorNeighbors() async throws {

--- a/Tests/WaxIntegrationTests/HybridSearchTests.swift
+++ b/Tests/WaxIntegrationTests/HybridSearchTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import Wax
 
@@ -79,5 +80,67 @@ import Wax
     )
 
     #expect(merged.count == 2)
+}
+
+@Test func rrfExclusiveTextRank1BeatsExclusiveVectorNeighborAtDefaultAlpha() {
+    // Vector neighbor gets a lower frame id so the old frame-id tie-break would
+    // bury the exclusive lexical canary when RRF scores are equal or vector-leaning.
+    let textCanary: UInt64 = 1706
+    let vectorNeighbor: UInt64 = 1
+    let merged = HybridSearch.rrfFusion(
+        textResults: [(textCanary, 0.9)],
+        vectorResults: [(vectorNeighbor, 0.95)],
+        k: 60,
+        alpha: 0.5
+    )
+
+    #expect(merged.first?.0 == textCanary)
+}
+
+@Test func hybridSearchRanksUniqueLexicalCanaryAboveVectorNeighbors() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = true
+        config.enableTextSearch = true
+        config.chunking = .tokenCount(targetTokens: 400, overlapTokens: 0)
+
+        let orchestrator = try await MemoryOrchestrator(
+            at: url,
+            config: config,
+            embedder: CanaryConfusionEmbedder()
+        )
+        try await orchestrator.remember("test with embedder Osaurus telemetry heartbeat")
+        try await orchestrator.remember("session health probe MiniLM neighbor filler")
+        try await orchestrator.remember("unique lexical canary 7f3a91 stored for hybrid recall")
+        try await orchestrator.flush()
+
+        let hits = try await orchestrator.search(query: "7f3a91", mode: .default, topK: 10)
+        let top = try #require(hits.first)
+        #expect(
+            top.previewText?.contains("7f3a91") == true,
+            "hybrid rank-1 was \(top.previewText ?? "<nil>")"
+        )
+
+        try await orchestrator.close()
+    }
+}
+
+private struct CanaryConfusionEmbedder: EmbeddingProvider {
+    let dimensions = 2
+    let normalize = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "Test",
+        model: "CanaryConfusion",
+        dimensions: 2,
+        normalized: true
+    )
+
+    func embed(_ text: String) async throws -> [Float] {
+        let lowered = text.lowercased()
+        if lowered.contains("7f3a91"), lowered != "7f3a91" {
+            return VectorMath.normalizeL2([0, 1])
+        }
+        return VectorMath.normalizeL2([1, 0])
+    }
 }
 

--- a/Tests/WaxIntegrationTests/QueryClassifierTests.swift
+++ b/Tests/WaxIntegrationTests/QueryClassifierTests.swift
@@ -31,3 +31,8 @@ import Wax
     #expect(RuleBasedQueryClassifier.classify("Swift") == .exploratory)
 }
 
+@Test func letterOnlyHexWordsStayExploratory() {
+    #expect(RuleBasedQueryClassifier.classify("facade") == .exploratory)
+    #expect(RuleBasedQueryClassifier.classify("decade") == .exploratory)
+}
+

--- a/Tests/WaxIntegrationTests/QueryClassifierTests.swift
+++ b/Tests/WaxIntegrationTests/QueryClassifierTests.swift
@@ -17,3 +17,17 @@ import Wax
     #expect(RuleBasedQueryClassifier.classify("Tell me about the project") == .exploratory)
 }
 
+@Test func hexCanaryQueryClassifiesAsFactual() {
+    #expect(RuleBasedQueryClassifier.classify("7f3a91") == .factual)
+    #expect(RuleBasedQueryClassifier.classify("DEADBEEF") == .factual)
+}
+
+@Test func singleTokenIdentifierQueryClassifiesAsFactual() {
+    #expect(RuleBasedQueryClassifier.classify("canary-token") == .factual)
+    #expect(RuleBasedQueryClassifier.classify("user_id") == .factual)
+}
+
+@Test func ordinarySingleWordStaysExploratory() {
+    #expect(RuleBasedQueryClassifier.classify("Swift") == .exploratory)
+}
+


### PR DESCRIPTION
## Why

Operator review: default hybrid on the long-term store missed unique canary `7f3a91` (scores ~0.004) while `mode: text` hit frame 1706 immediately. Agents following “prefer hybrid” miss known facts.

## Cause

Identifier queries classified as `.exploratory`. Adaptive weights × `alpha=0.5` made RRF vector rank-1 (`0.25/61`) beat text rank-1 (`0.2/61`).

## Change

- Hex / identifier single-token queries classify as `.factual`
- Exclusive text rank-1 cannot lose to an exclusive vector neighbor at default hybrid alpha
- Default MCP mode stays `hybrid`

## Test

`swift test --filter QueryClassifier`
`swift test --filter HybridSearch`
`swift test --filter AdaptiveFusion`

## Review

Dual PASS (behavior + safety) in run oi-e1695046.