### PR TITLE
Land leftover PR 113 review items

### DIFF
--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -35,7 +35,7 @@ Source: `Sources/Wax/Memory.swift`
 ### Memory.SearchOptions / RetrievalMode / TimeRange
 
 - `public struct SearchOptions` with `topK` (10), `includeSurrogates` (false), `timeRange: TimeRange?` (nil), `mode: RetrievalMode` (`.hybrid()`).
-- `public enum RetrievalMode { case textOnly, vectorOnly, hybrid(alpha: Float = 0.5) }`
+- `public enum RetrievalMode { case textOnly, vectorOnly, hybrid(alpha: Float = 0.5) }` (module-scope; `Memory.RetrievalMode` is a typealias)
   - `.hybrid` degrades to the text lane when no embedder is available; `.vectorOnly` throws when vector search is unavailable. Check `RAGContext.diagnostics` for what actually ran.
 - `public struct TimeRange { afterMs: Int64?, beforeMs: Int64? }`
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -80,6 +80,9 @@ package actor AgentBrokerService {
                     options: BuiltInEmbeddingProviderOptions(tuning: embedderTuning)
                 )
             } catch {
+                if EmbeddingReadinessBinding.isTypedOpenFailure(error) {
+                    throw error
+                }
                 throw BrokerStartupError(error.localizedDescription)
             }
         }
@@ -101,6 +104,9 @@ package actor AgentBrokerService {
             )
         } catch {
             if requireVector {
+                if EmbeddingReadinessBinding.isTypedOpenFailure(error) {
+                    throw error
+                }
                 throw BrokerStartupError("Vector search required but the embedding provider is unavailable.")
             }
             throw error

--- a/Sources/Wax/EmbeddingReadiness.swift
+++ b/Sources/Wax/EmbeddingReadiness.swift
@@ -234,6 +234,11 @@ package enum EmbeddingOpenRequest: Sendable, Equatable {
 
 /// Opens a ``MemoryOrchestrator`` bound to embedding readiness (load, status, attach).
 package enum EmbeddingReadinessBinding {
+    /// Typed store/provider failures stay typed under `--require-vector`.
+    package static func isTypedOpenFailure(_ error: Error) -> Bool {
+        error is BuiltInEmbeddingProviderError || error is WaxError
+    }
+
     package static func openOrchestrator(
         at url: URL,
         config: OrchestratorConfig,

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -71,17 +71,7 @@ public actor Memory {
         }
     }
 
-    public enum RetrievalMode: Sendable, Equatable {
-        /// Search only the full-text index.
-        case textOnly
-        /// Search only the vector index. Requires vector search and an embedding provider.
-        case vectorOnly
-        /// Blend full-text and vector results using Reciprocal Rank Fusion.
-        ///
-        /// The alpha value is clamped by Wax's search engine. Higher values favor
-        /// text results; lower values favor vector results.
-        case hybrid(alpha: Float = 0.5)
-    }
+    public typealias RetrievalMode = Wax.RetrievalMode
 
     public struct SearchOptions: Sendable, Equatable {
         public var topK: Int

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -309,7 +309,7 @@ package actor MemoryOrchestrator {
             switch resolvedStatus {
             case .active(let identity), .degraded(let identity, _):
                 resolvedStatus = .degraded(identity, reason: "some saved frames have no vectors")
-            default:
+            case .disabled, .loading, .unavailable:
                 break
             }
         }
@@ -957,7 +957,7 @@ package actor MemoryOrchestrator {
 
     package func recall(
         query: String,
-        mode: Memory.RetrievalMode,
+        mode: RetrievalMode,
         frameFilter: FrameFilter? = nil,
         timeRange: SearchTimeRange? = nil,
         topK: Int? = nil
@@ -973,7 +973,7 @@ package actor MemoryOrchestrator {
 
     package func recallExecution(
         query: String,
-        mode: Memory.RetrievalMode? = nil,
+        mode: RetrievalMode? = nil,
         frameFilter: FrameFilter? = nil,
         timeRange: SearchTimeRange? = nil,
         topK: Int? = nil
@@ -1047,7 +1047,7 @@ package actor MemoryOrchestrator {
     /// - Returns: Ranked raw hits.
     package func search(
         query: String,
-        mode: Memory.RetrievalMode = .hybrid(),
+        mode: RetrievalMode = .hybrid(),
         topK: Int = 10,
         frameFilter: FrameFilter? = nil,
         timeRange: SearchTimeRange? = nil
@@ -1063,7 +1063,7 @@ package actor MemoryOrchestrator {
 
     package func searchExecution(
         query: String,
-        mode: Memory.RetrievalMode = .hybrid(),
+        mode: RetrievalMode = .hybrid(),
         topK: Int = 10,
         frameFilter: FrameFilter? = nil,
         timeRange: SearchTimeRange? = nil
@@ -1493,7 +1493,7 @@ package actor MemoryOrchestrator {
         frameFilter: FrameFilter?,
         timeRange: SearchTimeRange?,
         topK: Int?,
-        requestedMode: Memory.RetrievalMode?
+        requestedMode: RetrievalMode?
     ) async throws -> RecallExecution {
         let recallConfig = ragConfigForRecall()
         let requestedSearchMode = requestedMode.map(Self.searchMode(from:)) ?? recallConfig.searchMode
@@ -1545,7 +1545,7 @@ package actor MemoryOrchestrator {
         let state: QueryEmbeddingState
     }
 
-    private static func queryEmbeddingPolicy(for mode: Memory.RetrievalMode) -> QueryEmbeddingPolicy {
+    private static func queryEmbeddingPolicy(for mode: RetrievalMode) -> QueryEmbeddingPolicy {
         switch mode {
         case .textOnly:
             .never
@@ -1556,7 +1556,7 @@ package actor MemoryOrchestrator {
         }
     }
 
-    private static func searchMode(from mode: Memory.RetrievalMode) -> SearchMode {
+    private static func searchMode(from mode: RetrievalMode) -> SearchMode {
         switch mode {
         case .textOnly:
             .textOnly
@@ -1593,7 +1593,7 @@ package actor MemoryOrchestrator {
         }
     }
 
-    private static func modeSummary(_ mode: Memory.RetrievalMode) -> String {
+    private static func modeSummary(_ mode: RetrievalMode) -> String {
         switch mode {
         case .textOnly:
             return "text"

--- a/Sources/Wax/RetrievalMode.swift
+++ b/Sources/Wax/RetrievalMode.swift
@@ -1,0 +1,15 @@
+/// Retrieval mode for `Memory.search` / `MemoryOrchestrator` recall.
+///
+/// Apps keep writing `Memory.RetrievalMode`. The enum lives at module scope so
+/// the package engine does not take a type nested on the public facade.
+public enum RetrievalMode: Sendable, Equatable {
+    /// Search only the full-text index.
+    case textOnly
+    /// Search only the vector index. Requires vector search and an embedding provider.
+    case vectorOnly
+    /// Blend full-text and vector results using Reciprocal Rank Fusion.
+    ///
+    /// The alpha value is clamped by Wax's search engine. Higher values favor
+    /// text results; lower values favor vector results.
+    case hybrid(alpha: Float = 0.5)
+}

--- a/Sources/WaxCLI/StoreSession.swift
+++ b/Sources/WaxCLI/StoreSession.swift
@@ -93,6 +93,9 @@ enum StoreSession {
                 options: BuiltInEmbeddingProviderOptions(tuning: embedderTuning)
             )
         } catch {
+            if EmbeddingReadinessBinding.isTypedOpenFailure(error) {
+                throw error
+            }
             throw CLIError(error.localizedDescription)
         }
 
@@ -107,6 +110,9 @@ enum StoreSession {
             )
         } catch {
             if requireVector {
+                if EmbeddingReadinessBinding.isTypedOpenFailure(error) {
+                    throw error
+                }
                 throw CLIError("Vector search required but \(error.localizedDescription)")
             }
             throw error

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -703,6 +703,73 @@ func coldRememberPendingWriteSurfacesTypedFailureWhenEmbedderFails() async throw
     }
 }
 
+@Test
+func requireVectorOpenPreservesBuiltInTimeoutError() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-require-vector-timeout-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    do {
+        _ = try await AgentBrokerService(
+            storePath: storeURL.path,
+            sessionRootPath: sessionRootURL.path,
+            noEmbedder: false,
+            embedderChoice: "minilm",
+            requireVector: true,
+            readiness: EmbeddingReadiness()
+        ) {
+            throw BuiltInEmbeddingProviderError.timedOut(.miniLM)
+        }
+        Issue.record("require-vector open should preserve BuiltInEmbeddingProviderError.timedOut")
+    } catch let error as BuiltInEmbeddingProviderError {
+        #expect(error == .timedOut(.miniLM))
+    } catch {
+        Issue.record("expected BuiltInEmbeddingProviderError.timedOut, got \(error)")
+    }
+}
+
+@Test
+func requireVectorOpenPreservesLockUnavailableError() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-require-vector-lock-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    var config = OrchestratorConfig.default
+    config.enableVectorSearch = false
+    let holder = try await MemoryOrchestrator(at: storeURL, config: config)
+    defer { Task { try? await holder.close() } }
+
+    setenv("WAX_LOCK_TIMEOUT_SECS", "0.2", 1)
+    defer { unsetenv("WAX_LOCK_TIMEOUT_SECS") }
+
+    do {
+        _ = try await AgentBrokerService(
+            storePath: storeURL.path,
+            sessionRootPath: sessionRootURL.path,
+            noEmbedder: false,
+            embedderChoice: "minilm",
+            requireVector: true,
+            readiness: EmbeddingReadiness()
+        ) {
+            PendingRememberTestEmbedder()
+        }
+        Issue.record("require-vector open should preserve WaxError.lockUnavailable")
+    } catch let error as WaxError {
+        guard case .lockUnavailable = error else {
+            Issue.record("expected WaxError.lockUnavailable, got \(error)")
+            return
+        }
+    } catch {
+        Issue.record("expected WaxError.lockUnavailable, got \(error)")
+    }
+}
+
 private func recallItem(frameId: UInt64, score: Float, text: String) -> RAGContext.Item {
     RAGContext.Item(
         kind: .snippet,

--- a/Tests/WaxTests/EmbeddingReadinessTests.swift
+++ b/Tests/WaxTests/EmbeddingReadinessTests.swift
@@ -187,6 +187,15 @@ func hostEmbeddingReadinessMapsExistingFlags() throws {
     )
 }
 
+@Test
+func memoryRetrievalModeAliasesModuleScopeRetrievalMode() {
+    let nested: Memory.RetrievalMode = .hybrid(alpha: 0.4)
+    let root: RetrievalMode = nested
+    #expect(root == .hybrid(alpha: 0.4))
+    #expect(Memory.RetrievalMode.textOnly == RetrievalMode.textOnly)
+    #expect(Memory.RetrievalMode.vectorOnly == RetrievalMode.vectorOnly)
+}
+
 private struct RecordingEmbedder: EmbeddingProvider {
     let dimensions = 2
     let normalize = true


### PR DESCRIPTION
## Summary
Follow-up to #113 leftover report-only items:

- Exhaustive `EmbeddingStatus` switch (no `default`) when deciding degrade.
- `RetrievalMode` lives at module scope; `Memory.RetrievalMode` is a typealias. `MemoryOrchestrator` takes the module type.
- `--require-vector` rethrows `BuiltInEmbeddingProviderError` and `WaxError` instead of flattening them to one unavailable string.

## Test plan
- [x] `swift test --traits MCPServer --filter 'memoryRetrievalModeAliasesModuleScopeRetrievalMode|requireVectorOpenPreserves|hostEmbeddingReadinessMapsExistingFlags|vectorRequiredOpenRejectsNoEmbedderFlag|brokerBackedVectorRequirementFailsFastWhenNoEmbedderIsConfigured'`
- [x] `swift test --filter 'publicAPI|WaxPublicDocs|docsPastePublicAPI'`