### PR TITLE
release: waxmcp v0.1.29

### DIFF
--- a/.pi/extensions/wax-agents/package.json
+++ b/.pi/extensions/wax-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-agents",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Wax-specific multi-agent orchestration for pi",
   "dependencies": {
     "typebox": "^1.0.0"

--- a/Resources/hermes/README.md
+++ b/Resources/hermes/README.md
@@ -98,7 +98,7 @@ Add to your Hermes `$HERMES_HOME/config.yaml`:
 mcp_servers:
   wax-memory:
     command: "npx"
-    args: ["-y", "waxmcp@0.1.28", "mcp", "serve"]
+    args: ["-y", "waxmcp@0.1.29", "mcp", "serve"]
     env:
       WAX_MCP_FEATURE_LICENSE: "0"
       WAX_MCP_FEATURE_STRUCTURED_MEMORY: "1"
@@ -115,7 +115,7 @@ mcp_servers:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `command` | `npx` | Launcher for waxmcp |
-| `args` | `["-y", "waxmcp@0.1.28", "mcp", "serve"]` | Arguments passed to waxmcp |
+| `args` | `["-y", "waxmcp@0.1.29", "mcp", "serve"]` | Arguments passed to waxmcp |
 | `env.WAX_MCP_FEATURE_LICENSE` | `"0"` | Disable license checks |
 | `env.WAX_MCP_FEATURE_STRUCTURED_MEMORY` | `"1"` | Enable structured memory tools |
 | `timeout` | `120` | MCP call timeout in seconds |

--- a/Resources/hermes/wax-memory-plugin/plugin.yaml
+++ b/Resources/hermes/wax-memory-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.28
+version: 0.1.29
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -1,8 +1,8 @@
 class Wax < Formula
   desc "On-device memory and RAG framework with MCP server for Claude Code"
   homepage "https://github.com/christopherkarani/Wax"
-  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.28.tar.gz"
-  sha256 "fed88cc87ea58a0b23f6088fedbab275cca91a53ef83d789367130f1a9ba87fb"
+  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.29.tar.gz"
+  sha256 "2411c4d01c1afee1ba79dab02a72dd6e38761c7f5dc9951e56f1a7cb5392954f"
   license "MIT"
 
   depends_on xcode: ["16.3", :build]

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxmcp",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "npx launcher for the Wax MCP server",
   "repository": {
     "type": "git",

--- a/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
+++ b/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.28
+version: 0.1.29
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/openclaw/wax-memory-plugin/package.json
+++ b/Resources/openclaw/wax-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wax/openclaw-wax-memory",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "description": "OpenClaw memory plugin for Wax-backed agent memory.",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "openclaw": ">=2026.3.24-beta.2"
   },
   "dependencies": {
-    "waxmcp": "0.1.28"
+    "waxmcp": "0.1.29"
   },
   "devDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -23,7 +23,7 @@ import WaxVectorSearchArctic
 #endif
 
 enum WaxMCPServerMetadata {
-    static let version = "0.1.28"
+    static let version = "0.1.29"
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
## Summary

Cut **waxmcp / Wax 0.1.29** from current `main` (everything merged since `waxmcp-v0.1.28`).

### Version surfaces
- `waxmcp` npm → 0.1.29
- `WaxMCPServerMetadata.version` → 0.1.29
- OpenClaw plugin + `waxmcp` dep → 0.1.29
- Homebrew formula URL → `waxmcp-v0.1.29`
- OpenCode extension → 0.1.29
- Hermes plugin (canonical + npm ship copy) → 0.1.29

### Since 0.1.28
- Shared-broker stdio clients stay isolated: session affinity is per MCP `Server`, not process-global (#118)
- Empty client cwd is unscoped and does not inherit the broker process repo (#118)
- `knowledge_capture` without `kind` keeps an existing entity kind (#118)
- Markdown session/dream export filters by project (#118)
- Geist README banner (replaces the 4.5MB gecko header)

### Known CI on this main
- Production gates were already red on `main` before this bump (MiniLM non-finite, embedding readiness timeouts, SurrogateSourceQueryTests, TUI demo, WAL burn). This PR is version-surface only.

## Test plan
- [x] `scripts/validate-congruency.sh` → all surfaces 0.1.29
- [x] `bash Resources/scripts/quality/hermes_plugin_tests.sh`
- [ ] Tag `waxmcp-v0.1.29` triggers release workflow → `npm view waxmcp version` is `0.1.29`
- [ ] After tag, set Homebrew sha256 from the live GitHub tarball