### PR TITLE
fix(broker): do not leak filesystem paths from session_resume

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1440,13 +1440,7 @@ extension AgentBrokerService {
         runID: String?
     ) throws -> BrokerSessionManifest {
         if let explicitSessionID {
-            do {
-                return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
-            } catch {
-                throw BrokerValidationError.invalid(
-                    "No session manifest found for session_id \(explicitSessionID.uuidString)"
-                )
-            }
+            return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
         }
 
         let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1440,7 +1440,13 @@ extension AgentBrokerService {
         runID: String?
     ) throws -> BrokerSessionManifest {
         if let explicitSessionID {
-            return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
+            do {
+                return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
+            } catch {
+                throw BrokerValidationError.invalid(
+                    "No session manifest found for session_id \(explicitSessionID.uuidString)"
+                )
+            }
         }
 
         let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)

--- a/Sources/Wax/Broker/BrokerSessionPersistence.swift
+++ b/Sources/Wax/Broker/BrokerSessionPersistence.swift
@@ -125,11 +125,17 @@ package struct BrokerSessionRecallSignals: Sendable, Equatable {
 
 package enum BrokerSessionPersistenceError: LocalizedError, Equatable {
     case manifestNotFound(sessionID: UUID)
+    case manifestUnreadable(sessionID: UUID?)
 
     package var errorDescription: String? {
         switch self {
         case .manifestNotFound(let sessionID):
             return "No session manifest found for session_id \(sessionID.uuidString)"
+        case .manifestUnreadable(let sessionID):
+            if let sessionID {
+                return "Unable to read session manifest for session_id \(sessionID.uuidString)"
+            }
+            return "Unable to read session manifest"
         }
     }
 }
@@ -158,14 +164,17 @@ package enum BrokerSessionPersistence {
 
     package static func loadManifest(at url: URL) throws -> BrokerSessionManifest {
         let sessionID = UUID(uuidString: url.deletingPathExtension().lastPathComponent)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            if let sessionID {
+                throw BrokerSessionPersistenceError.manifestNotFound(sessionID: sessionID)
+            }
+            throw BrokerSessionPersistenceError.manifestUnreadable(sessionID: nil)
+        }
         let data: Data
         do {
             data = try Data(contentsOf: url)
         } catch {
-            if let sessionID {
-                throw BrokerSessionPersistenceError.manifestNotFound(sessionID: sessionID)
-            }
-            throw error
+            throw BrokerSessionPersistenceError.manifestUnreadable(sessionID: sessionID)
         }
         return try decoder.decode(BrokerSessionManifest.self, from: data)
     }

--- a/Sources/Wax/Broker/BrokerSessionPersistence.swift
+++ b/Sources/Wax/Broker/BrokerSessionPersistence.swift
@@ -123,6 +123,17 @@ package struct BrokerSessionRecallSignals: Sendable, Equatable {
     }
 }
 
+package enum BrokerSessionPersistenceError: LocalizedError, Equatable {
+    case manifestNotFound(sessionID: UUID)
+
+    package var errorDescription: String? {
+        switch self {
+        case .manifestNotFound(let sessionID):
+            return "No session manifest found for session_id \(sessionID.uuidString)"
+        }
+    }
+}
+
 package enum BrokerSessionPersistence {
     private static let encoder: JSONEncoder = {
         let encoder = JSONEncoder()
@@ -146,7 +157,16 @@ package enum BrokerSessionPersistence {
     }
 
     package static func loadManifest(at url: URL) throws -> BrokerSessionManifest {
-        let data = try Data(contentsOf: url)
+        let sessionID = UUID(uuidString: url.deletingPathExtension().lastPathComponent)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            if let sessionID {
+                throw BrokerSessionPersistenceError.manifestNotFound(sessionID: sessionID)
+            }
+            throw error
+        }
         return try decoder.decode(BrokerSessionManifest.self, from: data)
     }
 

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -5468,6 +5468,25 @@ func knowledgeCaptureAndMemoryHealthWork() async throws {
     }
 }
 
+@Test
+func brokerSessionResumeMissingUUIDDoesNotLeakPath() async throws {
+    try await withAgentBrokerService { service, _ in
+        let missingSessionID = UUID()
+        let resumed = await service.handle(.init(
+            command: "session_resume",
+            arguments: ["session_id": .string(missingSessionID.uuidString)]
+        ))
+
+        #expect(resumed.ok != true)
+        let error = resumed.error ?? ""
+        #expect(error.contains(missingSessionID.uuidString))
+        #expect(!error.contains("/Users/"))
+        #expect(!error.contains("/home/"))
+        #expect(!error.contains("~/.wax"))
+        #expect(!error.contains(".json"))
+    }
+}
+
 private func firstText(in result: CallTool.Result) -> String {
     for content in result.content {
         if case .text(text: let text, annotations: _, _meta: _) = content {
@@ -6667,9 +6686,10 @@ struct WaxMCPProcessTests {
             #expect(search.ok == true)
             let searchPayload = try #require(search.payload?.objectValue)
             let searchResults = try #require(searchPayload["results"]?.arrayValue)
-            let rawFrameID = try #require(searchResults.compactMap { result -> UInt64? in
+            let searchFrameIDs = searchResults.compactMap { result -> UInt64? in
                 result.objectValue?["frameId"]?.intValue.map(UInt64.init)
-            }.first)
+            }
+            let rawFrameID = try #require(searchFrameIDs.first)
 
             let memorySearch = await service.handle(.init(
                 command: "memory_search",
@@ -6686,9 +6706,10 @@ struct WaxMCPProcessTests {
             #expect(memorySearch.ok == true)
             let memorySearchPayload = try #require(memorySearch.payload?.objectValue)
             let memorySearchResults = try #require(memorySearchPayload["results"]?.arrayValue)
-            let canonicalFrameID = try #require(memorySearchResults.compactMap { result -> UInt64? in
+            let memorySearchFrameIDs = memorySearchResults.compactMap { result -> UInt64? in
                 result.objectValue?["frame_id"]?.intValue.map(UInt64.init)
-            }.first)
+            }
+            let canonicalFrameID = try #require(memorySearchFrameIDs.first)
             #expect(canonicalFrameID != rawFrameID)
 
             let manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -4789,6 +4789,28 @@ func brokerSessionListManifestsPropagatesMalformedSessionManifest() throws {
 }
 
 @Test
+func brokerSessionLoadManifestMissingUUIDDoesNotLeakPath() throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-manifest-missing-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let sessionID = UUID()
+    do {
+        _ = try BrokerSessionPersistence.loadManifest(rootURL: rootURL, sessionID: sessionID)
+        Issue.record("missing manifest should throw")
+    } catch let error as BrokerSessionPersistenceError {
+        #expect(error == .manifestNotFound(sessionID: sessionID))
+        let description = error.localizedDescription
+        #expect(description == "No session manifest found for session_id \(sessionID.uuidString)")
+        #expect(!description.contains("/Users/"))
+        #expect(!description.contains("/home/"))
+        #expect(!description.contains("~/.wax"))
+        #expect(!description.contains(".json"))
+    }
+}
+
+@Test
 func brokerRememberPreservesContentWhitespace() async throws {
     try await withAgentBrokerService { service, _ in
         let content = "  WHITESPACE_KEEP_TOKEN\n"
@@ -5479,7 +5501,32 @@ func brokerSessionResumeMissingUUIDDoesNotLeakPath() async throws {
 
         #expect(resumed.ok != true)
         let error = resumed.error ?? ""
-        #expect(error.contains(missingSessionID.uuidString))
+        #expect(error == "No session manifest found for session_id \(missingSessionID.uuidString)")
+        #expect(!error.contains("/Users/"))
+        #expect(!error.contains("/home/"))
+        #expect(!error.contains("~/.wax"))
+        #expect(!error.contains(".json"))
+    }
+}
+
+@Test
+func brokerSessionResumeCorruptUUIDDoesNotReportMissing() async throws {
+    try await withAgentBrokerService { service, sessionRootURL in
+        let sessionID = UUID()
+        let corruptManifestURL = BrokerSessionPersistence.manifestURL(
+            rootURL: sessionRootURL,
+            sessionID: sessionID
+        )
+        try Data("{not valid json".utf8).write(to: corruptManifestURL)
+
+        let resumed = await service.handle(.init(
+            command: "session_resume",
+            arguments: ["session_id": .string(sessionID.uuidString)]
+        ))
+
+        #expect(resumed.ok != true)
+        let error = resumed.error ?? ""
+        #expect(!error.contains("No session manifest found"))
         #expect(!error.contains("/Users/"))
         #expect(!error.contains("/home/"))
         #expect(!error.contains("~/.wax"))


### PR DESCRIPTION
## Why

Operator review: `session_resume` of a missing UUID leaked a filesystem path (Cocoa `Data(contentsOf:)`).

## Change

Missing UUID fails closed with `No session manifest found for session_id <UUID>`. No `/Users/`, `~/.wax`, or `.json` path. Does not invent a session.

## Test

`swift test --traits MCPServer --filter brokerSessionResumeMissingUUIDDoesNotLeakPath`

## Review

Dual PASS in run oi-e1695046.