### PR TITLE
release: waxmcp v0.1.28

### DIFF
--- a/.pi/extensions/wax-agents/package.json
+++ b/.pi/extensions/wax-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-agents",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Wax-specific multi-agent orchestration for pi",
   "dependencies": {
     "typebox": "^1.0.0"

--- a/Resources/hermes/README.md
+++ b/Resources/hermes/README.md
@@ -98,7 +98,7 @@ Add to your Hermes `$HERMES_HOME/config.yaml`:
 mcp_servers:
   wax-memory:
     command: "npx"
-    args: ["-y", "waxmcp@0.1.27", "mcp", "serve"]
+    args: ["-y", "waxmcp@0.1.28", "mcp", "serve"]
     env:
       WAX_MCP_FEATURE_LICENSE: "0"
       WAX_MCP_FEATURE_STRUCTURED_MEMORY: "1"
@@ -115,7 +115,7 @@ mcp_servers:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `command` | `npx` | Launcher for waxmcp |
-| `args` | `["-y", "waxmcp@0.1.27", "mcp", "serve"]` | Arguments passed to waxmcp |
+| `args` | `["-y", "waxmcp@0.1.28", "mcp", "serve"]` | Arguments passed to waxmcp |
 | `env.WAX_MCP_FEATURE_LICENSE` | `"0"` | Disable license checks |
 | `env.WAX_MCP_FEATURE_STRUCTURED_MEMORY` | `"1"` | Enable structured memory tools |
 | `timeout` | `120` | MCP call timeout in seconds |

--- a/Resources/hermes/wax-memory-plugin/plugin.yaml
+++ b/Resources/hermes/wax-memory-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.27
+version: 0.1.28
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -1,8 +1,8 @@
 class Wax < Formula
   desc "On-device memory and RAG framework with MCP server for Claude Code"
   homepage "https://github.com/christopherkarani/Wax"
-  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.27.tar.gz"
-  sha256 "d7281898f90831ce61ae5851bd60d6dfdf5c05df8700ff71ea95cbdc6bac55a3"
+  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.28.tar.gz"
+  sha256 "8625eae9bdfc53372ab5dd4eb85035313266df7554e1ce66de38e8a052e82cf3"
   license "MIT"
 
   depends_on xcode: ["16.3", :build]

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxmcp",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "npx launcher for the Wax MCP server",
   "repository": {
     "type": "git",

--- a/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
+++ b/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.27
+version: 0.1.28
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/openclaw/wax-memory-plugin/package.json
+++ b/Resources/openclaw/wax-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wax/openclaw-wax-memory",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "type": "module",
   "description": "OpenClaw memory plugin for Wax-backed agent memory.",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "openclaw": ">=2026.3.24-beta.2"
   },
   "dependencies": {
-    "waxmcp": "0.1.27"
+    "waxmcp": "0.1.28"
   },
   "devDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -23,7 +23,7 @@ import WaxVectorSearchArctic
 #endif
 
 enum WaxMCPServerMetadata {
-    static let version = "0.1.27"
+    static let version = "0.1.28"
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
## Summary

Cut **waxmcp / Wax 0.1.28** from current `main` (everything merged since `waxmcp-v0.1.27`).

### Version surfaces
- `waxmcp` npm → 0.1.28
- `WaxMCPServerMetadata.version` → 0.1.28
- OpenClaw plugin + `waxmcp` dep → 0.1.28
- Homebrew formula URL → `waxmcp-v0.1.28`
- OpenCode extension → 0.1.28
- Hermes plugin (canonical + npm ship copy) → 0.1.28

### Since 0.1.27
- Session/broker honesty: recall with `session_id` merges durable memory; `session_start` reuses live agent/run; corpus/promote/synthesize no longer fail-open (#115)
- Embedder readiness: pending `remember` waits until ready; unavailable provider throws `missingEmbedder` (#113)
- Photo/video public facades land on the session-fix main (#113)
- Leftover PR 113 review items (#116)

### Known CI on this main
- `gates (full)` and Linux `WaxCoreTests` are red on `6a4ef4b7a` (Linux: `activeSurrogateSourceFramesReturnsOnlyCommittedEligibleChunks`; macOS: `WaxCLI demo harness` plus extra gate issues). Builds and burn/soak/hermes jobs passed. Same class of flake/pre-existing failures noted before this cut.

## Test plan
- [x] `scripts/validate-congruency.sh` → all surfaces 0.1.28
- [x] `bash Resources/scripts/quality/hermes_plugin_tests.sh`
- [ ] Tag `waxmcp-v0.1.28` triggers release workflow → `npm view waxmcp version` is `0.1.28`
- [ ] After tag, set Homebrew sha256 from the live GitHub tarball