### PR TITLE
release: waxmcp v0.1.27

### DIFF
--- a/.pi/extensions/wax-agents/package.json
+++ b/.pi/extensions/wax-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-agents",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Wax-specific multi-agent orchestration for pi",
   "dependencies": {
     "typebox": "^1.0.0"

--- a/Resources/hermes/README.md
+++ b/Resources/hermes/README.md
@@ -98,7 +98,7 @@ Add to your Hermes `$HERMES_HOME/config.yaml`:
 mcp_servers:
   wax-memory:
     command: "npx"
-    args: ["-y", "waxmcp@0.1.26", "mcp", "serve"]
+    args: ["-y", "waxmcp@0.1.27", "mcp", "serve"]
     env:
       WAX_MCP_FEATURE_LICENSE: "0"
       WAX_MCP_FEATURE_STRUCTURED_MEMORY: "1"
@@ -115,7 +115,7 @@ mcp_servers:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `command` | `npx` | Launcher for waxmcp |
-| `args` | `["-y", "waxmcp@0.1.26", "mcp", "serve"]` | Arguments passed to waxmcp |
+| `args` | `["-y", "waxmcp@0.1.27", "mcp", "serve"]` | Arguments passed to waxmcp |
 | `env.WAX_MCP_FEATURE_LICENSE` | `"0"` | Disable license checks |
 | `env.WAX_MCP_FEATURE_STRUCTURED_MEMORY` | `"1"` | Enable structured memory tools |
 | `timeout` | `120` | MCP call timeout in seconds |

--- a/Resources/hermes/wax-memory-plugin/plugin.yaml
+++ b/Resources/hermes/wax-memory-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.26
+version: 0.1.27
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -1,8 +1,8 @@
 class Wax < Formula
   desc "On-device memory and RAG framework with MCP server for Claude Code"
   homepage "https://github.com/christopherkarani/Wax"
-  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.26.tar.gz"
-  sha256 "ef853b9060f04d2fea437c3c03977396126ce1c55614b37ccd3d3612e216c810"
+  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.27.tar.gz"
+  sha256 "2faf1add2deaeb02f00b0187406492255b75075aea3133e057053cd1e62e7bcc"
   license "MIT"
 
   depends_on xcode: ["16.3", :build]

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxmcp",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "npx launcher for the Wax MCP server",
   "repository": {
     "type": "git",

--- a/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
+++ b/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.26
+version: 0.1.27
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/openclaw/wax-memory-plugin/package.json
+++ b/Resources/openclaw/wax-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wax/openclaw-wax-memory",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "description": "OpenClaw memory plugin for Wax-backed agent memory.",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "openclaw": ">=2026.3.24-beta.2"
   },
   "dependencies": {
-    "waxmcp": "0.1.26"
+    "waxmcp": "0.1.27"
   },
   "devDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -23,7 +23,7 @@ import WaxVectorSearchArctic
 #endif
 
 enum WaxMCPServerMetadata {
-    static let version = "0.1.26"
+    static let version = "0.1.27"
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -293,12 +293,17 @@ if [[ -f "$HERMES_README" ]]; then
   info "Hermes README → $TARGET_VERSION"
 fi
 
-# Surface 9: Hermes plugin
+# Surface 9: Hermes plugin (canonical + npm ship copy must stay byte-identical)
 if [[ -f "$HERMES_PLUGIN/plugin.yaml" ]] && [[ "$CURRENT_HERMES" != "$TARGET_VERSION" ]]; then
   sed_inplace \
     "s|^version: [0-9]+\\.[0-9]+\\.[0-9]+|version: ${TARGET_VERSION}|" \
     "$HERMES_PLUGIN/plugin.yaml"
   info "Hermes plugin → $TARGET_VERSION"
+  NPM_HERMES_PLUGIN="$ROOT/Resources/npm/waxmcp/plugins/hermes/plugin.yaml"
+  if [[ -f "$NPM_HERMES_PLUGIN" ]]; then
+    cp "$HERMES_PLUGIN/plugin.yaml" "$NPM_HERMES_PLUGIN"
+    info "Hermes npm ship copy → $TARGET_VERSION"
+  fi
 fi
 
 # ── Phase 6: Summary ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Cut **waxmcp / Wax 0.1.27** from current `main` (everything merged since `waxmcp-v0.1.26`).

Does **not** include open PR #113 (`feat/embedding-readiness`) or its uncommitted local work.

### Version surfaces
- `waxmcp` npm → 0.1.27
- `WaxMCPServerMetadata.version` → 0.1.27
- OpenClaw plugin + `waxmcp` dep → 0.1.27
- Homebrew formula URL → `waxmcp-v0.1.27`
- OpenCode extension → 0.1.27
- Hermes plugin (canonical + npm ship copy) → 0.1.27

### Since 0.1.26
- Hermes native MemoryProvider contract (#104)
- `session_resume` no longer leaks filesystem paths (#108)
- Single-chunk `remember` writes one searchable document (#110)
- `corpus_search` rebuild defaults to false (#107)
- Missing `fact_retract` id fails closed without wedging the queue (#106)
- Hybrid search no longer buries exact lexical canaries (#105)
- Ranked hits publish the score that actually ranked them (#111)
- OR-fallback single-token hits are not scored as perfect (#112)
- Linux `wax-cli` demo TUI (#84)

## Test plan
- [x] `scripts/validate-congruency.sh` → all surfaces 0.1.27
- [x] `bash Resources/scripts/quality/hermes_plugin_tests.sh`
- [ ] Tag `waxmcp-v0.1.27` triggers release workflow → `npm view waxmcp version` is `0.1.27`