### PR TITLE
fix(mcp): keep session recall and broker lifecycle honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,9 +315,9 @@ This is the **agent operator** skill (session lifecycle, remember/recall, handof
 Use the Wax MCP server for persistent memory in this repo.
 
 Workflow rules:
-- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
 - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
+- Use `recall` for assembled context and `search` for raw ranked hits. `recall` with `session_id` merges that session with durable long-term memory.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.

--- a/Resources/docs/wax-mcp-setup.md
+++ b/Resources/docs/wax-mcp-setup.md
@@ -62,9 +62,9 @@ Paste this into your repo prompt, `CLAUDE.md`, or `AGENTS.md` after installing W
 Use the Wax MCP server for persistent memory in this repo.
 
 Workflow rules:
-- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
 - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
+- Use `recall` for assembled context and `search` for raw ranked hits. `recall` with `session_id` merges that session with durable long-term memory.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.

--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -21,10 +21,10 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 
 1. **Start**
    - Call `handoff_latest` first (optionally with `project`) to load prior context.
-   - Call `session_start` once.
+   - Call `session_start` once. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
    - Keep the returned `session_id` for the rest of the session.
 2. **Work**
-   - Before answering from memory, call `recall` (default) or `search` (raw hits).
+   - Before answering from memory, call `recall` (default) or `search` (raw hits). `recall` with `session_id` merges that session with durable long-term memory.
    - When you learn something durable, call `remember` with concise factual text.
    - For session-scoped writes, pass `session_id` as a **top-level** argument.
    - Never put `session_id` inside `metadata`.

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -7,9 +7,9 @@ always-on instruction file after installing the Wax MCP server.
 Use the Wax MCP server for persistent memory in this repo.
 
 Workflow rules:
-- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
 - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
+- Use `recall` for assembled context and `search` for raw ranked hits. `recall` with `session_id` merges that session with durable long-term memory.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -21,10 +21,10 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 
 1. **Start**
    - Call `handoff_latest` first (optionally with `project`) to load prior context.
-   - Call `session_start` once.
+   - Call `session_start` once. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
    - Keep the returned `session_id` for the rest of the session.
 2. **Work**
-   - Before answering from memory, call `recall` (default) or `search` (raw hits).
+   - Before answering from memory, call `recall` (default) or `search` (raw hits). `recall` with `session_id` merges that session with durable long-term memory.
    - When you learn something durable, call `remember` with concise factual text.
    - For session-scoped writes, pass `session_id` as a **top-level** argument.
    - Never put `session_id` inside `metadata`.

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -7,9 +7,9 @@ always-on instruction file after installing the Wax MCP server.
 Use the Wax MCP server for persistent memory in this repo.
 
 Workflow rules:
-- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+- At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
 - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-- Use `recall` for assembled context and `search` for raw ranked hits.
+- Use `recall` for assembled context and `search` for raw ranked hits. `recall` with `session_id` merges that session with durable long-term memory.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.

--- a/Sources/Wax/Broker/AgentBrokerClient.swift
+++ b/Sources/Wax/Broker/AgentBrokerClient.swift
@@ -28,7 +28,7 @@ package enum AgentBrokerClient {
         envKey: "WAX_BROKER_SHUTDOWN_TIMEOUT_SECS",
         defaultValue: 2.0
     )
-    private static let responseTimeoutSeconds = configuredSeconds(
+    package static let responseTimeoutSeconds = configuredSeconds(
         envKey: "WAX_BROKER_RESPONSE_TIMEOUT_SECS",
         defaultValue: 30.0
     )
@@ -77,15 +77,17 @@ package enum AgentBrokerClient {
         if let response = try sendIfAvailable(
             AgentBrokerRequest(id: "__ping__", command: "stats"),
             socketPath: configuration.socketPath,
-            timeoutSeconds: min(5.0, responseTimeoutSeconds)
+            timeoutSeconds: min(5.0, responseTimeoutSeconds),
+            treatTimeoutAsUnavailable: true
         ), response.ok {
             return false
         }
 
-        if isConnectable(socketPath: configuration.socketPath) {
+        if isSocketLive(socketPath: configuration.socketPath) {
             if let response = try sendIfAvailable(
                 AgentBrokerRequest(id: "__ping__", command: "stats"),
-                socketPath: configuration.socketPath
+                socketPath: configuration.socketPath,
+                treatTimeoutAsUnavailable: true
             ), response.ok {
                 return false
             }
@@ -147,7 +149,12 @@ package enum AgentBrokerClient {
                 AgentBrokerRequest(id: "__ping__", command: "stats"),
                 socketPath: configuration.socketPath
             ), response.ok {
-                return true
+                if !process.isRunning {
+                    return false
+                }
+                // Bind-first loser may still be exiting after the winner answered.
+                Thread.sleep(forTimeInterval: 0.05)
+                return process.isRunning
             }
 
             if !process.isRunning {
@@ -220,7 +227,9 @@ package enum AgentBrokerClient {
         return true
     }
 
-    private static func isConnectable(socketPath: String) -> Bool {
+    /// Returns whether a Unix-domain listener is accepting connections at `socketPath`.
+    /// Never creates, replaces, or unlinks the path.
+    package static func isSocketLive(socketPath: String) -> Bool {
         guard FileManager.default.fileExists(atPath: socketPath) else { return false }
         let fd = socket(AF_UNIX, unixStreamSocketType, 0)
         guard fd >= 0 else { return false }
@@ -250,7 +259,8 @@ package enum AgentBrokerClient {
     private static func sendIfAvailable(
         _ request: AgentBrokerRequest,
         socketPath: String,
-        timeoutSeconds: Double? = nil
+        timeoutSeconds: Double? = nil,
+        treatTimeoutAsUnavailable: Bool = false
     ) throws -> AgentBrokerResponse? {
         guard FileManager.default.fileExists(atPath: socketPath) else {
             return nil
@@ -286,7 +296,6 @@ package enum AgentBrokerClient {
         }
         guard connectResult == 0 else {
             if errno == ECONNREFUSED || errno == ENOENT {
-                try? FileManager.default.removeItem(atPath: socketPath)
                 return nil
             }
             throw BrokerClientError("Unable to connect to broker socket at \(socketPath)")
@@ -298,19 +307,30 @@ package enum AgentBrokerClient {
         handle.write(Data([0x0A]))
         shutdown(fd, socketShutdownWrite)
 
-        guard let line = try readSocketResponseLine(fd: fd, timeoutSeconds: timeoutSeconds ?? responseTimeoutSeconds) else {
+        guard let line = try readSocketResponseLine(
+            fd: fd,
+            timeoutSeconds: timeoutSeconds ?? responseTimeoutSeconds,
+            treatTimeoutAsUnavailable: treatTimeoutAsUnavailable
+        ) else {
             return nil
         }
         return try JSONDecoder().decode(AgentBrokerResponse.self, from: Data(line.utf8))
     }
 
-    private static func readSocketResponseLine(fd: Int32, timeoutSeconds: Double? = nil) throws -> String? {
+    private static func readSocketResponseLine(
+        fd: Int32,
+        timeoutSeconds: Double? = nil,
+        treatTimeoutAsUnavailable: Bool = false
+    ) throws -> String? {
         var buffer = Data()
         let timeoutMS = Int32((timeoutSeconds ?? responseTimeoutSeconds) * 1000)
         while true {
             var descriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
             let pollResult = poll(&descriptor, 1, timeoutMS)
             if pollResult == 0 {
+                if treatTimeoutAsUnavailable {
+                    return nil
+                }
                 throw BrokerClientError("Timed out waiting for broker response")
             }
             if pollResult < 0 {

--- a/Sources/Wax/Broker/AgentBrokerClient.swift
+++ b/Sources/Wax/Broker/AgentBrokerClient.swift
@@ -76,9 +76,22 @@ package enum AgentBrokerClient {
     package static func ensureAvailable(configuration: AgentBrokerConfiguration) async throws -> Bool {
         if let response = try sendIfAvailable(
             AgentBrokerRequest(id: "__ping__", command: "stats"),
-            socketPath: configuration.socketPath
+            socketPath: configuration.socketPath,
+            timeoutSeconds: min(5.0, responseTimeoutSeconds)
         ), response.ok {
             return false
+        }
+
+        if isConnectable(socketPath: configuration.socketPath) {
+            if let response = try sendIfAvailable(
+                AgentBrokerRequest(id: "__ping__", command: "stats"),
+                socketPath: configuration.socketPath
+            ), response.ok {
+                return false
+            }
+            throw BrokerClientError(
+                "Broker socket is live at \(configuration.socketPath) but did not answer; not starting a second daemon."
+            )
         }
 
         return try startBrokerIfNeeded(configuration: configuration)
@@ -104,7 +117,6 @@ package enum AgentBrokerClient {
             "--embedder", configuration.embedderChoice,
             "--socket-path", configuration.socketPath,
             "--idle-timeout-secs", String(idleTimeoutSeconds),
-            "--skip-prewarm",
         ]
         process.arguments?.append(contentsOf: configuration.embedderTuning.daemonArguments())
         if configuration.noEmbedder {
@@ -208,9 +220,37 @@ package enum AgentBrokerClient {
         return true
     }
 
+    private static func isConnectable(socketPath: String) -> Bool {
+        guard FileManager.default.fileExists(atPath: socketPath) else { return false }
+        let fd = socket(AF_UNIX, unixStreamSocketType, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var address = sockaddr_un()
+        #if canImport(Darwin)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        #endif
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(socketPath.utf8)
+        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else { return false }
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.initializeMemory(as: CChar.self, repeating: 0)
+            for (index, byte) in pathBytes.enumerated() {
+                buffer[index] = byte
+            }
+        }
+        let connectResult = withUnsafePointer(to: &address) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        return connectResult == 0
+    }
+
     private static func sendIfAvailable(
         _ request: AgentBrokerRequest,
-        socketPath: String
+        socketPath: String,
+        timeoutSeconds: Double? = nil
     ) throws -> AgentBrokerResponse? {
         guard FileManager.default.fileExists(atPath: socketPath) else {
             return nil
@@ -258,15 +298,15 @@ package enum AgentBrokerClient {
         handle.write(Data([0x0A]))
         shutdown(fd, socketShutdownWrite)
 
-        guard let line = try readSocketResponseLine(fd: fd) else {
+        guard let line = try readSocketResponseLine(fd: fd, timeoutSeconds: timeoutSeconds ?? responseTimeoutSeconds) else {
             return nil
         }
         return try JSONDecoder().decode(AgentBrokerResponse.self, from: Data(line.utf8))
     }
 
-    private static func readSocketResponseLine(fd: Int32) throws -> String? {
+    private static func readSocketResponseLine(fd: Int32, timeoutSeconds: Double? = nil) throws -> String? {
         var buffer = Data()
-        let timeoutMS = Int32(responseTimeoutSeconds * 1000)
+        let timeoutMS = Int32((timeoutSeconds ?? responseTimeoutSeconds) * 1000)
         while true {
             var descriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
             let pollResult = poll(&descriptor, 1, timeoutMS)

--- a/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
+++ b/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
@@ -17,7 +17,7 @@ package enum AgentBrokerCommandSurface {
         "knowledge_capture": ["content", "metadata", "memory_type", "durability", "project", "repo", "confidence", "reviewed", "locked", "subject", "kind", "aliases", "predicate", "object"],
         "corpus_search": ["query", "rebuild", "recursive", "mode", "alpha", "topK"],
         "stats": [],
-        "session_start": ["session_id", "agent_id", "run_id"],
+        "session_start": ["session_id", "agent_id", "run_id", "cwd"],
         "session_resume": ["session_id", "agent_id", "run_id"],
         "session_end": ["session_id"],
         "handoff": ["content", "session_id", "project", "pending_tasks"],

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -279,8 +279,55 @@ extension AgentBrokerService {
         )
         try validateDurableWriteContent(content: content, metadata: metadata)
         let memory = try await memory(for: sessionID)
+        if let sessionID {
+            try await refreshSessionManifest(sessionID)
+        }
 
         let before = await memory.runtimeStats()
+        if !noEmbedder, before.vectorSearchEnabled, !before.queryEmbedderConfigured {
+            let capturedSessionID = sessionID
+            let capturedContent = content
+            let capturedMetadata = metadata
+            Task {
+                try? await self.completeRemember(
+                    memory: memory,
+                    content: capturedContent,
+                    metadata: capturedMetadata,
+                    sessionID: capturedSessionID
+                )
+            }
+            return .object([
+                "status": .string("pending"),
+                "embedding_state": .string("loading"),
+                "framesAdded": .from(0),
+                "frameCount": .from(before.frameCount),
+                "pendingFrames": .from(before.pendingFrames),
+                "display_text": .string("Remember accepted. Embedding provider is still loading; the frame will land when ready."),
+            ])
+        }
+
+        return try await completeRemember(
+            memory: memory,
+            content: content,
+            metadata: metadata,
+            sessionID: sessionID,
+            before: before
+        )
+    }
+
+    func completeRemember(
+        memory: MemoryOrchestrator,
+        content: String,
+        metadata: [String: String],
+        sessionID: UUID?,
+        before: MemoryOrchestrator.RuntimeStats? = nil
+    ) async throws -> AgentBrokerValue {
+        let beforeStats: MemoryOrchestrator.RuntimeStats
+        if let before {
+            beforeStats = before
+        } else {
+            beforeStats = await memory.runtimeStats()
+        }
         try await memory.remember(content, metadata: metadata)
         if let sessionID {
             try await refreshSessionManifest(sessionID)
@@ -296,7 +343,7 @@ extension AgentBrokerService {
         }
         try await memory.flush()
         let after = await memory.runtimeStats()
-        let totalBefore = before.frameCount + before.pendingFrames
+        let totalBefore = beforeStats.frameCount + beforeStats.pendingFrames
         let totalAfter = after.frameCount + after.pendingFrames
         let added = totalAfter >= totalBefore ? (totalAfter - totalBefore) : 0
 
@@ -315,13 +362,13 @@ extension AgentBrokerService {
 
     func recall(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
-        let query = try args.requiredString("query", maxBytes: Self.maxContentBytes)
+        let query = try requireNonEmptyQuery(args)
         let limit = try args.optionalInt("limit") ?? 5
         guard (1...Self.maxRecallLimit).contains(limit) else {
             throw BrokerValidationError.invalid("limit must be between 1 and \(Self.maxRecallLimit)")
         }
         let parsedFilters = try parseSearchFilters(args)
-        let memory = try await memory(for: parsedFilters.sessionId)
+        let sessionMemory = parsedFilters.sessionId == nil ? nil : try await memory(for: parsedFilters.sessionId)
 
         let mode = try parseRecallMode(args)
         let requestedTopK = try args.optionalInt("search_top_k") ?? (try args.optionalInt("topK"))
@@ -337,21 +384,61 @@ extension AgentBrokerService {
         case .hybrid?, nil:
             .ifAvailable
         }
-        let execution = try await memory.recallExecution(
+
+        let durableExecution = try await longTermMemory.recallExecution(
             query: query,
             embeddingPolicy: embeddingPolicy,
-            frameFilter: parsedFilters.frameFilter,
+            frameFilter: parsedFilters.sessionId == nil ? parsedFilters.frameFilter : nil,
             timeRange: parsedFilters.timeRange,
             topK: effectiveTopK,
             mode: mode
         )
-        let context = execution.context
-        let selected = Array(context.items.prefix(limit))
+        let sessionExecution: MemoryOrchestrator.RecallExecution?
+        var sessionItems: [RAGContext.Item] = []
+        if let sessionMemory {
+            let execution = try await sessionMemory.recallExecution(
+                query: query,
+                embeddingPolicy: embeddingPolicy,
+                frameFilter: parsedFilters.frameFilter,
+                timeRange: parsedFilters.timeRange,
+                topK: effectiveTopK,
+                mode: mode
+            )
+            sessionExecution = execution
+            sessionItems = execution.context.items
+            if sessionItems.isEmpty {
+                let documents = try await sessionMemory.corpusSourceDocuments()
+                    .sorted { lhs, rhs in
+                        if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
+                        return lhs.frameId > rhs.frameId
+                    }
+                sessionItems = documents.prefix(effectiveTopK).map { document in
+                    RAGContext.Item(
+                        kind: .snippet,
+                        frameId: document.frameId,
+                        score: 0.2,
+                        sources: [.text],
+                        text: document.text,
+                        metadata: document.metadata,
+                        explanations: ["current session", "recent session note"]
+                    )
+                }
+            }
+        } else {
+            sessionExecution = nil
+        }
+
+        let selected = Self.mergeRecallItems(
+            sessionItems: sessionItems,
+            durableItems: durableExecution.context.items,
+            limit: limit
+        )
+        let primaryExecution = sessionExecution ?? durableExecution
         var lines: [String] = [
-            "Query: \(context.query)",
-            "Total tokens: \(context.totalTokens)",
-            "Results: \(selected.count) of \(limit) requested (orchestrator returned \(context.items.count))",
-            "Search controls: requested_mode=\(execution.requestedModeSummary) effective_mode=\(execution.effectiveModeSummary) query_embedding_state=\(execution.queryEmbeddingState.rawValue) search_top_k=\(effectiveTopK) limit=\(limit)",
+            "Query: \(query)",
+            "Total tokens: \(selected.reduce(0) { $0 + max(1, $1.text.split(whereSeparator: \.isWhitespace).count) })",
+            "Results: \(selected.count) of \(limit) requested (orchestrator returned \(selected.count))",
+            "Search controls: requested_mode=\(primaryExecution.requestedModeSummary) effective_mode=\(primaryExecution.effectiveModeSummary) query_embedding_state=\(primaryExecution.queryEmbeddingState.rawValue) search_top_k=\(effectiveTopK) limit=\(limit)",
         ]
         lines.append("Applied filters: \(parsedFilters.summary.debugJSONString)")
         for (index, item) in selected.enumerated() {
@@ -370,34 +457,89 @@ extension AgentBrokerService {
                 "explanations": .array(item.explanations.map(AgentBrokerValue.string)),
             ])
         }
-        if let sessionID = parsedFilters.sessionId {
+        if let sessionID = parsedFilters.sessionId, let sessionMemory {
             try await refreshSessionManifest(sessionID)
             try await recordRetrievalHits(
                 sessionID: sessionID,
                 query: query,
                 hits: selected.map { ($0.frameId, $0.score) },
-                memory: memory
+                memory: sessionMemory
             )
         }
 
         return .object([
-            "query": .string(context.query),
-            "total_tokens": .from(context.totalTokens),
+            "query": .string(query),
+            "total_tokens": .from(selected.reduce(0) { $0 + max(1, $1.text.split(whereSeparator: \.isWhitespace).count) }),
             "result_count": .from(selected.count),
             "limit": .from(limit),
             "search_top_k": .from(effectiveTopK),
-            "requested_mode": .string(execution.requestedModeSummary),
-            "effective_mode": .string(execution.effectiveModeSummary),
-            "query_embedding_state": .string(execution.queryEmbeddingState.rawValue),
+            "requested_mode": .string(primaryExecution.requestedModeSummary),
+            "effective_mode": .string(primaryExecution.effectiveModeSummary),
+            "query_embedding_state": .string(primaryExecution.queryEmbeddingState.rawValue),
             "applied_filters": parsedFilters.summary,
             "results": .array(results),
             "display_text": .string(lines.joined(separator: "\n")),
         ])
     }
 
+    package static func mergeRecallItems(
+        sessionItems: [RAGContext.Item],
+        durableItems: [RAGContext.Item],
+        limit: Int
+    ) -> [RAGContext.Item] {
+        func identity(_ item: RAGContext.Item) -> String {
+            if let hash = item.metadata["wax.content.hash"] {
+                return hash
+            }
+            return item.text
+        }
+
+        let sessionTagged = sessionItems.map { item -> RAGContext.Item in
+            var copy = item
+            copy.score += 0.12
+            if !copy.explanations.contains("current session") {
+                copy.explanations = ["current session"] + copy.explanations
+            }
+            return copy
+        }
+        let durableTagged = durableItems.map { item -> RAGContext.Item in
+            var copy = item
+            if !copy.explanations.contains("durable memory") {
+                copy.explanations = ["durable memory"] + copy.explanations
+            }
+            return copy
+        }
+
+        var seen = Set<String>()
+        var merged: [RAGContext.Item] = []
+        let ranked = (sessionTagged + durableTagged).sorted { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.frameId < rhs.frameId
+        }
+        for item in ranked {
+            guard seen.insert(identity(item)).inserted else { continue }
+            merged.append(item)
+            if merged.count >= limit { break }
+        }
+
+        func ensureHorizon(from items: [RAGContext.Item], marker: String) {
+            guard merged.count < limit else { return }
+            guard !merged.contains(where: { $0.explanations.contains(marker) }) else { return }
+            guard let extra = items.first(where: { !seen.contains(identity($0)) }) else { return }
+            seen.insert(identity(extra))
+            merged.append(extra)
+        }
+        ensureHorizon(from: sessionTagged, marker: "current session")
+        ensureHorizon(from: durableTagged, marker: "durable memory")
+        if merged.count > limit {
+            merged = Array(merged.prefix(limit))
+        }
+        return merged
+    }
+
     func search(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
-        let query = try args.requiredString("query", maxBytes: Self.maxContentBytes)
+        let query = try requireNonEmptyQuery(args)
         let modeRaw = try args.optionalString("mode")?.lowercased()
         let mode = try parseSearchMode(modeRaw: modeRaw, alpha: try args.optionalDouble("alpha"))
         let topK = try args.optionalInt("topK") ?? 10
@@ -450,7 +592,7 @@ extension AgentBrokerService {
 
     func memorySearch(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
-        let query = try args.requiredString("query", maxBytes: Self.maxContentBytes)
+        let query = try requireNonEmptyQuery(args)
         let topK = try args.optionalInt("topK") ?? 10
         guard (1...Self.maxTopK).contains(topK) else {
             throw BrokerValidationError.invalid("topK must be between 1 and \(Self.maxTopK)")
@@ -462,7 +604,8 @@ extension AgentBrokerService {
         let includeDurable = try args.optionalBool("include_durable") ?? true
         let sessionID = try resolveSessionID(
             try parseOptionalSessionID(args),
-            requiringUnambiguousWorkingMemory: includeWorking
+            requiringUnambiguousWorkingMemory: includeWorking,
+            allowDurableWithoutSession: includeDurable || includeEpisodic
         )
         let hits = try await layeredMemorySearch(
             query: query,
@@ -519,6 +662,9 @@ extension AgentBrokerService {
         let args = BrokerArguments(arguments)
         let sessionID = try parseOptionalSessionID(args)
         guard let resolvedSessionID = try resolveSessionID(sessionID) else {
+            if activeSessions.count > 1 {
+                throw BrokerValidationError.invalid("session_id is required when more than one session is active")
+            }
             throw BrokerValidationError.invalid("session_id is required when no active session is available")
         }
         guard let session = activeSessions[resolvedSessionID] else {
@@ -826,6 +972,17 @@ extension AgentBrokerService {
         ])
     }
 
+    package func prewarmEmbedder() async {
+        guard !noEmbedder else { return }
+        _ = try? await longTermMemory.searchExecution(
+            query: "wax",
+            mode: .hybrid(alpha: 0.5),
+            topK: 1,
+            frameFilter: nil,
+            timeRange: nil
+        )
+    }
+
     func flush() async throws -> AgentBrokerValue {
         try await longTermMemory.flush()
         for session in activeSessions.values {
@@ -845,9 +1002,23 @@ extension AgentBrokerService {
     func sessionStart(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
         let explicitSessionID = try parseOptionalSessionID(args)
+        let requestedAgentID = try args.optionalString("agent_id")
+        let requestedRunID = try args.optionalString("run_id")
+        let requestedCWD = try args.optionalString("cwd")
+        let inferredScope = requestedCWD.map {
+            MemorySemantics.inferScopeContext(currentDirectoryPath: $0)
+        } ?? scopeContext
+
+        if explicitSessionID == nil, let requestedAgentID, let requestedRunID,
+           let existing = try findActiveSession(agentID: requestedAgentID, runID: requestedRunID) {
+            return try await sessionResume(arguments: [
+                "session_id": .string(existing.sessionID.uuidString),
+            ])
+        }
+
         let sessionID = explicitSessionID ?? UUID()
         if let active = activeSessions[sessionID] {
-            return renderSessionLifecycleResult(state: active, resumed: false, recoveredLease: false)
+            return renderSessionLifecycleResult(state: active, resumed: true, recoveredLease: false)
         }
 
         let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
@@ -860,14 +1031,14 @@ extension AgentBrokerService {
         let memory = try await openSessionMemory(at: sessionURL)
 
         let nowMs = Self.nowMs()
-        let agentID = try args.optionalString("agent_id") ?? scopeContext.repoName ?? "wax-agent"
-        let runID = try args.optionalString("run_id") ?? UUID().uuidString
+        let agentID = requestedAgentID ?? inferredScope.repoName ?? "wax-agent"
+        let runID = requestedRunID ?? UUID().uuidString
         let manifest = BrokerSessionManifest(
             sessionID: sessionID,
             agentID: agentID,
             runID: runID,
-            project: scopeContext.projectName,
-            repo: scopeContext.repoName,
+            project: inferredScope.projectName,
+            repo: inferredScope.repoName,
             storePath: sessionURL.path,
             eventLogPath: eventLogURL.path,
             status: .active,
@@ -901,6 +1072,17 @@ extension AgentBrokerService {
         )
         activeSessions[sessionID] = state
         return renderSessionLifecycleResult(state: state, resumed: false, recoveredLease: false)
+    }
+
+    func findActiveSession(agentID: String, runID: String) throws -> BrokerSessionManifest? {
+        if let live = activeSessions.values.first(where: {
+            $0.manifest.agentID == agentID && $0.manifest.runID == runID
+        }) {
+            return live.manifest
+        }
+        return try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL).first { manifest in
+            manifest.status == .active && manifest.agentID == agentID && manifest.runID == runID
+        }
     }
 
     func sessionResume(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
@@ -1052,7 +1234,7 @@ extension AgentBrokerService {
 
     func compactContext(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
-        let query = try args.requiredString("query", maxBytes: Self.maxContentBytes)
+        let query = try requireNonEmptyQuery(args)
         let tokenBudget = try args.optionalInt("token_budget") ?? 1800
         guard (128...Self.maxCompactContextTokenBudget).contains(tokenBudget) else {
             throw BrokerValidationError.invalid("token_budget must be between 128 and \(Self.maxCompactContextTokenBudget)")
@@ -1224,13 +1406,13 @@ extension AgentBrokerService {
         }
         let subject = try args.optionalString("subject").map { EntityKey($0) }
         let predicate = try args.optionalString("predicate").map { PredicateKey($0) }
-        let asOfMs = try args.optionalInt64("as_of") ?? Int64.max
+        let asOfMs = try args.optionalInt64("as_of")
         let systemAsOfMs = try args.optionalInt64("system_as_of")
         let validAsOfMs = try args.optionalInt64("valid_as_of")
         let result = try await longTermMemory.facts(
             about: subject,
             predicate: predicate,
-            asOfMs: asOfMs,
+            asOfMs: asOfMs ?? Int64.max,
             systemAsOfMs: systemAsOfMs,
             validAsOfMs: validAsOfMs,
             limit: limit
@@ -1257,9 +1439,9 @@ extension AgentBrokerService {
         return .object([
             "count": .from(result.hits.count),
             "truncated": .from(result.wasTruncated),
-            "as_of": .from(asOfMs),
-            "system_as_of": .from(effectiveSystemAsOfMs),
-            "valid_as_of": .from(effectiveValidAsOfMs),
+            "as_of": asOfMs.map(AgentBrokerValue.from) ?? .null,
+            "system_as_of": effectiveSystemAsOfMs.map(AgentBrokerValue.from) ?? .null,
+            "valid_as_of": effectiveValidAsOfMs.map(AgentBrokerValue.from) ?? .null,
             "hits": .array(hits),
         ])
     }
@@ -1284,7 +1466,7 @@ extension AgentBrokerService {
 
     func corpusSearch(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
-        let query = try args.requiredString("query", maxBytes: Self.maxContentBytes)
+        let query = try requireNonEmptyQuery(args)
         let recursive = try args.optionalBool("recursive") ?? true
         let rebuild = try args.optionalBool("rebuild") ?? AgentBrokerCommandSurface.corpusSearchDefaultRebuild
         let modeRaw = try args.optionalString("mode")?.lowercased()
@@ -1349,7 +1531,38 @@ extension AgentBrokerService {
             $0.id.uuidString < $1.id.uuidString
         }
         var activeSessionHitGroups: [[BrokerCorpusMergeHit]] = []
-        activeSessionHitGroups.reserveCapacity(orderedActiveSessions.count)
+        let longTermExecution = try await longTermMemory.searchExecution(
+            query: query,
+            mode: mode,
+            topK: topK,
+            frameFilter: nil,
+            timeRange: nil
+        )
+        let longTermHits: [BrokerCorpusMergeHit] = longTermExecution.hits.map { hit in
+            let preview = hit.previewText ?? ""
+            let storePath = longTermStoreURL.path
+            var metadata = hit.metadata
+            metadata[BrokerCorpusMetadataKeys.origin] = "long_term"
+            metadata[BrokerCorpusMetadataKeys.sourceStorePath] = storePath
+            metadata[BrokerCorpusMetadataKeys.sourceStoreName] = longTermStoreURL.lastPathComponent
+            metadata[BrokerCorpusMetadataKeys.sourceFrameID] = String(hit.frameId)
+            return BrokerCorpusMergeHit(
+                frameId: hit.frameId,
+                score: hit.score,
+                sources: hit.sources.map(\.rawValue),
+                preview: preview,
+                metadata: metadata,
+                dedupeKey: BrokerCorpusMergeHit.makeDedupeKey(
+                    sourcePath: storePath,
+                    frameId: hit.frameId,
+                    preview: preview
+                )
+            )
+        }
+        if !longTermHits.isEmpty {
+            activeSessionHitGroups.append(longTermHits)
+        }
+        activeSessionHitGroups.reserveCapacity(orderedActiveSessions.count + 1)
         for state in orderedActiveSessions {
             let sessionExecution = try await state.memory.searchExecution(
                 query: query,
@@ -1822,6 +2035,29 @@ extension AgentBrokerService {
                     timestampMs: state.manifest.updatedAtMs
                 ))
             }
+            if short.isEmpty {
+                let documents = try await state.memory.corpusSourceDocuments()
+                    .sorted { lhs, rhs in
+                        if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
+                        return lhs.frameId > rhs.frameId
+                    }
+                for document in documents.prefix(min(4, maxItems)) {
+                    short.append(LayeredMemoryHit(
+                        reference: Self.makeMemoryReference(.working, sessionID: sessionID, frameID: document.frameId),
+                        horizon: .working,
+                        sessionID: sessionID,
+                        agentID: state.manifest.agentID,
+                        runID: state.manifest.runID,
+                        frameID: document.frameId,
+                        score: 0.2,
+                        text: document.text,
+                        preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
+                        metadata: document.metadata,
+                        explanations: ["current session", "recent session note"],
+                        timestampMs: document.timestampMs
+                    ))
+                }
+            }
         }
 
         let longExecution = try await longTermMemory.recallExecution(
@@ -2252,7 +2488,8 @@ extension AgentBrokerService {
 
     func resolveSessionID(
         _ explicit: UUID?,
-        requiringUnambiguousWorkingMemory includeWorking: Bool
+        requiringUnambiguousWorkingMemory includeWorking: Bool,
+        allowDurableWithoutSession: Bool = false
     ) throws -> UUID? {
         if let explicit { return explicit }
         guard includeWorking else { return nil }
@@ -2262,8 +2499,19 @@ extension AgentBrokerService {
         case 1:
             return activeSessions.keys.first
         default:
+            if allowDurableWithoutSession {
+                return nil
+            }
             throw BrokerValidationError.invalid("session_id is required when more than one session is active")
         }
+    }
+
+    func requireNonEmptyQuery(_ args: BrokerArguments) throws -> String {
+        let query = try args.requiredString("query", maxBytes: Self.maxContentBytes)
+        guard !query.isEmpty else {
+            throw BrokerValidationError.invalid("query must not be empty")
+        }
+        return query
     }
 
     struct ParsedSearchFilters {
@@ -2411,6 +2659,9 @@ extension AgentBrokerService {
             }
             return nil
         }
+        if alpha != nil, modeRaw != "hybrid" {
+            throw BrokerValidationError.invalid("alpha is only valid when mode=hybrid")
+        }
 
         switch modeRaw {
         case "text":
@@ -2428,8 +2679,12 @@ extension AgentBrokerService {
         modeRaw: String?,
         alpha: Double?
     ) throws -> MemoryOrchestrator.DirectSearchMode {
+        let resolvedMode = modeRaw ?? "text"
+        if alpha != nil, resolvedMode != "hybrid" {
+            throw BrokerValidationError.invalid("alpha is only valid when mode=hybrid")
+        }
         let validatedAlpha = try validatedHybridAlpha(alpha ?? 0.5)
-        switch modeRaw ?? "text" {
+        switch resolvedMode {
         case "text":
             return .text
         case "vector":

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -11,6 +11,11 @@ package actor AgentBrokerService {
         let memory: MemoryOrchestrator
     }
 
+    struct PendingRememberWrite: Sendable {
+        let sessionID: UUID?
+        let task: Task<Void, Error>
+    }
+
     let longTermMemory: MemoryOrchestrator
     let longTermStoreURL: URL
     let sessionRootURL: URL
@@ -23,6 +28,7 @@ package actor AgentBrokerService {
     let promotionSettings: BrokerPromotionSettings
     let brokerInstanceID = UUID().uuidString
     var activeSessions: [UUID: SessionState] = [:]
+    var pendingRememberWrites: [PendingRememberWrite] = []
 
     package init(
         storePath: String,
@@ -31,7 +37,8 @@ package actor AgentBrokerService {
         embedderChoice: String,
         requireVector: Bool,
         enableAccessStatsScoring: Bool = false,
-        embedderTuning: CommandLineEmbedderRuntimeTuning = .fromEnvironment()
+        embedderTuning: CommandLineEmbedderRuntimeTuning = .fromEnvironment(),
+        embedderOverride: (any EmbeddingProvider)? = nil
     ) async throws {
         self.longTermStoreURL = URL(fileURLWithPath: AgentBrokerPathing.expandPath(storePath)).standardizedFileURL
         self.sessionRootURL = URL(fileURLWithPath: AgentBrokerPathing.expandPath(sessionRootPath)).standardizedFileURL
@@ -51,11 +58,16 @@ package actor AgentBrokerService {
         let corpusFileName = ".corpus-\(Self.stableHash(longTermStoreURL.path)).wax"
         self.corpusStoreURL = sessionRootURL.deletingLastPathComponent().appendingPathComponent(corpusFileName)
 
-        let embedder = try await CommandLineEmbedderFactory.buildEmbedder(
-            noEmbedder: noEmbedder,
-            embedderChoice: embedderChoice,
-            tuning: embedderTuning
-        )
+        let embedder: (any EmbeddingProvider)?
+        if let embedderOverride {
+            embedder = embedderOverride
+        } else {
+            embedder = try await CommandLineEmbedderFactory.buildEmbedder(
+                noEmbedder: noEmbedder,
+                embedderChoice: embedderChoice,
+                tuning: embedderTuning
+            )
+        }
         if requireVector {
             if noEmbedder {
                 throw BrokerStartupError("Vector search required but --no-embedder was set.")
@@ -81,6 +93,12 @@ package actor AgentBrokerService {
     }
 
     package func close() async throws {
+        var pendingError: Error?
+        do {
+            try await settlePendingRememberWrites()
+        } catch {
+            pendingError = error
+        }
         for session in activeSessions.values {
             try? await session.memory.flush()
             try? await session.memory.close()
@@ -88,6 +106,9 @@ package actor AgentBrokerService {
         activeSessions.removeAll()
         try await longTermMemory.flush()
         try await longTermMemory.close()
+        if let pendingError {
+            throw pendingError
+        }
     }
 
     package func handle(_ request: AgentBrokerRequest) async -> AgentBrokerResponse {
@@ -275,7 +296,7 @@ extension AgentBrokerService {
             metadata: rawMetadata,
             semantics: writeSemantics,
             sessionID: sessionID,
-            inferredScope: scopeContext
+            inferredScope: writeScope(for: sessionID)
         )
         try validateDurableWriteContent(content: content, metadata: metadata)
         let memory = try await memory(for: sessionID)
@@ -284,18 +305,19 @@ extension AgentBrokerService {
         }
 
         let before = await memory.runtimeStats()
-        if !noEmbedder, before.vectorSearchEnabled, !before.queryEmbedderConfigured {
+        if !noEmbedder, before.vectorSearchEnabled, !before.queryEmbedderReady {
             let capturedSessionID = sessionID
             let capturedContent = content
             let capturedMetadata = metadata
-            Task {
-                try? await self.completeRemember(
+            let task = Task<Void, Error> {
+                _ = try await self.completeRemember(
                     memory: memory,
                     content: capturedContent,
                     metadata: capturedMetadata,
                     sessionID: capturedSessionID
                 )
             }
+            pendingRememberWrites.append(PendingRememberWrite(sessionID: sessionID, task: task))
             return .object([
                 "status": .string("pending"),
                 "embedding_state": .string("loading"),
@@ -388,7 +410,7 @@ extension AgentBrokerService {
         let durableExecution = try await longTermMemory.recallExecution(
             query: query,
             embeddingPolicy: embeddingPolicy,
-            frameFilter: parsedFilters.sessionId == nil ? parsedFilters.frameFilter : nil,
+            frameFilter: parsedFilters.frameFilter,
             timeRange: parsedFilters.timeRange,
             topK: effectiveTopK,
             mode: mode
@@ -462,7 +484,10 @@ extension AgentBrokerService {
             try await recordRetrievalHits(
                 sessionID: sessionID,
                 query: query,
-                hits: selected.map { ($0.frameId, $0.score) },
+                hits: selected.compactMap { item in
+                    guard item.explanations.contains("current session") else { return nil }
+                    return (item.frameId, item.score)
+                },
                 memory: sessionMemory
             )
         }
@@ -523,9 +548,23 @@ extension AgentBrokerService {
         }
 
         func ensureHorizon(from items: [RAGContext.Item], marker: String) {
-            guard merged.count < limit else { return }
+            guard !items.isEmpty else { return }
             guard !merged.contains(where: { $0.explanations.contains(marker) }) else { return }
-            guard let extra = items.first(where: { !seen.contains(identity($0)) }) else { return }
+            guard let extra = items
+                .filter({ !seen.contains(identity($0)) })
+                .max(by: { lhs, rhs in
+                    if lhs.score != rhs.score { return lhs.score < rhs.score }
+                    return lhs.frameId > rhs.frameId
+                })
+            else { return }
+
+            if merged.count >= limit {
+                guard let evictIndex = merged.lastIndex(where: { !$0.explanations.contains(marker) }) else {
+                    return
+                }
+                let evicted = merged.remove(at: evictIndex)
+                seen.remove(identity(evicted))
+            }
             seen.insert(identity(extra))
             merged.append(extra)
         }
@@ -533,6 +572,10 @@ extension AgentBrokerService {
         ensureHorizon(from: durableTagged, marker: "durable memory")
         if merged.count > limit {
             merged = Array(merged.prefix(limit))
+        }
+        merged.sort { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.frameId < rhs.frameId
         }
         return merged
     }
@@ -599,14 +642,37 @@ extension AgentBrokerService {
         }
         let modeRaw = try args.optionalString("mode")?.lowercased()
         let mode = try parseSearchMode(modeRaw: modeRaw, alpha: try args.optionalDouble("alpha"))
-        let includeWorking = try args.optionalBool("include_working") ?? true
-        let includeEpisodic = try args.optionalBool("include_episodic") ?? true
-        let includeDurable = try args.optionalBool("include_durable") ?? true
-        let sessionID = try resolveSessionID(
-            try parseOptionalSessionID(args),
-            requiringUnambiguousWorkingMemory: includeWorking,
-            allowDurableWithoutSession: includeDurable || includeEpisodic
-        )
+        let requestedWorking = try args.optionalBool("include_working") ?? true
+        let requestedEpisodic = try args.optionalBool("include_episodic") ?? true
+        let requestedDurable = try args.optionalBool("include_durable") ?? true
+        let policy: SessionResolutionPolicy
+        if requestedWorking || requestedEpisodic {
+            policy = requestedDurable ? .durableOnlyWhenAmbiguous : .requireUnambiguousWorking
+        } else {
+            policy = .unscoped
+        }
+        let scope = try resolveSessionScope(try parseOptionalSessionID(args), policy: policy)
+        let sessionID: UUID?
+        let includeWorking: Bool
+        let includeEpisodic: Bool
+        let includeDurable: Bool
+        switch scope {
+        case .session(let resolved):
+            sessionID = resolved
+            includeWorking = requestedWorking
+            includeEpisodic = requestedEpisodic
+            includeDurable = requestedDurable
+        case .durableOnly:
+            sessionID = nil
+            includeWorking = false
+            includeEpisodic = false
+            includeDurable = true
+        case .none:
+            sessionID = nil
+            includeWorking = false
+            includeEpisodic = requestedEpisodic
+            includeDurable = requestedDurable
+        }
         let hits = try await layeredMemorySearch(
             query: query,
             mode: mode,
@@ -623,7 +689,10 @@ extension AgentBrokerService {
             try await recordRetrievalHits(
                 sessionID: sessionID,
                 query: query,
-                hits: hits.map { ($0.frameID, $0.score) },
+                hits: hits.compactMap { hit in
+                    guard hit.horizon == .working else { return nil }
+                    return (hit.frameID, hit.score)
+                },
                 memory: sessionMemory
             )
         }
@@ -738,7 +807,7 @@ extension AgentBrokerService {
             metadata: baseMetadata,
             semantics: writeSemantics,
             sessionID: nil,
-            inferredScope: scopeContext
+            inferredScope: writeScope(for: resolvedPromotionSessionID)
         )
         if let resolvedPromotionSessionID {
             normalizedMetadata[MemoryMetadataKeys.promotedFromSession] = resolvedPromotionSessionID.uuidString
@@ -941,7 +1010,7 @@ extension AgentBrokerService {
             "storePath": .string(stats.storeURL.path),
             "vectorSearchEnabled": .from(stats.vectorSearchEnabled),
             "queryEmbeddingAvailable": .from(
-                stats.vectorSearchEnabled && stats.queryEmbedderConfigured && !stats.queryEmbeddingCircuitOpen
+                stats.vectorSearchEnabled && stats.queryEmbedderReady && !stats.queryEmbeddingCircuitOpen
             ),
             "queryEmbeddingCircuitOpen": .from(stats.queryEmbeddingCircuitOpen),
             "features": .object([
@@ -984,6 +1053,7 @@ extension AgentBrokerService {
     }
 
     func flush() async throws -> AgentBrokerValue {
+        try await settlePendingRememberWrites()
         try await longTermMemory.flush()
         for session in activeSessions.values {
             try await session.memory.flush()
@@ -1162,6 +1232,7 @@ extension AgentBrokerService {
             throw BrokerValidationError.invalid("session_id is required when more than one session is active")
         }
         if let state = activeSessions[target] {
+            try await settlePendingRememberWrites(sessionID: target)
             var manifest = state.manifest
             manifest.status = .ended
             manifest.updatedAtMs = Self.nowMs()
@@ -1245,10 +1316,13 @@ extension AgentBrokerService {
         }
         let modeRaw = try args.optionalString("mode")?.lowercased()
         let mode = try parseSearchMode(modeRaw: modeRaw, alpha: try args.optionalDouble("alpha"))
-        let sessionID = try resolveSessionID(
-            try parseOptionalSessionID(args),
-            requiringUnambiguousWorkingMemory: true
-        )
+        let sessionID: UUID?
+        switch try resolveSessionScope(try parseOptionalSessionID(args), policy: .requireUnambiguousWorking) {
+        case .session(let resolved):
+            sessionID = resolved
+        case .none, .durableOnly:
+            sessionID = nil
+        }
         if let sessionID {
             let sessionMemory = try await memory(for: sessionID)
             try await sessionMemory.flush()
@@ -2478,6 +2552,18 @@ extension AgentBrokerService {
         return value
     }
 
+    func writeScope(for sessionID: UUID?) -> MemoryScopeContext {
+        guard let sessionID, let session = activeSessions[sessionID] else {
+            return scopeContext
+        }
+        return MemoryScopeContext(
+            cwdPath: scopeContext.cwdPath,
+            repoRootPath: scopeContext.repoRootPath,
+            repoName: session.manifest.repo ?? scopeContext.repoName,
+            projectName: session.manifest.project ?? scopeContext.projectName
+        )
+    }
+
     func resolveSessionID(_ explicit: UUID?) throws -> UUID? {
         if let explicit { return explicit }
         if activeSessions.count == 1 {
@@ -2486,23 +2572,82 @@ extension AgentBrokerService {
         return nil
     }
 
-    func resolveSessionID(
+    enum SessionResolutionPolicy: Sendable, Equatable {
+        /// Do not infer a working session from live sessions.
+        case unscoped
+        /// Infer the sole live session; throw if more than one is live.
+        case requireUnambiguousWorking
+        /// Infer the sole live session; if more than one is live, search durable only.
+        case durableOnlyWhenAmbiguous
+    }
+
+    enum ResolvedSessionScope: Sendable, Equatable {
+        case session(UUID)
+        case durableOnly
+        case none
+    }
+
+    func resolveSessionScope(
         _ explicit: UUID?,
-        requiringUnambiguousWorkingMemory includeWorking: Bool,
-        allowDurableWithoutSession: Bool = false
-    ) throws -> UUID? {
-        if let explicit { return explicit }
-        guard includeWorking else { return nil }
-        switch activeSessions.count {
-        case 0:
-            return nil
-        case 1:
-            return activeSessions.keys.first
-        default:
-            if allowDurableWithoutSession {
-                return nil
+        policy: SessionResolutionPolicy
+    ) throws -> ResolvedSessionScope {
+        if let explicit { return .session(explicit) }
+        switch policy {
+        case .unscoped:
+            return .none
+        case .requireUnambiguousWorking:
+            switch activeSessions.count {
+            case 0:
+                return .none
+            case 1:
+                return .session(activeSessions.keys.first!)
+            default:
+                throw BrokerValidationError.invalid("session_id is required when more than one session is active")
             }
-            throw BrokerValidationError.invalid("session_id is required when more than one session is active")
+        case .durableOnlyWhenAmbiguous:
+            switch activeSessions.count {
+            case 0:
+                return .none
+            case 1:
+                return .session(activeSessions.keys.first!)
+            default:
+                return .durableOnly
+            }
+        }
+    }
+
+    package func settlePendingRememberWrites(sessionID: UUID? = nil) async throws {
+        let selected: [PendingRememberWrite]
+        if let sessionID {
+            var remaining: [PendingRememberWrite] = []
+            remaining.reserveCapacity(pendingRememberWrites.count)
+            var matched: [PendingRememberWrite] = []
+            for write in pendingRememberWrites {
+                if write.sessionID == sessionID {
+                    matched.append(write)
+                } else {
+                    remaining.append(write)
+                }
+            }
+            pendingRememberWrites = remaining
+            selected = matched
+        } else {
+            selected = pendingRememberWrites
+            pendingRememberWrites.removeAll()
+        }
+
+        var firstError: Error?
+        for write in selected {
+            do {
+                try await write.task.value
+            } catch {
+                if firstError == nil {
+                    firstError = error
+                }
+            }
+        }
+        if let firstError {
+            throw firstError
         }
     }
 

--- a/Sources/Wax/Broker/BrokerMemoryInsights.swift
+++ b/Sources/Wax/Broker/BrokerMemoryInsights.swift
@@ -42,7 +42,7 @@ package struct BrokerPromotionSettings: Sendable, Equatable {
 
     package static let `default` = BrokerPromotionSettings(
         minimumConfidence: 0.72,
-        minimumRecallCount: 0,
+        minimumRecallCount: 2,
         maxCandidates: 6
     )
 
@@ -185,6 +185,10 @@ package enum BrokerMemoryInsights {
                 || suggestedType == .userPreference
                 || suggestedType == .constraint
                 || suggestedType == .fact
+        let blocksPromotion = Self.explicitlyBlocksPromotion(content)
+        if blocksPromotion {
+            reasons.append("explicit do not promote instruction")
+        }
         let meetsThreshold = confidence >= settings.minimumConfidence && recallCount >= settings.minimumRecallCount
         if !isAlwaysPromotableType {
             reasons.append(String(format: "requires confidence >= %.2f", settings.minimumConfidence))
@@ -192,7 +196,7 @@ package enum BrokerMemoryInsights {
                 reasons.append("requires >=\(settings.minimumRecallCount) recalls")
             }
         }
-        let shouldWrite = !exactDuplicate && (isAlwaysPromotableType || meetsThreshold)
+        let shouldWrite = !exactDuplicate && !blocksPromotion && (isAlwaysPromotableType || meetsThreshold)
 
         return BrokerPromotionProposal(
             content: content,
@@ -388,6 +392,19 @@ package enum BrokerMemoryInsights {
         case .data(let data):
             return "data(\(data.count)b)"
         }
+    }
+
+    package static func explicitlyBlocksPromotion(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        let markers = [
+            "do not promote",
+            "don't promote",
+            "do not persist",
+            "don't persist",
+            "do not write",
+            "session-only note",
+        ]
+        return markers.contains { lower.contains($0) }
     }
 
     private static func baseConfidence(for type: MemoryType) -> Float {

--- a/Sources/Wax/Broker/BrokerMemoryInsights.swift
+++ b/Sources/Wax/Broker/BrokerMemoryInsights.swift
@@ -394,15 +394,11 @@ package enum BrokerMemoryInsights {
         }
     }
 
-    package static func explicitlyBlocksPromotion(_ text: String) -> Bool {
+    private static func explicitlyBlocksPromotion(_ text: String) -> Bool {
         let lower = text.lowercased()
         let markers = [
             "do not promote",
             "don't promote",
-            "do not persist",
-            "don't persist",
-            "do not write",
-            "session-only note",
         ]
         return markers.contains { lower.contains($0) }
     }

--- a/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
+++ b/Sources/Wax/Broker/CommandLineEmbedderFactory.swift
@@ -10,6 +10,14 @@ import WaxVectorSearchMiniLM
 import WaxVectorSearchArctic
 #endif
 
+/// Reports whether a deferred query embedder has resolved its inner provider.
+///
+/// `EmbeddingProvider` presence is not readiness: `DeferredCommandLineEmbedder`
+/// is non-nil at broker start while CoreML load is still in flight.
+package protocol QueryEmbedderReadiness: Sendable {
+    func isQueryEmbedderReady() async -> Bool
+}
+
 package enum CommandLineEmbedderFactory {
     private static let defaultLockTimeoutSeconds = 2.0
 
@@ -73,7 +81,7 @@ package enum CommandLineEmbedderFactory {
 }
 
 @available(macOS 15.0, iOS 18.0, *)
-private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmbeddingProvider {
+private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmbeddingProvider, QueryEmbedderReadiness {
     enum Kind: Sendable {
         case minilm
         case arctic
@@ -136,6 +144,10 @@ private actor DeferredCommandLineEmbedder: BatchEmbeddingProvider, QueryAwareEmb
             return try await queryAware.embedQuery(query)
         }
         return try await provider.embed(query)
+    }
+
+    func isQueryEmbedderReady() -> Bool {
+        provider != nil
     }
 
     private func resolvedProvider() async throws -> (any EmbeddingProvider)? {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -103,6 +103,7 @@ package actor MemoryOrchestrator {
         package var storeURL: URL
         package var vectorSearchEnabled: Bool
         package var queryEmbedderConfigured: Bool
+        package var queryEmbedderReady: Bool
         package var queryEmbeddingCircuitOpen: Bool
         package var structuredMemoryEnabled: Bool
         package var accessStatsScoringEnabled: Bool
@@ -116,6 +117,7 @@ package actor MemoryOrchestrator {
             storeURL: URL,
             vectorSearchEnabled: Bool,
             queryEmbedderConfigured: Bool,
+            queryEmbedderReady: Bool,
             queryEmbeddingCircuitOpen: Bool,
             structuredMemoryEnabled: Bool,
             accessStatsScoringEnabled: Bool,
@@ -128,6 +130,7 @@ package actor MemoryOrchestrator {
             self.storeURL = storeURL
             self.vectorSearchEnabled = vectorSearchEnabled
             self.queryEmbedderConfigured = queryEmbedderConfigured
+            self.queryEmbedderReady = queryEmbedderReady
             self.queryEmbeddingCircuitOpen = queryEmbeddingCircuitOpen
             self.structuredMemoryEnabled = structuredMemoryEnabled
             self.accessStatsScoringEnabled = accessStatsScoringEnabled
@@ -1130,11 +1133,25 @@ package actor MemoryOrchestrator {
             storeURL: storeURL,
             vectorSearchEnabled: config.enableVectorSearch,
             queryEmbedderConfigured: embedder != nil,
+            queryEmbedderReady: await isQueryEmbedderReady(),
             queryEmbeddingCircuitOpen: queryEmbeddingCircuitOpen,
             structuredMemoryEnabled: config.enableStructuredMemory,
             accessStatsScoringEnabled: config.enableAccessStatsScoring,
             embedderIdentity: embedder?.identity
         )
+    }
+
+    /// True when query embedding can run now.
+    ///
+    /// A deferred command-line embedder is configured (`embedder != nil`) before
+    /// its inner provider has loaded. Cold remember must wait on this, not on
+    /// mere configuration.
+    package func isQueryEmbedderReady() async -> Bool {
+        guard let embedder else { return false }
+        if let readiness = embedder as? any QueryEmbedderReadiness {
+            return await readiness.isQueryEmbedderReady()
+        }
+        return true
     }
 
     package func accessStatsSnapshot() async -> [UInt64: FrameAccessStats] {

--- a/Sources/WaxCLI/DaemonCommand.swift
+++ b/Sources/WaxCLI/DaemonCommand.swift
@@ -17,7 +17,7 @@ struct DaemonCommand: AsyncParsableCommand {
 
     @Flag(
         name: .customLong("skip-prewarm"),
-        help: "Accepted for compatibility. The broker uses lazy embedders and does not eagerly prewarm."
+        help: "Skip background embedder prewarm. Cold first writes may then wait on MiniLM."
     )
     var skipPrewarm = false
 
@@ -43,6 +43,12 @@ struct DaemonCommand: AsyncParsableCommand {
             ),
             embedderTuning: store.embedderTuning
         )
+
+        if !store.noEmbedder, !skipPrewarm {
+            Task {
+                await service.prewarmEmbedder()
+            }
+        }
 
         do {
             if let socketPath {
@@ -123,6 +129,9 @@ private extension DaemonCommand {
         let socketURL = URL(fileURLWithPath: AgentBrokerPathing.expandPath(rawSocketPath))
         let parent = socketURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        if isLiveBrokerSocket(at: socketURL.path) {
+            throw CLIError("Broker already running at \(socketURL.path)")
+        }
         try removeExistingSocket(at: socketURL.path)
 
         let listener = socket(AF_UNIX, unixStreamSocketType, 0)
@@ -163,12 +172,19 @@ private extension DaemonCommand {
             throw CLIError("Unable to listen on broker socket: \(String(cString: strerror(errno)))")
         }
 
-        let timeoutMS: Int32 = idleTimeoutSeconds > 0 ? Int32(idleTimeoutSeconds * 1000) : -1
-        while true {
+        let inflight = SocketInflight()
+        let pollSliceMS: Int32 = 200
+        var lastActivity = Date()
+        while !inflight.shouldStop {
             var descriptor = pollfd(fd: listener, events: Int16(POLLIN), revents: 0)
-            let pollResult = poll(&descriptor, 1, timeoutMS)
+            let pollResult = poll(&descriptor, 1, pollSliceMS)
             if pollResult == 0 {
-                return
+                if idleTimeoutSeconds > 0,
+                   Date().timeIntervalSince(lastActivity) >= idleTimeoutSeconds,
+                   !inflight.isBusy {
+                    return
+                }
+                continue
             }
             if pollResult < 0 {
                 if errno == EINTR { continue }
@@ -181,15 +197,23 @@ private extension DaemonCommand {
                 throw CLIError("Broker accept failed: \(String(cString: strerror(errno)))")
             }
 
-            do {
-                let shouldExit = try await handleSocketClient(service: service, fd: client)
-                if shouldExit {
-                    return
+            lastActivity = Date()
+            inflight.enter()
+            Task {
+                defer { inflight.leave() }
+                do {
+                    let shouldExit = try await handleSocketClient(service: service, fd: client)
+                    if shouldExit {
+                        inflight.requestStop()
+                    }
+                } catch {
+                    close(client)
                 }
-            } catch {
-                close(client)
-                throw error
             }
+        }
+        let drainDeadline = Date().addingTimeInterval(2)
+        while inflight.isBusy, Date() < drainDeadline {
+            try await Task.sleep(for: .milliseconds(20))
         }
     }
 
@@ -281,6 +305,33 @@ private extension DaemonCommand {
         return line.isEmpty ? nil : line
     }
 
+    func isLiveBrokerSocket(at path: String) -> Bool {
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+        let fd = socket(AF_UNIX, unixStreamSocketType, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var address = sockaddr_un()
+        #if canImport(Darwin)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        #endif
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8)
+        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else { return false }
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.initializeMemory(as: CChar.self, repeating: 0)
+            for (index, byte) in pathBytes.enumerated() {
+                buffer[index] = byte
+            }
+        }
+        let connectResult = withUnsafePointer(to: &address) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        return connectResult == 0
+    }
+
     func removeExistingSocket(at path: String) throws {
         var existing = stat()
         if lstat(path, &existing) != 0 {
@@ -305,6 +356,42 @@ private extension DaemonCommand {
 }
 
 private struct ExitRequested: Error {}
+
+private final class SocketInflight: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    private var stop = false
+
+    func enter() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    func leave() {
+        lock.lock()
+        count = max(0, count - 1)
+        lock.unlock()
+    }
+
+    var isBusy: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return count > 0
+    }
+
+    func requestStop() {
+        lock.lock()
+        stop = true
+        lock.unlock()
+    }
+
+    var shouldStop: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stop
+    }
+}
 
 private func featureFlagEnabled(_ key: String, default defaultValue: Bool) -> Bool {
     let env = ProcessInfo.processInfo.environment

--- a/Sources/WaxCLI/DaemonCommand.swift
+++ b/Sources/WaxCLI/DaemonCommand.swift
@@ -65,6 +65,10 @@ struct DaemonCommand: AsyncParsableCommand {
                 )
             }
             try await service.close()
+        } catch is BrokerStoreBusyDuringShutdown {
+            throw CLIError(
+                "Broker still has in-flight clients after shutdown drain; not closing the store"
+            )
         } catch {
             try? await service.close()
             throw error
@@ -80,6 +84,7 @@ private extension DaemonCommand {
     #endif
     var socketClientReadTimeoutMS: Int32 { 1_000 }
     var maxSocketRequestBytes: Int { 1_048_576 }
+    var socketInflightDrainSeconds: TimeInterval { AgentBrokerClient.responseTimeoutSeconds }
 
     func runLoop(
         service: AgentBrokerService,
@@ -129,18 +134,20 @@ private extension DaemonCommand {
         let socketURL = URL(fileURLWithPath: AgentBrokerPathing.expandPath(rawSocketPath))
         let parent = socketURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-        if isLiveBrokerSocket(at: socketURL.path) {
+        if AgentBrokerClient.isSocketLive(socketPath: socketURL.path) {
             throw CLIError("Broker already running at \(socketURL.path)")
         }
-        try removeExistingSocket(at: socketURL.path)
 
         let listener = socket(AF_UNIX, unixStreamSocketType, 0)
         guard listener >= 0 else {
             throw CLIError("Unable to create broker socket: \(String(cString: strerror(errno)))")
         }
+        var boundOwnSocket = false
         defer {
             close(listener)
-            unlink(socketURL.path)
+            if boundOwnSocket {
+                unlink(socketURL.path)
+            }
         }
 
         var address = sockaddr_un()
@@ -160,14 +167,18 @@ private extension DaemonCommand {
             }
         }
 
-        let bindResult = withUnsafePointer(to: &address) { pointer -> Int32 in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
-                bind(listener, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        var bindResult = bindUnixSocket(listener, address: &address)
+        if bindResult != 0, errno == EADDRINUSE {
+            if AgentBrokerClient.isSocketLive(socketPath: socketURL.path) {
+                throw CLIError("Broker already running at \(socketURL.path)")
             }
+            try removeExistingSocket(at: socketURL.path)
+            bindResult = bindUnixSocket(listener, address: &address)
         }
         guard bindResult == 0 else {
             throw CLIError("Unable to bind broker socket at \(socketURL.path): \(String(cString: strerror(errno)))")
         }
+        boundOwnSocket = true
         guard listen(listener, 16) == 0 else {
             throw CLIError("Unable to listen on broker socket: \(String(cString: strerror(errno)))")
         }
@@ -175,45 +186,70 @@ private extension DaemonCommand {
         let inflight = SocketInflight()
         let pollSliceMS: Int32 = 200
         var lastActivity = Date()
-        while !inflight.shouldStop {
-            var descriptor = pollfd(fd: listener, events: Int16(POLLIN), revents: 0)
-            let pollResult = poll(&descriptor, 1, pollSliceMS)
-            if pollResult == 0 {
-                if idleTimeoutSeconds > 0,
-                   Date().timeIntervalSince(lastActivity) >= idleTimeoutSeconds,
-                   !inflight.isBusy {
-                    return
-                }
-                continue
-            }
-            if pollResult < 0 {
-                if errno == EINTR { continue }
-                throw CLIError("Broker poll failed: \(String(cString: strerror(errno)))")
-            }
-
-            let client = accept(listener, nil, nil)
-            if client < 0 {
-                if errno == EINTR { continue }
-                throw CLIError("Broker accept failed: \(String(cString: strerror(errno)))")
-            }
-
-            lastActivity = Date()
-            inflight.enter()
-            Task {
-                defer { inflight.leave() }
-                do {
-                    let shouldExit = try await handleSocketClient(service: service, fd: client)
-                    if shouldExit {
-                        inflight.requestStop()
+        var loopError: Error?
+        do {
+            while !inflight.shouldStop {
+                var descriptor = pollfd(fd: listener, events: Int16(POLLIN), revents: 0)
+                let pollResult = poll(&descriptor, 1, pollSliceMS)
+                if pollResult == 0 {
+                    if idleTimeoutSeconds > 0,
+                       Date().timeIntervalSince(lastActivity) >= idleTimeoutSeconds,
+                       !inflight.isBusy {
+                        break
                     }
-                } catch {
-                    close(client)
+                    continue
+                }
+                if pollResult < 0 {
+                    if errno == EINTR { continue }
+                    throw CLIError("Broker poll failed: \(String(cString: strerror(errno)))")
+                }
+
+                let client = accept(listener, nil, nil)
+                if client < 0 {
+                    if errno == EINTR { continue }
+                    throw CLIError("Broker accept failed: \(String(cString: strerror(errno)))")
+                }
+
+                lastActivity = Date()
+                inflight.enter()
+                Task {
+                    defer { inflight.leave() }
+                    do {
+                        let shouldExit = try await handleSocketClient(service: service, fd: client)
+                        if shouldExit {
+                            inflight.requestStop()
+                        }
+                    } catch {
+                        // FileHandle owns the accepted fd. A dead peer must not
+                        // double-close it or skip inflight.leave().
+                    }
                 }
             }
+        } catch {
+            loopError = error
         }
-        let drainDeadline = Date().addingTimeInterval(2)
+
+        try await drainSocketInflight(inflight)
+        if let loopError {
+            throw loopError
+        }
+    }
+
+    func drainSocketInflight(_ inflight: SocketInflight) async throws {
+        let drainDeadline = Date().addingTimeInterval(socketInflightDrainSeconds)
         while inflight.isBusy, Date() < drainDeadline {
             try await Task.sleep(for: .milliseconds(20))
+        }
+        if inflight.isBusy {
+            throw BrokerStoreBusyDuringShutdown()
+        }
+    }
+
+    func bindUnixSocket(_ listener: Int32, address: inout sockaddr_un) -> Int32 {
+        withUnsafePointer(to: &address) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                bind(listener, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
         }
     }
 
@@ -305,33 +341,6 @@ private extension DaemonCommand {
         return line.isEmpty ? nil : line
     }
 
-    func isLiveBrokerSocket(at path: String) -> Bool {
-        guard FileManager.default.fileExists(atPath: path) else { return false }
-        let fd = socket(AF_UNIX, unixStreamSocketType, 0)
-        guard fd >= 0 else { return false }
-        defer { close(fd) }
-
-        var address = sockaddr_un()
-        #if canImport(Darwin)
-        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
-        #endif
-        address.sun_family = sa_family_t(AF_UNIX)
-        let pathBytes = Array(path.utf8)
-        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else { return false }
-        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
-            buffer.initializeMemory(as: CChar.self, repeating: 0)
-            for (index, byte) in pathBytes.enumerated() {
-                buffer[index] = byte
-            }
-        }
-        let connectResult = withUnsafePointer(to: &address) { pointer -> Int32 in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
-                connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        return connectResult == 0
-    }
-
     func removeExistingSocket(at path: String) throws {
         var existing = stat()
         if lstat(path, &existing) != 0 {
@@ -356,6 +365,7 @@ private extension DaemonCommand {
 }
 
 private struct ExitRequested: Error {}
+private struct BrokerStoreBusyDuringShutdown: Error {}
 
 private final class SocketInflight: @unchecked Sendable {
     private let lock = NSLock()

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -753,9 +753,9 @@ enum WaxMCPAgentPlaybook {
         Use the Wax MCP server for persistent memory in this repo.
 
         Workflow rules:
-        - At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`.
+        - At session start, call `handoff_latest` first to load prior context, then call `session_start` once and keep the returned `session_id`. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
         - Use `remember` to store decisions, discoveries, and short factual notes. If the memory is session-scoped, pass `session_id` as a top-level argument. Do not put `session_id` inside `metadata`.
-        - Use `recall` for assembled context and `search` for raw ranked hits.
+        - Use `recall` for assembled context and `search` for raw ranked hits. `recall` with `session_id` merges that session with durable long-term memory.
         - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
         - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
         - Use `handoff` near the end of the session with `content`, optional `project`, and `pending_tasks`, then call `session_end`.

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -10,8 +10,8 @@ enum MCPAgentInstructions {
 
         Session lifecycle (required):
         1) Call handoff_latest first (optional project) to resume prior context.
-        2) Call session_start once and keep the returned session_id for the session.
-        3) Before answering from memory, call recall (default) or search (raw ranked hits).
+        2) Call session_start once and keep the returned session_id for the session. The same agent_id+run_id resumes the active session.
+        3) Before answering from memory, call recall (default) or search (raw ranked hits). recall with session_id merges that session with durable long-term memory.
         4) When you learn durable facts, call remember with concise factual content. Pass session_id as a top-level argument for session-scoped writes — never put session_id inside metadata.
         5) Near session end, call handoff (content, optional project/pending_tasks/session_id), then session_end.
 

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -31,7 +31,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "recall",
-            description: "Preferred read path: assemble RAG context for a query. Call after handoff_latest/session_start when answering from memory.",
+            description: "Preferred read path: assemble RAG context for a query. Call after handoff_latest/session_start when answering from memory. Passing session_id merges that session with durable long-term memory.",
             inputSchema: waxRecall
         ),
         Tool(
@@ -61,7 +61,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "corpus_search",
-            description: "Search broker-managed session history with provenance. Use for cross-session retrieval; cite provenance when results matter.",
+            description: "Search broker-managed session history and the long-term store with provenance. Use for cross-session retrieval; cite provenance when results matter.",
             inputSchema: waxCorpusSearch
         ),
         Tool(
@@ -71,7 +71,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "session_start",
-            description: "Create a broker-managed virtual session and return session_id. Call after handoff_latest at session start; keep session_id for later tools.",
+            description: "Create a broker-managed virtual session and return session_id. Call after handoff_latest at session start; keep session_id for later tools. The same agent_id+run_id reuses the active session instead of minting a sibling.",
             inputSchema: waxSessionStart
         ),
         Tool(
@@ -221,7 +221,7 @@ enum ToolSchemas {
             ],
             "session_id": [
                 "type": "string",
-                "description": "Optional session UUID for scoped recall.",
+                "description": "Optional session UUID. When set, recall merges that session with durable long-term memory.",
             ],
             "mode": [
                 "type": "string",
@@ -440,8 +440,8 @@ enum ToolSchemas {
     static let waxSessionStart: Value = objectSchema(
         properties: [
             "session_id": ["type": "string", "description": "Optional explicit session UUID. If it already exists, use session_resume instead."],
-            "agent_id": ["type": "string", "description": "Stable agent identifier for long-running runtimes."],
-            "run_id": ["type": "string", "description": "Stable run identifier for the current autonomous run."],
+            "agent_id": ["type": "string", "description": "Stable agent identifier for long-running runtimes. Combined with run_id, reuses the active session."],
+            "run_id": ["type": "string", "description": "Stable run identifier for the current autonomous run. Combined with agent_id, reuses the active session."],
         ],
         required: []
     )

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -45,10 +45,15 @@ enum WaxMCPTools {
             try validateToolAvailability(name: params.name, structuredMemoryEnabled: structuredMemoryEnabled)
             try validateArgumentSurface(name: params.name, arguments: params.arguments)
 
+            var forwarded = params.arguments ?? [:]
+            if params.name == "session_start", forwarded["cwd"] == nil {
+                forwarded["cwd"] = .string(FileManager.default.currentDirectoryPath)
+            }
+
             let response = try await AgentBrokerClient.perform(
                 request: AgentBrokerRequest(
                     command: params.name,
-                    arguments: (params.arguments ?? [:]).mapValues(brokerValue(from:))
+                    arguments: forwarded.mapValues(brokerValue(from:))
                 ),
                 configuration: brokerConfiguration
             )
@@ -883,7 +888,7 @@ private extension WaxMCPTools {
             alpha: try args.optionalDouble("alpha")
         )
         let embeddingPolicy = compatEmbeddingPolicy(for: directMode)
-        let execution = try await memory.recallExecution(
+        let sessionExecution = try await memory.recallExecution(
             query: query,
             embeddingPolicy: embeddingPolicy,
             frameFilter: filters.frameFilter,
@@ -891,8 +896,33 @@ private extension WaxMCPTools {
             topK: effectiveTopK,
             mode: directMode
         )
-        let context = execution.context
-        let selected = Array(context.items.prefix(limit))
+        let durableExecution: MemoryOrchestrator.RecallExecution
+        if filters.sessionID != nil {
+            durableExecution = try await memory.recallExecution(
+                query: query,
+                embeddingPolicy: embeddingPolicy,
+                frameFilter: nil,
+                timeRange: filters.timeRange,
+                topK: effectiveTopK,
+                mode: directMode
+            )
+        } else {
+            durableExecution = sessionExecution
+        }
+        let durableItems = filters.sessionID == nil
+            ? durableExecution.context.items
+            : durableExecution.context.items.filter { $0.metadata["session_id"] == nil }
+        let selected = AgentBrokerService.mergeRecallItems(
+            sessionItems: filters.sessionID == nil ? [] : sessionExecution.context.items,
+            durableItems: durableItems,
+            limit: limit
+        )
+        let execution = sessionExecution
+        let context = RAGContext(
+            query: query,
+            items: selected,
+            totalTokens: selected.reduce(0) { $0 + max(1, $1.text.split(whereSeparator: \.isWhitespace).count) }
+        )
         let filterSummaryJSON = encodeJSON(filters.summary) ?? "{}"
         var lines: [String] = [
             "Query: \(context.query)",

--- a/Tests/WaxIntegrationTests/BrokerPromotionHeuristicTests.swift
+++ b/Tests/WaxIntegrationTests/BrokerPromotionHeuristicTests.swift
@@ -40,3 +40,64 @@ func promotionStillWritesCanonicalDecisionWithoutRecall() {
     )
     #expect(proposal.shouldWrite == true)
 }
+
+@Test
+func promotionRejectsNoteAfterSingleRecallWithoutCanary() {
+    let proposal = BrokerMemoryInsights.proposePromotion(
+        content: "Scratch reminder about MiniLM cache warmup before the first recall.",
+        metadata: [
+            MemoryMetadataKeys.type: MemoryType.note.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.working.rawValue,
+        ],
+        sessionID: UUID(),
+        sourceFrameID: 2,
+        scope: nil,
+        longTermDocuments: [],
+        recallSignals: BrokerSessionRecallSignals(
+            recallCount: 1,
+            uniqueQueryCount: 1,
+            lastRetrievedAtMs: 1,
+            averageScore: 0.9
+        )
+    )
+    #expect(proposal.shouldWrite == false)
+    #expect(proposal.reasons.contains { $0.contains("requires >=2 recalls") })
+}
+
+@Test
+func promotionWritesNoteAfterTwoRecallsAndHighScore() {
+    let proposal = BrokerMemoryInsights.proposePromotion(
+        content: "Scratch reminder about MiniLM cache warmup before the first recall.",
+        metadata: [
+            MemoryMetadataKeys.type: MemoryType.note.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.working.rawValue,
+        ],
+        sessionID: UUID(),
+        sourceFrameID: 3,
+        scope: nil,
+        longTermDocuments: [],
+        recallSignals: BrokerSessionRecallSignals(
+            recallCount: 2,
+            uniqueQueryCount: 2,
+            lastRetrievedAtMs: 1,
+            averageScore: 0.9
+        )
+    )
+    #expect(proposal.shouldWrite == true)
+}
+
+@Test
+func promotionStillWritesDecisionContainingDoNotWrite() {
+    let proposal = BrokerMemoryInsights.proposePromotion(
+        content: "Decision: keep MiniLM as the default embedder and do not write embeddings to disk.",
+        metadata: [
+            MemoryMetadataKeys.type: MemoryType.decision.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+        ],
+        sessionID: UUID(),
+        sourceFrameID: 4,
+        scope: nil,
+        longTermDocuments: []
+    )
+    #expect(proposal.shouldWrite == true)
+}

--- a/Tests/WaxIntegrationTests/BrokerPromotionHeuristicTests.swift
+++ b/Tests/WaxIntegrationTests/BrokerPromotionHeuristicTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func promotionRejectsExplicitDoNotPromoteCanaryAfterOneRecall() {
+    let proposal = BrokerMemoryInsights.proposePromotion(
+        content: "Session-only note: do not promote. CLEAN-TOKEN-20260818",
+        metadata: [
+            MemoryMetadataKeys.type: MemoryType.note.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.working.rawValue,
+        ],
+        sessionID: UUID(),
+        sourceFrameID: 0,
+        scope: nil,
+        longTermDocuments: [],
+        recallSignals: BrokerSessionRecallSignals(
+            recallCount: 1,
+            uniqueQueryCount: 1,
+            lastRetrievedAtMs: 1,
+            averageScore: 0.9
+        )
+    )
+    #expect(proposal.shouldWrite == false)
+    #expect(proposal.reasons.contains { $0.localizedCaseInsensitiveContains("do not promote") })
+}
+
+@Test
+func promotionStillWritesCanonicalDecisionWithoutRecall() {
+    let proposal = BrokerMemoryInsights.proposePromotion(
+        content: "Decision: keep MiniLM as the default embedder for waxmcp.",
+        metadata: [
+            MemoryMetadataKeys.type: MemoryType.decision.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+        ],
+        sessionID: UUID(),
+        sourceFrameID: 1,
+        scope: nil,
+        longTermDocuments: []
+    )
+    #expect(proposal.shouldWrite == true)
+}

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -148,6 +148,32 @@ func sessionStartInfersProjectFromClientCwdNotBrokerBinary() async throws {
         #expect(payload["project"]?.stringValue == repo.lastPathComponent)
         #expect(payload["project"]?.stringValue != "Wax")
         #expect(payload["repo"]?.stringValue == repo.lastPathComponent)
+
+        let sessionID = try requireString(payload, "session_id")
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Session write should inherit the client cwd project, not the daemon cwd."),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        #expect(write.ok == true)
+
+        let search = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string("inherit the client cwd project"),
+                "session_id": .string(sessionID),
+                "include_working": .bool(true),
+                "include_durable": .bool(false),
+                "include_episodic": .bool(false),
+            ]
+        ))
+        #expect(search.ok == true)
+        let hit = try #require(try requireObject(search.payload)["results"]?.arrayValue?.first?.objectValue)
+        let metadata = try #require(hit["metadata"]?.objectValue)
+        #expect(metadata["wax.project"]?.stringValue == repo.lastPathComponent)
+        #expect(metadata["wax.repo"]?.stringValue == repo.lastPathComponent)
     }
 }
 
@@ -346,6 +372,379 @@ func compactContextIncludesLiveSessionNote() async throws {
         let short = payload["short_context"]?.arrayValue ?? []
         #expect(short.contains { $0.objectValue?["preview"]?.stringValue?.contains(token) == true
             || $0.objectValue?["text"]?.stringValue?.contains(token) == true })
+    }
+}
+
+@Test
+func defaultMemorySearchDoesNotReturnOtherSessionsEndedNoteWhenMultipleSessionsAreLive() async throws {
+    try await withIsolatedBroker { service, _ in
+        let ended = await service.handle(.init(command: "session_start"))
+        #expect(ended.ok == true)
+        let endedID = try requireString(try requireObject(ended.payload), "session_id")
+        let token = "ENDED-WORKING-\(UUID().uuidString.prefix(8))"
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Ended-session working note \(token) must not leak unscoped."),
+                "session_id": .string(endedID),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "session_end",
+            arguments: ["session_id": .string(endedID)]
+        ))).ok == true)
+
+        #expect((await service.handle(.init(command: "session_start"))).ok == true)
+        #expect((await service.handle(.init(command: "session_start"))).ok == true)
+
+        let search = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string(token),
+                "mode": .string("text"),
+            ]
+        ))
+        #expect(search.ok == true, "memory_search failed: \(search.error ?? "nil")")
+        let payload = try requireObject(search.payload)
+        let texts = resultTexts(payload)
+        let display = payload["display_text"]?.stringValue ?? ""
+        #expect(!texts.contains { $0.contains(token) })
+        #expect(!display.contains(token))
+        #expect(!(payload["results"]?.arrayValue ?? []).contains { result in
+            result.objectValue?["horizon"]?.stringValue == "episodic"
+                && (result.objectValue?["text"]?.stringValue?.contains(token) == true
+                    || result.objectValue?["preview"]?.stringValue?.contains(token) == true)
+        })
+    }
+}
+
+@Test
+func mergeRecallItemsReservesMissingSessionHorizonWhenDurableFillsLimit() {
+    let durable = (1...5).map { index in
+        recallItem(frameId: UInt64(index), score: 1.0 - Float(index) * 0.01, text: "durable hit \(index)")
+    }
+    let session = [recallItem(frameId: 99, score: 0.05, text: "session reserved note")]
+    let merged = AgentBrokerService.mergeRecallItems(
+        sessionItems: session,
+        durableItems: durable,
+        limit: 5
+    )
+    #expect(merged.count == 5)
+    #expect(merged.contains { $0.text.contains("session reserved note") })
+    #expect(merged.contains { $0.explanations.contains("current session") })
+    #expect(merged.contains { $0.explanations.contains("durable memory") })
+}
+
+@Test
+func mergeRecallItemsReservesMissingDurableHorizonWhenSessionFillsLimit() {
+    let session = (1...5).map { index in
+        recallItem(frameId: UInt64(index), score: 1.0 - Float(index) * 0.01, text: "session hit \(index)")
+    }
+    let durable = [recallItem(frameId: 99, score: 0.05, text: "durable reserved note")]
+    let merged = AgentBrokerService.mergeRecallItems(
+        sessionItems: session,
+        durableItems: durable,
+        limit: 5
+    )
+    #expect(merged.count == 5)
+    #expect(merged.contains { $0.text.contains("durable reserved note") })
+    #expect(merged.contains { $0.explanations.contains("current session") })
+    #expect(merged.contains { $0.explanations.contains("durable memory") })
+}
+
+@Test
+func recallAppliesFrameFilterToDurableHitsWhenSessionIDIsSet() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(command: "session_start"))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        let token = "FILTER-DURABLE-\(UUID().uuidString.prefix(8))"
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("\(token) keep this durable fact"),
+                "memory_type": .string("fact"),
+                "durability": .string("durable"),
+                "metadata": .object(["topic": .string("keep")]),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("\(token) drop this durable fact"),
+                "memory_type": .string("fact"),
+                "durability": .string("durable"),
+                "metadata": .object(["topic": .string("drop")]),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("\(token) session note without topic"),
+                "session_id": .string(sessionID),
+            ]
+        ))).ok == true)
+
+        let recalled = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(token),
+                "session_id": .string(sessionID),
+                "mode": .string("text"),
+                "limit": .int(10),
+                "filters": .object([
+                    "metadata": .object(["topic": .string("keep")]),
+                ]),
+            ]
+        ))
+        #expect(recalled.ok == true, "recall failed: \(recalled.error ?? "nil")")
+        let texts = resultTexts(try requireObject(recalled.payload))
+        #expect(texts.contains { $0.contains("keep this durable fact") })
+        #expect(!texts.contains { $0.contains("drop this durable fact") })
+    }
+}
+
+@Test
+func recallRecordsRetrievalHitsOnlyForSessionHorizonItems() async throws {
+    try await withIsolatedBroker { service, sessionRootURL in
+        let started = await service.handle(.init(command: "session_start"))
+        let startedPayload = try requireObject(started.payload)
+        let sessionID = try requireString(startedPayload, "session_id")
+        let sessionUUID = try #require(UUID(uuidString: sessionID))
+        let token = "HIT-SCOPE-\(UUID().uuidString.prefix(8))"
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Decoy session note that must not inherit durable frame hits."),
+                "session_id": .string(sessionID),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("\(token) session mention that should be recorded."),
+                "session_id": .string(sessionID),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("\(token) durable fact that shares no session store."),
+                "memory_type": .string("fact"),
+                "durability": .string("durable"),
+            ]
+        ))).ok == true)
+
+        let scopedWorking = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string(token),
+                "session_id": .string(sessionID),
+                "mode": .string("text"),
+                "include_working": .bool(true),
+                "include_episodic": .bool(false),
+                "include_durable": .bool(false),
+            ]
+        ))
+        #expect(scopedWorking.ok == true)
+        let workingHits = try requireObject(scopedWorking.payload)["results"]?.arrayValue ?? []
+        let sessionFrameIDs = Set(workingHits.compactMap { $0.objectValue?["frame_id"]?.intValue }.map(UInt64.init))
+        #expect(!sessionFrameIDs.isEmpty)
+
+        let recalled = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(token),
+                "session_id": .string(sessionID),
+                "mode": .string("text"),
+                "limit": .int(10),
+            ]
+        ))
+        #expect(recalled.ok == true, "recall failed: \(recalled.error ?? "nil")")
+        let recallPayload = try requireObject(recalled.payload)
+        let recallTexts = resultTexts(recallPayload)
+        #expect(recallTexts.contains { $0.contains("durable fact") })
+        #expect(recallTexts.contains { $0.contains("session mention") })
+
+        let manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionUUID)
+        let events = try BrokerSessionPersistence.loadEvents(from: URL(fileURLWithPath: manifest.eventLogPath))
+        let recordedFrameIDs = Set(events.compactMap { event -> UInt64? in
+            guard event.kind == .retrievalHit else { return nil }
+            return event.payload["frame_id"].flatMap(UInt64.init)
+        })
+        #expect(!recordedFrameIDs.isEmpty)
+        #expect(recordedFrameIDs.isSubset(of: sessionFrameIDs))
+    }
+}
+
+@Test
+func coldRememberReturnsPendingThenFrameLandsWhenDeferredEmbedderBecomesReady() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-pending-remember-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let embedder = GateableQueryEmbedder()
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "auto",
+        requireVector: false,
+        embedderOverride: embedder
+    )
+    do {
+        let token = "PENDINGLAND\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12))"
+        let remembered = await service.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("Cold remember \(token) should land after embedder ready.")]
+        ))
+        #expect(remembered.ok == true, "remember failed: \(remembered.error ?? "nil")")
+        let pendingPayload = try requireObject(remembered.payload)
+        #expect(pendingPayload["status"]?.stringValue == "pending")
+        #expect(pendingPayload["embedding_state"]?.stringValue == "loading")
+
+        await embedder.markReady()
+        try await service.settlePendingRememberWrites()
+        #expect((await service.handle(.init(command: "flush"))).ok == true)
+
+        let search = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string(token),
+                "mode": .string("text"),
+                "topK": .int(5),
+            ]
+        ))
+        #expect(search.ok == true, "search failed: \(search.error ?? "nil")")
+        let searchPayload = try requireObject(search.payload)
+        let texts = resultTexts(searchPayload)
+        let display = searchPayload["display_text"]?.stringValue ?? ""
+        #expect(
+            texts.contains { $0.contains(token) } || display.contains(token),
+            "expected landed frame for \(token); display=\(display) texts=\(texts)"
+        )
+        try await service.close()
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+@Test
+func coldRememberPendingWriteSurfacesTypedFailureWhenEmbedderFails() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-pending-fail-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let embedder = GateableQueryEmbedder()
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "auto",
+        requireVector: false,
+        embedderOverride: embedder
+    )
+    do {
+        let remembered = await service.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("Cold remember should surface embedder failure.")]
+        ))
+        #expect(remembered.ok == true)
+        #expect(try requireObject(remembered.payload)["status"]?.stringValue == "pending")
+
+        await embedder.fail(GateableQueryEmbedder.Failure.unavailable)
+        do {
+            try await service.settlePendingRememberWrites()
+            Issue.record("pending remember should fail when the embedder never becomes ready")
+        } catch {
+            #expect(error.localizedDescription.localizedCaseInsensitiveContains("unavailable")
+                || error.localizedDescription.localizedCaseInsensitiveContains("embed"))
+        }
+        try await service.close()
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+private func recallItem(frameId: UInt64, score: Float, text: String) -> RAGContext.Item {
+    RAGContext.Item(
+        kind: .snippet,
+        frameId: frameId,
+        score: score,
+        sources: [.text],
+        text: text
+    )
+}
+
+private actor GateableQueryEmbedder: EmbeddingProvider, QueryEmbedderReadiness {
+    enum Failure: LocalizedError {
+        case unavailable
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable:
+                return "Embedding provider is unavailable."
+            }
+        }
+    }
+
+    nonisolated let dimensions = 8
+    nonisolated let normalize = true
+    nonisolated let identity: EmbeddingIdentity? = EmbeddingIdentity(provider: "Test", model: "Gateable", dimensions: 8, normalized: true)
+    nonisolated var executionMode: ProviderExecutionMode { .onDeviceOnly }
+    private var ready = false
+    private var failure: (any Error)?
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func isQueryEmbedderReady() -> Bool {
+        ready && failure == nil
+    }
+
+    func markReady() {
+        ready = true
+        resumeWaiters()
+    }
+
+    func fail(_ error: any Error) {
+        failure = error
+        resumeWaiters()
+    }
+
+    func embed(_ text: String) async throws -> [Float] {
+        if !ready && failure == nil {
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+        if let failure {
+            throw failure
+        }
+        var vector = [Float](repeating: 0, count: dimensions)
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        vector[0] = Float(hash % 1_000) / 1_000
+        return vector
+    }
+
+    private func resumeWaiters() {
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
     }
 }
 

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -1,0 +1,352 @@
+import Foundation
+import Testing
+
+#if MCPServer
+@testable import wax_mcp
+@testable import Wax
+
+private func withIsolatedBroker<T>(
+    _ body: (AgentBrokerService, URL) async throws -> T
+) async throws -> T {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-session-model-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        let result = try await body(service, sessionRootURL)
+        try await service.close()
+        return result
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+private func requireObject(_ value: AgentBrokerValue?) throws -> [String: AgentBrokerValue] {
+    try #require(value?.objectValue)
+}
+
+private func requireString(_ object: [String: AgentBrokerValue], _ key: String) throws -> String {
+    try #require(object[key]?.stringValue)
+}
+
+private func resultTexts(_ payload: [String: AgentBrokerValue]) -> [String] {
+    payload["results"]?.arrayValue?.compactMap { result in
+        result.objectValue?["text"]?.stringValue ?? result.objectValue?["preview"]?.stringValue
+    } ?? []
+}
+
+@Test
+func sessionScopedRecallMergesDurableAndSessionNotes() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("recall-agent"),
+                "run_id": .string("recall-run"),
+            ]
+        ))
+        #expect(started.ok == true)
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+
+        let durable = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("rv is a Zig CLI that evaluates policy and attaches an OS sandbox."),
+                "memory_type": .string("decision"),
+                "durability": .string("durable"),
+            ]
+        ))
+        #expect(durable.ok == true)
+
+        let sessionNote = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Session-only note: do not promote. CLEAN-TOKEN-20260818"),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        #expect(sessionNote.ok == true)
+
+        let scoped = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string("What is rv?"),
+                "session_id": .string(sessionID),
+                "mode": .string("text"),
+                "limit": .int(10),
+            ]
+        ))
+        #expect(scoped.ok == true, "scoped recall failed: \(scoped.error ?? "nil")")
+        let payload = try requireObject(scoped.payload)
+        let texts = resultTexts(payload)
+        #expect(texts.contains { $0.contains("Zig CLI") && $0.contains("policy") })
+        #expect(texts.contains { $0.contains("CLEAN-TOKEN-20260818") })
+    }
+}
+
+@Test
+func sessionStartReusesActiveSessionForSameAgentAndRun() async throws {
+    try await withIsolatedBroker { service, _ in
+        let first = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("same-agent"),
+                "run_id": .string("same-run"),
+            ]
+        ))
+        #expect(first.ok == true)
+        let firstPayload = try requireObject(first.payload)
+        let firstID = try requireString(firstPayload, "session_id")
+
+        let second = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("same-agent"),
+                "run_id": .string("same-run"),
+            ]
+        ))
+        #expect(second.ok == true)
+        let secondPayload = try requireObject(second.payload)
+        #expect(try requireString(secondPayload, "session_id") == firstID)
+        #expect(secondPayload["resumed"]?.boolValue == true)
+    }
+}
+
+@Test
+func sessionStartInfersProjectFromClientCwdNotBrokerBinary() async throws {
+    try await withIsolatedBroker { service, _ in
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rv-cwd-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: repo.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("cwd-agent"),
+                "run_id": .string("cwd-run"),
+                "cwd": .string(repo.path),
+            ]
+        ))
+        #expect(started.ok == true)
+        let payload = try requireObject(started.payload)
+        #expect(payload["project"]?.stringValue == repo.lastPathComponent)
+        #expect(payload["project"]?.stringValue != "Wax")
+        #expect(payload["repo"]?.stringValue == repo.lastPathComponent)
+    }
+}
+
+@Test
+func corpusSearchIncludesDurableLongTermFrames() async throws {
+    try await withIsolatedBroker { service, _ in
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("DCG is the destructive command guard for ryk policy evaluation."),
+                "memory_type": .string("fact"),
+                "durability": .string("durable"),
+            ]
+        ))
+        #expect(write.ok == true)
+
+        let corpus = await service.handle(.init(
+            command: "corpus_search",
+            arguments: [
+                "query": .string("rv DCG"),
+                "mode": .string("text"),
+                "topK": .int(8),
+                "rebuild": .bool(false),
+            ]
+        ))
+        #expect(corpus.ok == true, "corpus_search failed: \(corpus.error ?? "nil")")
+        let payload = try requireObject(corpus.payload)
+        let texts = resultTexts(payload)
+        #expect(texts.contains { $0.contains("destructive command guard") })
+    }
+}
+
+@Test
+func memorySearchWithoutSessionIDStillSearchesDurableWhenMultipleSessionsAreActive() async throws {
+    try await withIsolatedBroker { service, _ in
+        let first = await service.handle(.init(command: "session_start"))
+        let second = await service.handle(.init(command: "session_start"))
+        #expect(first.ok == true)
+        #expect(second.ok == true)
+
+        let token = "minilmdimscanary\(UUID().uuidString.prefix(8).lowercased())"
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Durable fact \(token) about MiniLM dimensions."),
+                "memory_type": .string("fact"),
+                "durability": .string("durable"),
+            ]
+        ))
+        #expect(write.ok == true)
+
+        let search = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string(token),
+                "mode": .string("text"),
+                "include_working": .bool(true),
+                "include_durable": .bool(true),
+            ]
+        ))
+        #expect(search.ok == true, "memory_search failed: \(search.error ?? "nil")")
+        let payload = try requireObject(search.payload)
+        let texts = resultTexts(payload)
+        let display = payload["display_text"]?.stringValue ?? ""
+        #expect(
+            texts.contains { $0.localizedCaseInsensitiveContains(token) } || display.localizedCaseInsensitiveContains(token),
+            "expected durable hit for \(token); display=\(display) texts=\(texts)"
+        )
+    }
+}
+
+@Test
+func sessionSynthesizeWithMultipleSessionsAsksForSessionIDNotMissingSession() async throws {
+    try await withIsolatedBroker { service, _ in
+        #expect((await service.handle(.init(command: "session_start"))).ok == true)
+        #expect((await service.handle(.init(command: "session_start"))).ok == true)
+
+        let synthesized = await service.handle(.init(command: "session_synthesize"))
+        #expect(synthesized.ok == false)
+        #expect((synthesized.error ?? "").contains("more than one session is active"))
+        #expect(!(synthesized.error ?? "").contains("no active session is available"))
+    }
+}
+
+@Test
+func memoryPromoteDoesNotRecommendDoNotPromoteCanaryAfterOneRecall() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(command: "session_start"))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        let canary = "Session-only note: do not promote. CLEAN-TOKEN-20260818"
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string(canary),
+                "session_id": .string(sessionID),
+            ]
+        ))).ok == true)
+
+        #expect((await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(canary),
+                "session_id": .string(sessionID),
+                "mode": .string("text"),
+            ]
+        ))).ok == true)
+
+        let promote = await service.handle(.init(
+            command: "memory_promote",
+            arguments: ["session_id": .string(sessionID)]
+        ))
+        #expect(promote.ok == true)
+        let payload = try requireObject(promote.payload)
+        let proposal = try requireObject(payload["proposal"])
+        #expect(proposal["should_write"]?.boolValue == false)
+    }
+}
+
+@Test
+func recallRejectsEmptyQuery() async throws {
+    try await withIsolatedBroker { service, _ in
+        let empty = await service.handle(.init(
+            command: "recall",
+            arguments: ["query": .string("   ")]
+        ))
+        #expect(empty.ok == false)
+        #expect((empty.error ?? "").contains("query"))
+    }
+}
+
+@Test
+func searchRejectsAlphaUnlessHybrid() async throws {
+    try await withIsolatedBroker { service, _ in
+        let rejected = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string("alpha"),
+                "mode": .string("text"),
+                "alpha": .double(0.7),
+            ]
+        ))
+        #expect(rejected.ok == false)
+        #expect((rejected.error ?? "").contains("alpha"))
+    }
+}
+
+@Test
+func factsQueryOmitsSentinelAsOfWhenCallerDidNotPassOne() async throws {
+    try await withIsolatedBroker { service, _ in
+        #expect((await service.handle(.init(
+            command: "fact_assert",
+            arguments: [
+                "subject": .string("wax"),
+                "predicate": .string("status"),
+                "object": .string("open"),
+            ]
+        ))).ok == true)
+
+        let queried = await service.handle(.init(command: "facts_query"))
+        #expect(queried.ok == true)
+        let payload = try requireObject(queried.payload)
+        #expect(payload["as_of"] == .null || payload["as_of"] == nil)
+        if let raw = payload["as_of"]?.intValue {
+            #expect(raw != Int64.max)
+        }
+    }
+}
+
+@Test
+func compactContextIncludesLiveSessionNote() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(command: "session_start"))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        let token = "COMPACT-LIVE-\(UUID().uuidString.prefix(8))"
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Working session note \(token) must appear in short context."),
+                "session_id": .string(sessionID),
+            ]
+        ))).ok == true)
+
+        let compact = await service.handle(.init(
+            command: "compact_context",
+            arguments: [
+                "query": .string("unrelated compact query"),
+                "session_id": .string(sessionID),
+                "mode": .string("text"),
+                "token_budget": .int(800),
+            ]
+        ))
+        #expect(compact.ok == true, "compact_context failed: \(compact.error ?? "nil")")
+        let payload = try requireObject(compact.payload)
+        let short = payload["short_context"]?.arrayValue ?? []
+        #expect(short.contains { $0.objectValue?["preview"]?.stringValue?.contains(token) == true
+            || $0.objectValue?["text"]?.stringValue?.contains(token) == true })
+    }
+}
+
+#endif

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -67,6 +67,268 @@ func brokerRejectsInvalidEmbedderChoice() async throws {
 }
 
 @Test
+func isSocketLiveDistinguishesMissingStaleAndListeningSockets() throws {
+    let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        .appendingPathComponent("wxsa-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let missing = root.appendingPathComponent("missing.sock").path
+    #expect(!AgentBrokerClient.isSocketLive(socketPath: missing))
+
+    let stale = root.appendingPathComponent("stale.sock").path
+    try makeStaleUnixSocket(at: stale)
+    #expect(FileManager.default.fileExists(atPath: stale))
+    #expect(!AgentBrokerClient.isSocketLive(socketPath: stale))
+
+    let live = root.appendingPathComponent("live.sock").path
+    let listener = try bindAndListenUnixSocket(at: live)
+    defer {
+        close(listener)
+        unlink(live)
+    }
+    #expect(AgentBrokerClient.isSocketLive(socketPath: live))
+}
+
+@Test
+func ensureAvailableDoesNotUnlinkSocketOnConnectFailure() async throws {
+    let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        .appendingPathComponent("wxsa-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let socketPath = root.appendingPathComponent("broker.sock").path
+    try makeStaleUnixSocket(at: socketPath)
+
+    do {
+        _ = try await AgentBrokerClient.ensureAvailable(
+            configuration: testBrokerConfiguration(root: root, socketPath: socketPath)
+        )
+        Issue.record("expected ensureAvailable to fail without a broker executable")
+    } catch {
+        #expect(error.localizedDescription.contains("not executable"))
+    }
+
+    #expect(FileManager.default.fileExists(atPath: socketPath))
+}
+
+@Test
+func ensureAvailableReusesLiveBrokerWithoutStartingReplacement() async throws {
+    let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        .appendingPathComponent("wxsa-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let socketPath = root.appendingPathComponent("broker.sock").path
+    let listener = try bindAndListenUnixSocket(at: socketPath)
+    defer {
+        close(listener)
+        unlink(socketPath)
+    }
+
+    let server = UnixStatsResponder(listener: listener)
+    server.start(holdFirstRequest: false)
+    defer { server.stop() }
+
+    let started = try await AgentBrokerClient.ensureAvailable(
+        configuration: testBrokerConfiguration(root: root, socketPath: socketPath)
+    )
+    #expect(started == false)
+}
+
+@Test(.timeLimit(.minutes(1)))
+func shortAttachPingTimeoutFallsThroughToLiveRetry() async throws {
+    let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        .appendingPathComponent("wxsa-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let socketPath = root.appendingPathComponent("broker.sock").path
+    let listener = try bindAndListenUnixSocket(at: socketPath)
+    defer {
+        close(listener)
+        unlink(socketPath)
+    }
+
+    let server = UnixStatsResponder(listener: listener)
+    server.start(holdFirstRequest: true)
+    defer { server.stop() }
+
+    let started = try await AgentBrokerClient.ensureAvailable(
+        configuration: testBrokerConfiguration(root: root, socketPath: socketPath)
+    )
+    #expect(started == false)
+}
+
+#if canImport(Darwin)
+private let testUnixStreamSocketType: Int32 = SOCK_STREAM
+#else
+private let testUnixStreamSocketType: Int32 = Int32(SOCK_STREAM.rawValue)
+#endif
+
+private func testBrokerConfiguration(root: URL, socketPath: String) -> AgentBrokerConfiguration {
+    AgentBrokerConfiguration(
+        brokerExecutablePath: "/nonexistent/wax-cli-must-not-start",
+        storePath: root.appendingPathComponent("memory.wax").path,
+        sessionRootPath: root.appendingPathComponent("sessions").path,
+        socketPath: socketPath,
+        embedderChoice: "auto",
+        noEmbedder: true,
+        requireVector: false,
+        embedderTuning: .fromEnvironment()
+    )
+}
+
+private func bindAndListenUnixSocket(at path: String) throws -> Int32 {
+    let fd = socket(AF_UNIX, testUnixStreamSocketType, 0)
+    guard fd >= 0 else {
+        throw TestUnixSocketError("socket: \(String(cString: strerror(errno)))")
+    }
+
+    var address = sockaddr_un()
+    #if canImport(Darwin)
+    address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+    #endif
+    address.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = Array(path.utf8)
+    guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
+        close(fd)
+        throw TestUnixSocketError("path too long: \(path)")
+    }
+    withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+        buffer.initializeMemory(as: CChar.self, repeating: 0)
+        for (index, byte) in pathBytes.enumerated() {
+            buffer[index] = byte
+        }
+    }
+
+    let bindResult = withUnsafePointer(to: &address) { pointer -> Int32 in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+            bind(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard bindResult == 0 else {
+        close(fd)
+        throw TestUnixSocketError("bind: \(String(cString: strerror(errno)))")
+    }
+    guard listen(fd, 16) == 0 else {
+        close(fd)
+        unlink(path)
+        throw TestUnixSocketError("listen: \(String(cString: strerror(errno)))")
+    }
+    return fd
+}
+
+private func makeStaleUnixSocket(at path: String) throws {
+    let fd = try bindAndListenUnixSocket(at: path)
+    close(fd)
+}
+
+private struct TestUnixSocketError: Error, CustomStringConvertible {
+    let message: String
+    init(_ message: String) { self.message = message }
+    var description: String { message }
+}
+
+private final class UnixStatsResponder: @unchecked Sendable {
+    private let listener: Int32
+    private let lock = NSLock()
+    private var stopped = false
+    private var heldFDs: [Int32] = []
+    private var holdFirstRequest = false
+    private var heldFirstRequest = false
+
+    init(listener: Int32) {
+        self.listener = listener
+    }
+
+    func start(holdFirstRequest: Bool) {
+        lock.lock()
+        self.holdFirstRequest = holdFirstRequest
+        lock.unlock()
+
+        DispatchQueue.global().async { [weak self] in
+            while true {
+                guard let self, !self.isStopped else { return }
+                var descriptor = pollfd(fd: self.listener, events: Int16(POLLIN), revents: 0)
+                let pollResult = poll(&descriptor, 1, 50)
+                if pollResult == 0 { continue }
+                if pollResult < 0 {
+                    if errno == EINTR { continue }
+                    return
+                }
+                let client = accept(self.listener, nil, nil)
+                if client < 0 {
+                    if errno == EINTR { continue }
+                    return
+                }
+                self.handle(client: client)
+            }
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        stopped = true
+        let held = heldFDs
+        heldFDs.removeAll()
+        lock.unlock()
+        for fd in held {
+            close(fd)
+        }
+    }
+
+    private var isStopped: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+
+    private func handle(client: Int32) {
+        var descriptor = pollfd(fd: client, events: Int16(POLLIN), revents: 0)
+        let pollResult = poll(&descriptor, 1, 200)
+        if pollResult <= 0 {
+            close(client)
+            return
+        }
+
+        var chunk = [UInt8](repeating: 0, count: 4096)
+        let count = recv(client, &chunk, chunk.count, 0)
+        if count <= 0 {
+            close(client)
+            return
+        }
+
+        let shouldHold: Bool = {
+            lock.lock()
+            defer { lock.unlock() }
+            if holdFirstRequest && !heldFirstRequest {
+                heldFirstRequest = true
+                heldFDs.append(client)
+                return true
+            }
+            return false
+        }()
+        if shouldHold {
+            return
+        }
+
+        let response = AgentBrokerResponse(id: "__ping__", ok: true, payload: .object([:]))
+        guard let payload = try? JSONEncoder().encode(response) else {
+            close(client)
+            return
+        }
+        var data = payload
+        data.append(0x0A)
+        data.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            _ = write(client, base, data.count)
+        }
+        close(client)
+    }
+}
+
+@Test
 func toolsListContainsExpectedTools() {
     let names = Set(ToolSchemas.allTools.map(\.name))
     #expect(names.contains("memory_append"))

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -2532,7 +2532,7 @@ func sessionStartEndAndScopedRecallSearchWork() async throws {
         #expect(scopedRecall.isError != true)
         let scopedRecallText = firstText(in: scopedRecall)
         #expect(scopedRecallText.contains("SESSION_ONLY_XYZ"))
-        #expect(!scopedRecallText.contains("GLOBAL_ONLY_ABC"))
+        #expect(scopedRecallText.contains("GLOBAL_") && scopedRecallText.contains("ABC"))
 
         let unscopedSearch = await WaxMCPTools.handleCall(
             params: .init(
@@ -5263,7 +5263,11 @@ func brokerSessionResumeSelectorSkipsEndedManifests() async throws {
         let firstPayload = try #require(first.payload?.objectValue)
         let firstSessionID = try #require(firstPayload["session_id"]?.stringValue)
 
-        try await Task.sleep(for: .milliseconds(2))
+        let ended = await service.handle(.init(
+            command: "session_end",
+            arguments: ["session_id": .string(firstSessionID)]
+        ))
+        #expect(ended.ok == true)
 
         let second = await service.handle(.init(
             command: "session_start",
@@ -5275,12 +5279,7 @@ func brokerSessionResumeSelectorSkipsEndedManifests() async throws {
         #expect(second.ok == true)
         let secondPayload = try #require(second.payload?.objectValue)
         let secondSessionID = try #require(secondPayload["session_id"]?.stringValue)
-
-        let ended = await service.handle(.init(
-            command: "session_end",
-            arguments: ["session_id": .string(secondSessionID)]
-        ))
-        #expect(ended.ok == true)
+        #expect(secondSessionID != firstSessionID)
 
         let resumed = await service.handle(.init(
             command: "session_resume",
@@ -5292,7 +5291,7 @@ func brokerSessionResumeSelectorSkipsEndedManifests() async throws {
 
         #expect(resumed.ok == true)
         let resumedPayload = try #require(resumed.payload?.objectValue)
-        #expect(resumedPayload["session_id"]?.stringValue == firstSessionID)
+        #expect(resumedPayload["session_id"]?.stringValue == secondSessionID)
         #expect(resumedPayload["resumed"]?.boolValue == true)
     }
 }
@@ -6613,7 +6612,7 @@ struct WaxMCPProcessTests {
             timeout: 20
         )
         #expect(recall.contains("SESSION_ONLY_XYZ"))
-        #expect(!recall.contains("GLOBAL_ONLY_ABC"))
+        #expect(recall.contains("GLOBAL_") && recall.contains("ABC"))
 
         _ = try await harness.callTool(
             id: 7,
@@ -7623,6 +7622,39 @@ struct WaxMCPProcessTests {
         #expect(bootstrap.initialize.contains(#""protocolVersion":"2024-11-05""#))
         #expect(bootstrap.toolsList?.contains(#""name":"remember""#) == true)
         #expect(!stderr.localizedCaseInsensitiveContains("use a unique --store-path"))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func threeMCPClientsAttachToOneBrokerWithoutExclusiveLockTimeout() async throws {
+        let sharedStoreURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-mcp-three-clients-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+
+        let first = try MCPServerProcessHarness(storeURL: sharedStoreURL)
+        let second = try MCPServerProcessHarness(storeURL: sharedStoreURL)
+        let third = try MCPServerProcessHarness(storeURL: sharedStoreURL)
+        try first.start()
+        try second.start()
+        try third.start()
+        defer {
+            first.terminateIfNeeded()
+            second.terminateIfNeeded()
+            third.terminateIfNeeded()
+        }
+
+        _ = try await first.bootstrap(clientName: "wax-mcp-three-a", includeToolsList: true)
+        _ = try await second.bootstrap(clientName: "wax-mcp-three-b", includeToolsList: true)
+        _ = try await third.bootstrap(clientName: "wax-mcp-three-c", includeToolsList: true)
+
+        let statsA = try await first.callTool(id: 41, name: "stats", arguments: [:], timeout: 15)
+        let statsB = try await second.callTool(id: 42, name: "stats", arguments: [:], timeout: 15)
+        let statsC = try await third.callTool(id: 43, name: "stats", arguments: [:], timeout: 15)
+        #expect(!statsA.localizedCaseInsensitiveContains("Lock unavailable"))
+        #expect(!statsB.localizedCaseInsensitiveContains("Lock unavailable"))
+        #expect(!statsC.localizedCaseInsensitiveContains("Lock unavailable"))
+        #expect(statsA.contains("frameCount") || statsA.contains("storePath"))
+        #expect(first.brokerSocketPath == second.brokerSocketPath)
+        #expect(second.brokerSocketPath == third.brokerSocketPath)
     }
 
     @Test(.timeLimit(.minutes(1)))


### PR DESCRIPTION
On a clean waxmcp store, hybrid ranking was fine. The session/broker path was not: `recall` with `session_id` hid durable memory, `session_start(agent_id, run_id)` minted siblings, a cold MiniLM `remember` stalled the socket and dropped the lease, and `corpus_search` skipped the long-term store.

## Changes
- `recall(query, session_id)` merges the active session with durable long-term memory. If session search is empty, recent session notes are still included.
- `session_start(agent_id, run_id)` resumes the live pair instead of creating a sibling. Project/repo come from the MCP client's `cwd`, not the daemon binary path.
- Cold `remember` refreshes the session lease first. If the embedder is not ready, it returns `status: pending` and finishes in the background.
- The daemon accepts clients concurrently, prewarms MiniLM, and refuses to replace a live socket. MCP children attach when the socket is already up.
- `corpus_search` always searches live long-term memory.
- `memory_promote` no longer `should_write`s a one-recall "do not promote" canary. Default min recall count for non-canonical types is 2.
- `memory_search` without `session_id` can still search durable when several sessions are live. `session_synthesize` says "more than one session" instead of "no active session".
- Empty `recall` query is rejected. `alpha` is rejected unless `mode=hybrid`. Omitted `facts_query.as_of` is `null`. `compact_context` includes a live session note even when the query misses.
- Operator playbook / README paste updated to match.

## Tests
```
swift test --traits MCPServer --filter 'BrokerSessionModel|sessionStartEndAndScopedRecall|brokerSessionResumeSelectorSkipsEnded|threeMCPClientsAttach|promotionRejectsExplicit|promotionStillWritesCanonical'
```
16 passed, including the 3-client attach test.

Not in this PR: text delete/forget, WAL sparse-size footgun, flipping `accessStatsScoringEnabled`.