### PR TITLE
fix(memory): write one searchable frame for a single-chunk remember

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -370,8 +370,19 @@ package actor MemoryOrchestrator {
             metadata: docMeta.entries,
             expectedChunkCount: chunks.count,
             embeddingIdentity: Self.rememberDedupEmbeddingIdentity(from: localEmbedder?.identity)
-        ), existingProbe.isComplete {
-            return
+        ) {
+            if existingProbe.isComplete {
+                return
+            }
+            // Single-chunk remember writes only the document. A matching
+            // document is not complete unless it is actually searchable.
+            if chunks.count == 1 {
+                try await ensureSingleChunkDocumentSearchable(
+                    documentId: existingProbe.documentId,
+                    text: chunks[0]
+                )
+                return
+            }
         }
 
         let chunkCount = chunks.count
@@ -403,12 +414,11 @@ package actor MemoryOrchestrator {
 
         if chunkCount == 1 {
             let chunk = chunks[0]
-            let chunkData = Data(chunk.utf8)
-
-            var chunkMeta = Metadata(metadata)
-            if let effectiveSessionId {
-                chunkMeta.entries["session_id"] = effectiveSessionId
-            }
+            var docOptions = FrameMetaSubset(
+                role: .document,
+                metadata: docMeta
+            )
+            docOptions.searchText = chunk
 
             let chunkEmbedding: [Float]?
             if useVectorSearch {
@@ -425,51 +435,22 @@ package actor MemoryOrchestrator {
                 chunkEmbedding = nil
             }
 
-            let docId = try await localSession.put(
-                contentData,
-                options: FrameMetaSubset(
-                    role: .document,
-                    metadata: docMeta
-                )
-            )
-
-            var option = FrameMetaSubset()
-            option.role = .chunk
-            option.parentId = docId
-            option.chunkIndex = 0
-            option.chunkCount = 1
-            option.searchText = chunk
-            option.metadata = chunkMeta
-
+            // Put without identity so doc metadata stays user keys + hash.
+            // `put(..., identity:)` stamps wax.embedding.* and the rematch
+            // probe uses exact metadata equality without those keys.
+            let frameId = try await localSession.put(contentData, options: docOptions)
             if let chunkEmbedding {
-                guard let localEmbedder else {
-                    throw WaxError.missingEmbedder
-                }
-                let frameId = try await localSession.put(
-                    chunkData,
-                    embedding: chunkEmbedding,
-                    identity: localEmbedder.identity,
-                    options: option
-                )
+                try await wax.putEmbedding(frameId: frameId, vector: chunkEmbedding)
                 try await ensureMemoryBindingIfNeeded(bindingForEmbedderIdentity)
-                if config.enableTextSearch {
-                    try await localSession.indexText(frameId: frameId, text: chunk)
-                }
-                if let enrichmentPipeline {
-                    try await enrichmentPipeline.enqueue(
-                        EnrichmentTask(frameId: frameId, text: chunk)
-                    )
-                }
-            } else {
-                let frameId = try await localSession.put(chunkData, options: option)
-                if config.enableTextSearch {
-                    try await localSession.indexText(frameId: frameId, text: chunk)
-                }
-                if let enrichmentPipeline {
-                    try await enrichmentPipeline.enqueue(
-                        EnrichmentTask(frameId: frameId, text: chunk)
-                    )
-                }
+            }
+
+            if config.enableTextSearch {
+                try await localSession.indexText(frameId: frameId, text: chunk)
+            }
+            if let enrichmentPipeline {
+                try await enrichmentPipeline.enqueue(
+                    EnrichmentTask(frameId: frameId, text: chunk)
+                )
             }
             return
         }
@@ -632,6 +613,106 @@ package actor MemoryOrchestrator {
             dimensions: identity.dimensions,
             normalized: identity.normalized
         )
+    }
+
+    /// Re-index / re-embed an existing single-chunk document in place (0 new frames).
+    /// `searchText` cannot be patched on a written frame; FTS and embeddings can.
+    private func ensureSingleChunkDocumentSearchable(
+        documentId: UInt64,
+        text: String
+    ) async throws {
+        if await isSingleChunkDocumentSearchable(documentId: documentId, expectedText: text) {
+            return
+        }
+
+        if config.enableTextSearch {
+            let alreadyIndexed = await documentIsInTextIndex(documentId: documentId, text: text)
+            if !alreadyIndexed {
+                try await session.indexText(frameId: documentId, text: text)
+            }
+        }
+
+        if config.enableVectorSearch {
+            let alreadyEmbedded = await documentHasEmbedding(frameId: documentId)
+            if !alreadyEmbedded {
+                guard let localEmbedder = embedder else {
+                    throw WaxError.missingEmbedder
+                }
+                let embedding = try await Self.embedOne(
+                    text,
+                    embedder: localEmbedder,
+                    cache: embeddingCache,
+                    timeout: config.ingestEmbeddingTimeout
+                )
+                try await wax.putEmbedding(frameId: documentId, vector: embedding)
+                if let identity = localEmbedder.identity {
+                    try await ensureMemoryBindingIfNeeded(
+                        MemoryBindingCompatibility.binding(from: identity)
+                    )
+                }
+            }
+        }
+    }
+
+    private func isSingleChunkDocumentSearchable(
+        documentId: UInt64,
+        expectedText: String
+    ) async -> Bool {
+        let meta: FrameMeta
+        do {
+            meta = try await wax.frameMetaIncludingPending(frameId: documentId)
+        } catch {
+            return false
+        }
+        let searchText = meta.searchText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !searchText.isEmpty else { return false }
+
+        if config.enableTextSearch {
+            let indexed = await documentIsInTextIndex(documentId: documentId, text: expectedText)
+            guard indexed else { return false }
+        }
+        if config.enableVectorSearch {
+            let embedded = await documentHasEmbedding(frameId: documentId)
+            guard embedded else { return false }
+        }
+        return true
+    }
+
+    private func documentIsInTextIndex(documentId: UInt64, text: String) async -> Bool {
+        let query = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return false }
+        do {
+            let hits = try await session.searchText(query: query, topK: 64)
+            return hits.contains { $0.frameId == documentId }
+        } catch {
+            return false
+        }
+    }
+
+    private func documentHasEmbedding(frameId: UInt64) async -> Bool {
+        let pending = await wax.pendingEmbeddingMutations()
+        if pending.contains(where: { $0.frameId == frameId }) {
+            return true
+        }
+        if let staged = await wax.readStagedVecIndexBytes(),
+           Self.vecSegmentContains(frameId: frameId, bytes: staged.bytes) {
+            return true
+        }
+        if let bytes = try? await wax.readCommittedVecIndexBytes(),
+           Self.vecSegmentContains(frameId: frameId, bytes: bytes) {
+            return true
+        }
+        return false
+    }
+
+    private static func vecSegmentContains(frameId: UInt64, bytes: Data) -> Bool {
+        guard let payload = try? VectorSerializer.decodeVecSegment(from: bytes) else {
+            return false
+        }
+        switch payload {
+        case .metal(_, _, let frameIds):
+            return frameIds.contains(frameId)
+        }
     }
 
     private static func persistEnrichmentResult(

--- a/Sources/WaxCore/Wax.swift
+++ b/Sources/WaxCore/Wax.swift
@@ -2027,7 +2027,10 @@ package actor Wax {
 
             for frame in toc.frames {
                 guard frame.status == .active, frame.supersededBy == nil else { continue }
-                guard frame.role == .chunk else { continue }
+                // Single-chunk remember writes only a searchable document.
+                // Corpus ingest already does the same. Chunks stay the
+                // multi-chunk source.
+                guard frame.role == .chunk || frame.role == .document else { continue }
                 guard frame.kind != "surrogate" else { continue }
                 guard let searchText = frame.searchText?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !searchText.isEmpty else {

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -59,6 +59,24 @@ struct WaxCLIMemoryTests {
 
     // MARK: - Tests
 
+    @Test func singleChunkRememberAddsOneFrame() async throws {
+        try await withCLIMemory { memory in
+            let content = "cli canary-7f3a91 single-chunk remember"
+            let before = await memory.runtimeStats()
+            try await memory.remember(content, metadata: ["source": "cli-single-chunk"])
+            try await memory.flush()
+            let after = await memory.runtimeStats()
+            let added = after.frameCount - before.frameCount
+            #expect(added == 1)
+            #expect(after.frameCount == before.frameCount + 1)
+
+            try await memory.remember(content, metadata: ["source": "cli-single-chunk"])
+            try await memory.flush()
+            let afterDuplicate = await memory.runtimeStats()
+            #expect(afterDuplicate.frameCount == after.frameCount)
+        }
+    }
+
     @Test func rememberFlushRecallRoundTrip() async throws {
         try await withCLIMemory { memory in
             try await memory.remember(

--- a/Tests/WaxIntegrationTests/DeduplicationTests.swift
+++ b/Tests/WaxIntegrationTests/DeduplicationTests.swift
@@ -38,7 +38,8 @@ import WaxCore
         try await orchestrator.flush()
 
         let stats = await orchestrator.runtimeStats()
-        #expect(stats.frameCount == UInt64(expectedChunks.count + 1))
+        let expectedFrames = expectedChunks.count == 1 ? 1 : expectedChunks.count + 1
+        #expect(stats.frameCount == UInt64(expectedFrames))
 
         try await orchestrator.close()
     }

--- a/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
+++ b/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+import Wax
+import WaxCore
+
+@Test
+func singleChunkRememberAddsOneFrame() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        config.enableTextSearch = true
+
+        let content = "canary-7f3a91 single-chunk remember must add one frame"
+        let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)
+        #expect(chunks.count == 1)
+
+        let orchestrator = try await MemoryOrchestrator(at: url, config: config)
+        let before = await orchestrator.runtimeStats()
+        try await orchestrator.remember(content, metadata: ["source": "single-chunk-test"])
+        try await orchestrator.flush()
+        let after = await orchestrator.runtimeStats()
+
+        let added = after.frameCount - before.frameCount
+        #expect(added == 1)
+        #expect(after.frameCount == before.frameCount + 1)
+
+        try await orchestrator.remember(content, metadata: ["source": "single-chunk-test"])
+        try await orchestrator.flush()
+        let afterDuplicate = await orchestrator.runtimeStats()
+        #expect(afterDuplicate.frameCount == after.frameCount)
+
+        let hits = try await orchestrator.search(
+            query: "canary-7f3a91",
+            mode: .text,
+            topK: 5
+        )
+        #expect(!hits.isEmpty)
+
+        try await orchestrator.close()
+
+        let wax = try await Wax.open(at: url)
+        let stats = await wax.stats()
+        #expect(stats.frameCount == 1)
+        let meta = try await wax.frameMeta(frameId: 0)
+        #expect(meta.role == .document)
+        #expect(meta.searchText == content)
+        try await wax.close()
+    }
+}
+
+@Test
+func multiChunkRememberKeepsParentAndChunkFrames() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        config.enableTextSearch = true
+        config.chunking = .tokenCount(targetTokens: 6, overlapTokens: 0)
+
+        let content = "multi-chunk remember must keep one parent document plus each child chunk frame"
+        let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)
+        #expect(chunks.count >= 2)
+
+        let orchestrator = try await MemoryOrchestrator(at: url, config: config)
+        let before = await orchestrator.runtimeStats()
+        try await orchestrator.remember(content, metadata: ["source": "multi-chunk-test"])
+        try await orchestrator.flush()
+        let after = await orchestrator.runtimeStats()
+
+        let expected = UInt64(chunks.count + 1)
+        #expect(after.frameCount == before.frameCount + expected)
+
+        try await orchestrator.close()
+
+        let wax = try await Wax.open(at: url)
+        let doc = try await wax.frameMeta(frameId: 0)
+        #expect(doc.role == .document)
+        for index in chunks.indices {
+            let chunkMeta = try await wax.frameMeta(frameId: UInt64(index + 1))
+            #expect(chunkMeta.role == .chunk)
+            #expect(chunkMeta.parentId == 0)
+            #expect(chunkMeta.chunkIndex == UInt32(index))
+            #expect(chunkMeta.chunkCount == UInt32(chunks.count))
+        }
+        try await wax.close()
+    }
+}
+
+@Test
+func singleChunkRememberRepairsUnsearchableDocument() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = true
+        config.enableTextSearch = true
+
+        let content = "repair-canary-a91c2e incomplete single-chunk must become searchable"
+        let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)
+        #expect(chunks.count == 1)
+
+        let hash = ContentHasher.hash(Data(content.utf8)).hexString
+        let metadata = ["source": "incomplete-single-chunk"]
+        let wax = try await Wax.create(at: url)
+        _ = try await wax.put(
+            Data(content.utf8),
+            options: FrameMetaSubset(
+                role: .document,
+                metadata: Metadata([
+                    "source": "incomplete-single-chunk",
+                    "wax.content.hash": hash,
+                ])
+            )
+        )
+        try await wax.commit()
+        try await wax.close()
+
+        let orchestrator = try await MemoryOrchestrator(
+            at: url,
+            config: config,
+            embedder: DeterministicTextEmbedder()
+        )
+        let beforeHits = try await orchestrator.search(
+            query: "repair-canary-a91c2e",
+            mode: .text,
+            topK: 5
+        )
+        #expect(beforeHits.isEmpty)
+
+        let before = await orchestrator.runtimeStats()
+        #expect(before.frameCount == 1)
+
+        try await orchestrator.remember(content, metadata: metadata)
+        try await orchestrator.flush()
+        let after = await orchestrator.runtimeStats()
+        #expect(after.frameCount == before.frameCount)
+
+        let textHits = try await orchestrator.search(
+            query: "repair-canary-a91c2e",
+            mode: .text,
+            topK: 5
+        )
+        #expect(!textHits.isEmpty)
+
+        let vectorHits = try await orchestrator.search(
+            query: "repair-canary-a91c2e",
+            mode: .vector,
+            topK: 5
+        )
+        #expect(!vectorHits.isEmpty)
+
+        try await orchestrator.remember(content, metadata: metadata)
+        try await orchestrator.flush()
+        let afterDuplicate = await orchestrator.runtimeStats()
+        #expect(afterDuplicate.frameCount == after.frameCount)
+
+        try await orchestrator.close()
+    }
+}
+
+@Test
+func singleChunkRememberIndexesDocumentForVectorSearch() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = true
+        config.enableTextSearch = true
+
+        let content = "vector canary-7f3a91 single searchable document frame"
+        let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)
+        #expect(chunks.count == 1)
+
+        let orchestrator = try await MemoryOrchestrator(
+            at: url,
+            config: config,
+            embedder: DeterministicTextEmbedder()
+        )
+        try await orchestrator.remember(content, metadata: ["source": "single-chunk-vector"])
+        try await orchestrator.flush()
+
+        let after = await orchestrator.runtimeStats()
+        #expect(after.frameCount == 1)
+
+        let textHits = try await orchestrator.search(query: "canary-7f3a91", mode: .text, topK: 5)
+        #expect(!textHits.isEmpty)
+
+        let vectorHits = try await orchestrator.search(query: "canary-7f3a91", mode: .vector, topK: 5)
+        #expect(!vectorHits.isEmpty)
+
+        try await orchestrator.remember(content, metadata: ["source": "single-chunk-vector"])
+        try await orchestrator.flush()
+        let afterRematch = await orchestrator.runtimeStats()
+        #expect(afterRematch.frameCount == 1)
+
+        try await orchestrator.close()
+    }
+}

--- a/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
+++ b/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
@@ -191,3 +191,26 @@ func singleChunkRememberIndexesDocumentForVectorSearch() async throws {
         try await orchestrator.close()
     }
 }
+
+@Test
+func singleChunkRememberIsEligibleForSurrogateMaintenance() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        config.enableTextSearch = true
+
+        let content = "surrogate-canary-b4e18c single-chunk remember must still be a surrogate source"
+        let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)
+        #expect(chunks.count == 1)
+
+        let orchestrator = try await MemoryOrchestrator(at: url, config: config)
+        try await orchestrator.remember(content, metadata: ["source": "single-chunk-surrogate"])
+        try await orchestrator.flush()
+
+        let report = try await orchestrator.optimizeSurrogates()
+        #expect(report.generatedSurrogates == 1)
+        #expect(report.eligibleFrames == 1)
+
+        try await orchestrator.close()
+    }
+}


### PR DESCRIPTION
## Why

Operator review: every `remember` reported `framesAdded: 2`, and long-term health showed exact-dupe pairs.

## Change

Single-chunk remember writes one document with text + vector index. No identical child chunk. Rematch of the same content adds 0 frames (including the vector path). Incomplete documents are repaired in place instead of treated as done.

## Test

`swift test --filter singleChunkRemember`
`swift test --filter singleChunkRememberIndexesDocumentForVectorSearch`

## Review

Dual PASS after two safety/behavior fix rounds (searchable short-circuit + vector rematch metadata).