### PR TITLE
fix(mcp): make search and memory_search share the document frame id

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -23,6 +23,8 @@ package actor AgentBrokerService {
     let promotionSettings: BrokerPromotionSettings
     let brokerInstanceID = UUID().uuidString
     var activeSessions: [UUID: SessionState] = [:]
+    /// Test-only: treat these hit ids as canonicalization failures.
+    var testFailCanonicalDocumentFrameIDs: Set<UInt64> = []
 
     package init(
         storePath: String,
@@ -413,16 +415,18 @@ extension AgentBrokerService {
             frameFilter: parsedFilters.frameFilter,
             timeRange: parsedFilters.timeRange
         )
-        let rows: [AgentBrokerValue] = execution.hits.enumerated().map { index, hit in
-            .object([
-                "rank": .from(index + 1),
-                "frameId": .from(hit.frameId),
+        var rows: [AgentBrokerValue] = []
+        for hit in execution.hits {
+            guard let frameId = await bestEffortCanonicalDocumentFrameID(for: hit.frameId, memory: memory) else { continue }
+            rows.append(.object([
+                "rank": .from(rows.count + 1),
+                "frameId": .from(frameId),
                 "score": .double(Double(hit.score)),
                 "sources": .array(hit.sources.map { .string($0.rawValue) }),
                 "preview": .string(hit.previewText ?? ""),
                 "metadata": .object(hit.metadata.mapValues(AgentBrokerValue.string)),
                 "explanations": .array(hit.explanations.map(AgentBrokerValue.string)),
-            ])
+            ]))
         }
         if let sessionID = parsedFilters.sessionId {
             try await refreshSessionManifest(sessionID)
@@ -2771,10 +2775,17 @@ extension AgentBrokerService {
         return frameID
     }
 
+    package func setTestFailCanonicalDocumentFrameIDs(_ ids: Set<UInt64>) {
+        testFailCanonicalDocumentFrameIDs = ids
+    }
+
     func bestEffortCanonicalDocumentFrameID(
         for frameID: UInt64,
         memory: MemoryOrchestrator
     ) async -> UInt64? {
+        if testFailCanonicalDocumentFrameIDs.contains(frameID) {
+            return nil
+        }
         do {
             return try await canonicalDocumentFrameID(for: frameID, memory: memory)
         } catch {

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -964,22 +964,32 @@ private extension WaxMCPTools {
             frameFilter: filters.frameFilter,
             timeRange: filters.timeRange
         )
-        let rows: [Value] = execution.hits.enumerated().map { index, hit in
-            [
-                "rank": .int(index + 1),
-                "frameId": .int(Int(hit.frameId)),
+        let documents = try await memory.corpusSourceDocuments()
+        let documentByFrameID = Dictionary(uniqueKeysWithValues: documents.map { ($0.frameId, $0) })
+        var rows: [Value] = []
+        var recordedHits: [(frameID: UInt64, score: Float)] = []
+        for hit in execution.hits {
+            guard let document = try await compatDocument(
+                for: hit.frameId,
+                in: documentByFrameID,
+                memory: memory
+            ) else { continue }
+            rows.append([
+                "rank": .int(rows.count + 1),
+                "frameId": .int(Int(document.frameId)),
                 "score": .double(Double(hit.score)),
                 "sources": .array(hit.sources.map { .string($0.rawValue) }),
                 "preview": .string(hit.previewText ?? ""),
                 "metadata": .object(hit.metadata.mapValues(Value.string)),
                 "explanations": .array(hit.explanations.map(Value.string)),
-            ]
+            ])
+            recordedHits.append((frameID: document.frameId, score: hit.score))
         }
         if let sessionID = filters.sessionID {
-            for hit in execution.hits {
+            for hit in recordedHits {
                 await sessionRegistry.recordRetrievalHit(
                     sessionID: sessionID,
-                    frameID: hit.frameId,
+                    frameID: hit.frameID,
                     query: query,
                     score: hit.score
                 )

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -6667,9 +6667,10 @@ struct WaxMCPProcessTests {
             #expect(search.ok == true)
             let searchPayload = try #require(search.payload?.objectValue)
             let searchResults = try #require(searchPayload["results"]?.arrayValue)
-            let rawFrameID = try #require(searchResults.compactMap { result -> UInt64? in
+            let rawFrameIDs = searchResults.compactMap { result -> UInt64? in
                 result.objectValue?["frameId"]?.intValue.map(UInt64.init)
-            }.first)
+            }
+            let rawFrameID = try #require(rawFrameIDs.first)
 
             let memorySearch = await service.handle(.init(
                 command: "memory_search",
@@ -6686,16 +6687,16 @@ struct WaxMCPProcessTests {
             #expect(memorySearch.ok == true)
             let memorySearchPayload = try #require(memorySearch.payload?.objectValue)
             let memorySearchResults = try #require(memorySearchPayload["results"]?.arrayValue)
-            let canonicalFrameID = try #require(memorySearchResults.compactMap { result -> UInt64? in
+            let canonicalFrameIDs = memorySearchResults.compactMap { result -> UInt64? in
                 result.objectValue?["frame_id"]?.intValue.map(UInt64.init)
-            }.first)
-            #expect(canonicalFrameID != rawFrameID)
+            }
+            let canonicalFrameID = try #require(canonicalFrameIDs.first)
+            #expect(canonicalFrameID == rawFrameID)
 
             let manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)
             let signals = BrokerSessionPersistence.recallSignals(
                 from: try BrokerSessionPersistence.loadEvents(from: URL(fileURLWithPath: manifest.eventLogPath))
             )
-            #expect(signals[rawFrameID] == nil)
             let signal = try #require(signals[canonicalFrameID])
             #expect(signal.recallCount == 2)
             #expect(signal.uniqueQueryCount == 1)
@@ -7531,6 +7532,146 @@ struct WaxMCPProcessTests {
             let preview = object["preview"] as? String ?? ""
             return preview.contains("UNLOCKED") && preview.contains("MATCH")
         })
+    }
+}
+
+@Test
+func memory_searchAndSearchShareTheSameGettableFrameIdAfterRemember() async throws {
+    try await withMemory { memory in
+        let started = await WaxMCPTools.handleCall(
+            params: .init(name: "session_start", arguments: [:]),
+            memory: memory
+        )
+        #expect(started.isError != true)
+        let sessionID = try requireString(try parseJSONText(in: started), key: "session_id")
+        let canary = "ID_SKEW_CANARY_7f3a91"
+        let content = "\(canary) remembered text agents must load via memory_get"
+
+        let remember = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "remember",
+                arguments: [
+                    "content": .string(content),
+                    "session_id": .string(sessionID),
+                ]
+            ),
+            memory: memory
+        )
+        #expect(remember.isError != true)
+
+        let search = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "search",
+                arguments: [
+                    "query": .string(canary),
+                    "mode": .string("text"),
+                    "topK": .int(5),
+                    "session_id": .string(sessionID),
+                ]
+            ),
+            memory: memory
+        )
+        #expect(search.isError != true, "search failed: \(firstText(in: search))")
+        let searchJSON = try parseJSONResource(in: search, uriSuffix: "search-summary")
+        let searchResults = try requireArray(searchJSON, key: "results")
+        #expect(!searchResults.isEmpty, "search returned no hits: \(firstText(in: search))")
+        let searchHit = try requireObject(try #require(searchResults.first))
+        let searchFrameID = try requireInt(searchHit, key: "frameId")
+
+        let memorySearch = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "memory_search",
+                arguments: [
+                    "query": .string(canary),
+                    "mode": .string("text"),
+                    "topK": .int(5),
+                    "session_id": .string(sessionID),
+                    "include_working": .bool(true),
+                    "include_episodic": .bool(false),
+                    "include_durable": .bool(false),
+                ]
+            ),
+            memory: memory
+        )
+        #expect(memorySearch.isError != true, "memory_search failed: \(firstText(in: memorySearch))")
+        let memoryJSON = try parseJSONResource(in: memorySearch, uriSuffix: "memory-search-summary")
+        let memoryResults = try requireArray(memoryJSON, key: "results")
+        #expect(!memoryResults.isEmpty, "memory_search returned no hits: \(firstText(in: memorySearch))")
+        let memoryHit = try requireObject(try #require(memoryResults.first))
+        let memoryFrameID = try requireInt(memoryHit, key: "frame_id")
+        let memoryID = try requireString(memoryHit, key: "memory_id")
+
+        #expect(searchFrameID == memoryFrameID)
+        #expect(memoryID == "working:\(sessionID):\(memoryFrameID)")
+
+        let get = await WaxMCPTools.handleCall(
+            params: .init(name: "memory_get", arguments: ["memory_id": .string(memoryID)]),
+            memory: memory
+        )
+        #expect(get.isError != true)
+        #expect(firstText(in: get).contains(canary))
+        #expect(firstText(in: get).contains("remembered text agents must load"))
+
+        let searchBuiltMemoryID = "working:\(sessionID):\(searchFrameID)"
+        let getFromSearch = await WaxMCPTools.handleCall(
+            params: .init(name: "memory_get", arguments: ["memory_id": .string(searchBuiltMemoryID)]),
+            memory: memory
+        )
+        #expect(getFromSearch.isError != true)
+        #expect(firstText(in: getFromSearch).contains(canary))
+    }
+}
+
+@Test
+func brokerSearchOmitsRawChunkIdWhenCanonicalizationFails() async throws {
+    try await withAgentBrokerService { service, _ in
+        let started = await service.handle(.init(command: "session_start"))
+        #expect(started.ok == true)
+        let sessionIDString = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
+        let sessionID = try #require(UUID(uuidString: sessionIDString))
+        let state = try #require(await service.activeSessions[sessionID])
+
+        let anchor = "CANON_FAIL_OMIT_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let content = Array(
+            repeating: "\(anchor) broker search must not republish a raw chunk id when document-frame lookup fails.",
+            count: 80
+        ).joined(separator: " ")
+        let append = await service.handle(.init(
+            command: "memory_append",
+            arguments: [
+                "content": .string(content),
+                "session_id": .string(sessionIDString),
+            ]
+        ))
+        #expect(append.ok == true)
+
+        let execution = try await state.memory.searchExecution(
+            query: anchor,
+            mode: .text,
+            topK: 10
+        )
+        #expect(!execution.hits.isEmpty, "expected indexed hits before forcing canonicalization failure")
+        let rawHitFrameIDs = Set(execution.hits.map(\.frameId))
+        #expect(!rawHitFrameIDs.isEmpty)
+
+        await service.setTestFailCanonicalDocumentFrameIDs(rawHitFrameIDs)
+
+        let search = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string(anchor),
+                "mode": .string("text"),
+                "topK": .int(10),
+                "session_id": .string(sessionIDString),
+            ]
+        ))
+        #expect(search.ok == true)
+        let results = try #require(search.payload?.objectValue?["results"]?.arrayValue)
+        let emitted = Set(results.compactMap { result -> UInt64? in
+            result.objectValue?["frameId"]?.intValue.map(UInt64.init)
+        })
+        #expect(emitted.isDisjoint(with: rawHitFrameIDs))
+        #expect(emitted.isEmpty)
     }
 }
 


### PR DESCRIPTION
## Why

Operator review: the same item was `search frameId=3` and `memory_id=…:2`. Agents could not `memory_get` a search hit.

## Change

Both MCP `search` and broker `search` remap to the parent document frame. Failed remaps skip the hit (no raw chunk fallback). `memory_id` session encoding is unchanged.

## Test

`swift test --traits MCPServer --filter memory_searchAndSearchShareTheSameGettableFrameIdAfterRemember`
`swift test --traits MCPServer --filter brokerSearchOmitsRawChunkIdWhenCanonicalizationFails`

## Review

Dual PASS after one safety fix (skip-on-nil).