### PR TITLE
fix(search): rank hyphenated identifiers first and shrink session WAL

### DIFF
--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -31,6 +31,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Call `session_end` (pass `session_id` when multiple sessions may be active).
+   - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
 ## Read Path
 

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -31,6 +31,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Call `session_end` (pass `session_id` when multiple sessions may be active).
+   - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
 ## Read Path
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1291,7 +1291,10 @@ extension AgentBrokerService {
         return .object([
             "status": .string("ok"),
             "session_id": .string(target.uuidString),
-            "active": .from(!activeSessions.isEmpty),
+            "ended": .bool(true),
+            "active": .bool(false),
+            "remaining_active": .from(!activeSessions.isEmpty),
+            "active_session_count": .from(activeSessions.count),
         ])
     }
 
@@ -2557,7 +2560,8 @@ extension AgentBrokerService {
             request: embeddingRequest,
             waxOptions: CommandLineEmbedderFactory.waxOptions(),
             readiness: readiness,
-            factoryOverride: factoryOverride
+            factoryOverride: factoryOverride,
+            createWalSize: Constants.sessionWalSize
         )
     }
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1258,11 +1258,7 @@ extension AgentBrokerService {
         case (.none, 1):
             target = activeSessions.keys.first!
         case (.none, 0):
-            return .object([
-                "status": .string("ok"),
-                "session_id": .null,
-                "active": .bool(false),
-            ])
+            return sessionEndPayload(sessionID: nil, ended: false)
         default:
             throw BrokerValidationError.invalid("session_id is required when more than one session is active")
         }
@@ -1288,10 +1284,14 @@ extension AgentBrokerService {
             try await state.memory.close()
             activeSessions.removeValue(forKey: target)
         }
-        return .object([
+        return sessionEndPayload(sessionID: target, ended: true)
+    }
+
+    private func sessionEndPayload(sessionID: UUID?, ended: Bool) -> AgentBrokerValue {
+        .object([
             "status": .string("ok"),
-            "session_id": .string(target.uuidString),
-            "ended": .bool(true),
+            "session_id": sessionID.map { .string($0.uuidString) } ?? .null,
+            "ended": .bool(ended),
             "active": .bool(false),
             "remaining_active": .from(!activeSessions.isEmpty),
             "active_session_count": .from(activeSessions.count),
@@ -2554,14 +2554,22 @@ extension AgentBrokerService {
         config.enableStructuredMemory = false
         config.enableAccessStatsScoring = enableAccessStatsScoring
         config.defaultScopeContext = scopeContext
+        let waxOptions = CommandLineEmbedderFactory.waxOptions()
+        if !FileManager.default.fileExists(atPath: url.path) {
+            let created = try await Wax.create(
+                at: url,
+                walSize: Constants.sessionWalSize,
+                options: waxOptions
+            )
+            try await created.close()
+        }
         return try await EmbeddingReadinessBinding.openOrchestrator(
             at: url,
             config: config,
             request: embeddingRequest,
-            waxOptions: CommandLineEmbedderFactory.waxOptions(),
+            waxOptions: waxOptions,
             readiness: readiness,
-            factoryOverride: factoryOverride,
-            createWalSize: Constants.sessionWalSize
+            factoryOverride: factoryOverride
         )
     }
 

--- a/Sources/Wax/EmbeddingReadiness.swift
+++ b/Sources/Wax/EmbeddingReadiness.swift
@@ -245,8 +245,7 @@ package enum EmbeddingReadinessBinding {
         request: EmbeddingOpenRequest,
         waxOptions: WaxOptions = .init(),
         readiness: EmbeddingReadiness = .shared,
-        factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)? = nil,
-        createWalSize: UInt64? = nil
+        factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)? = nil
     ) async throws -> MemoryOrchestrator {
         switch request {
         case .disabled:
@@ -257,8 +256,7 @@ package enum EmbeddingReadinessBinding {
                 config: disabled,
                 embedder: nil,
                 waxOptions: waxOptions,
-                initialEmbeddingStatus: .disabled,
-                createWalSize: createWalSize
+                initialEmbeddingStatus: .disabled
             )
         case .custom(let provider):
             return try await MemoryOrchestrator(
@@ -266,8 +264,7 @@ package enum EmbeddingReadinessBinding {
                 config: config,
                 embedder: provider,
                 waxOptions: waxOptions,
-                initialEmbeddingStatus: .active(provider.identity),
-                createWalSize: createWalSize
+                initialEmbeddingStatus: .active(provider.identity)
             )
         case .automatic(let provider, let options):
             let factory = factoryOverride ?? {
@@ -284,8 +281,7 @@ package enum EmbeddingReadinessBinding {
                 at: url,
                 config: config,
                 session: session,
-                waxOptions: waxOptions,
-                createWalSize: createWalSize
+                waxOptions: waxOptions
             )
         case .builtIn(let provider, let options):
             let factory = factoryOverride ?? {
@@ -303,8 +299,7 @@ package enum EmbeddingReadinessBinding {
                     at: url,
                     config: config,
                     session: session,
-                    waxOptions: waxOptions,
-                    createWalSize: createWalSize
+                    waxOptions: waxOptions
                 )
             } catch is EmbeddingReadiness.WaitError {
                 throw BuiltInEmbeddingProviderError.timedOut(provider)
@@ -316,8 +311,7 @@ package enum EmbeddingReadinessBinding {
         at url: URL,
         config: OrchestratorConfig,
         session: EmbeddingReadinessSession,
-        waxOptions: WaxOptions,
-        createWalSize: UInt64? = nil
+        waxOptions: WaxOptions
     ) async throws -> MemoryOrchestrator {
         let snapshot = await session.snapshot()
         let orchestrator = try await MemoryOrchestrator(
@@ -325,8 +319,7 @@ package enum EmbeddingReadinessBinding {
             config: config,
             embedder: snapshot.provider,
             waxOptions: waxOptions,
-            initialEmbeddingStatus: snapshot.status,
-            createWalSize: createWalSize
+            initialEmbeddingStatus: snapshot.status
         )
         let latest = await session.snapshot()
         switch latest.status {

--- a/Sources/Wax/EmbeddingReadiness.swift
+++ b/Sources/Wax/EmbeddingReadiness.swift
@@ -245,7 +245,8 @@ package enum EmbeddingReadinessBinding {
         request: EmbeddingOpenRequest,
         waxOptions: WaxOptions = .init(),
         readiness: EmbeddingReadiness = .shared,
-        factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)? = nil
+        factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)? = nil,
+        createWalSize: UInt64? = nil
     ) async throws -> MemoryOrchestrator {
         switch request {
         case .disabled:
@@ -256,7 +257,8 @@ package enum EmbeddingReadinessBinding {
                 config: disabled,
                 embedder: nil,
                 waxOptions: waxOptions,
-                initialEmbeddingStatus: .disabled
+                initialEmbeddingStatus: .disabled,
+                createWalSize: createWalSize
             )
         case .custom(let provider):
             return try await MemoryOrchestrator(
@@ -264,7 +266,8 @@ package enum EmbeddingReadinessBinding {
                 config: config,
                 embedder: provider,
                 waxOptions: waxOptions,
-                initialEmbeddingStatus: .active(provider.identity)
+                initialEmbeddingStatus: .active(provider.identity),
+                createWalSize: createWalSize
             )
         case .automatic(let provider, let options):
             let factory = factoryOverride ?? {
@@ -281,7 +284,8 @@ package enum EmbeddingReadinessBinding {
                 at: url,
                 config: config,
                 session: session,
-                waxOptions: waxOptions
+                waxOptions: waxOptions,
+                createWalSize: createWalSize
             )
         case .builtIn(let provider, let options):
             let factory = factoryOverride ?? {
@@ -299,7 +303,8 @@ package enum EmbeddingReadinessBinding {
                     at: url,
                     config: config,
                     session: session,
-                    waxOptions: waxOptions
+                    waxOptions: waxOptions,
+                    createWalSize: createWalSize
                 )
             } catch is EmbeddingReadiness.WaitError {
                 throw BuiltInEmbeddingProviderError.timedOut(provider)
@@ -311,7 +316,8 @@ package enum EmbeddingReadinessBinding {
         at url: URL,
         config: OrchestratorConfig,
         session: EmbeddingReadinessSession,
-        waxOptions: WaxOptions
+        waxOptions: WaxOptions,
+        createWalSize: UInt64? = nil
     ) async throws -> MemoryOrchestrator {
         let snapshot = await session.snapshot()
         let orchestrator = try await MemoryOrchestrator(
@@ -319,7 +325,8 @@ package enum EmbeddingReadinessBinding {
             config: config,
             embedder: snapshot.provider,
             waxOptions: waxOptions,
-            initialEmbeddingStatus: snapshot.status
+            initialEmbeddingStatus: snapshot.status,
+            createWalSize: createWalSize
         )
         let latest = await session.snapshot()
         switch latest.status {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -237,15 +237,13 @@ package actor MemoryOrchestrator {
     package init(
         at url: URL,
         config: OrchestratorConfig = .default,
-        waxOptions: WaxOptions = .init(),
-        createWalSize: UInt64? = nil
+        waxOptions: WaxOptions = .init()
     ) async throws {
         try await self.init(
             at: url,
             config: config,
             embedder: nil,
-            waxOptions: waxOptions,
-            createWalSize: createWalSize
+            waxOptions: waxOptions
         )
     }
 
@@ -254,8 +252,7 @@ package actor MemoryOrchestrator {
         config: OrchestratorConfig = .default,
         embedder: (any EmbeddingProvider)? = nil,
         waxOptions: WaxOptions = .init(),
-        initialEmbeddingStatus: EmbeddingStatus? = nil,
-        createWalSize: UInt64? = nil
+        initialEmbeddingStatus: EmbeddingStatus? = nil
     ) async throws {
         // Prewarm tokenizer in parallel with Wax file operations
         // This overlaps BPE loading (~9-13ms) with I/O-bound file operations
@@ -284,7 +281,7 @@ package actor MemoryOrchestrator {
         } else {
             self.wax = try await Wax.create(
                 at: url,
-                walSize: createWalSize ?? Constants.defaultWalSize,
+                walSize: Constants.defaultWalSize,
                 options: waxOptions
             )
         }

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -237,9 +237,16 @@ package actor MemoryOrchestrator {
     package init(
         at url: URL,
         config: OrchestratorConfig = .default,
-        waxOptions: WaxOptions = .init()
+        waxOptions: WaxOptions = .init(),
+        createWalSize: UInt64? = nil
     ) async throws {
-        try await self.init(at: url, config: config, embedder: nil, waxOptions: waxOptions)
+        try await self.init(
+            at: url,
+            config: config,
+            embedder: nil,
+            waxOptions: waxOptions,
+            createWalSize: createWalSize
+        )
     }
 
     package init(
@@ -247,7 +254,8 @@ package actor MemoryOrchestrator {
         config: OrchestratorConfig = .default,
         embedder: (any EmbeddingProvider)? = nil,
         waxOptions: WaxOptions = .init(),
-        initialEmbeddingStatus: EmbeddingStatus? = nil
+        initialEmbeddingStatus: EmbeddingStatus? = nil,
+        createWalSize: UInt64? = nil
     ) async throws {
         // Prewarm tokenizer in parallel with Wax file operations
         // This overlaps BPE loading (~9-13ms) with I/O-bound file operations
@@ -274,7 +282,11 @@ package actor MemoryOrchestrator {
         if FileManager.default.fileExists(atPath: url.path) {
             self.wax = try await Wax.open(at: url, options: waxOptions)
         } else {
-            self.wax = try await Wax.create(at: url, options: waxOptions)
+            self.wax = try await Wax.create(
+                at: url,
+                walSize: createWalSize ?? Constants.defaultWalSize,
+                options: waxOptions
+            )
         }
 
         // Auto-disable vector search when no embedder is provided and no pre-existing

--- a/Sources/Wax/StoreLockProbe.swift
+++ b/Sources/Wax/StoreLockProbe.swift
@@ -8,6 +8,17 @@ package enum StoreLockProbe {
         try lock.release()
     }
 
+    /// Non-blocking exclusive probe. Missing stores are treated as free.
+    /// Returns `true` when exclusive access can be taken immediately.
+    package static func tryExclusiveAccess(at url: URL) throws -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path) else { return true }
+        guard let lock = try FileLock.tryAcquire(at: url, mode: .exclusive) else {
+            return false
+        }
+        try lock.release()
+        return true
+    }
+
     package static func decorateLockError(
         _ error: Error,
         at url: URL,

--- a/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
+++ b/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
@@ -52,7 +52,7 @@ package enum RuleBasedQueryClassifier {
     private static let hexScalars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
 
     /// Single-token hex / identifier canaries (not ordinary English words).
-    private static func isLexicalIdentifierQuery(_ query: String) -> Bool {
+    package static func isLexicalIdentifierQuery(_ query: String) -> Bool {
         let tokens = query.split { $0.isWhitespace || $0.isNewline }
         guard tokens.count == 1 else { return false }
         let token = tokens[0]

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -27,6 +27,7 @@ extension Wax {
 
         let trimmedQuery = request.query?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let identifierQuery = trimmedQuery.map(RuleBasedQueryClassifier.isLexicalIdentifierQuery) ?? false
         let queryType: QueryType
         if let trimmedQuery, !trimmedQuery.isEmpty {
             queryType = RuleBasedQueryClassifier.classify(trimmedQuery)
@@ -461,7 +462,10 @@ extension Wax {
         }
 
         var pendingResults: [PendingResult] = []
-        pendingResults.reserveCapacity(min(requestedTopK, baseResults.count))
+        let pendingLimit = identifierQuery
+            ? min(max(requestedTopK * 3, 12), 48)
+            : requestedTopK
+        pendingResults.reserveCapacity(min(pendingLimit, baseResults.count))
 
         if !baseResults.isEmpty {
             // Optimization: Use lazy metadata loading for small result sets
@@ -494,7 +498,7 @@ extension Wax {
                         )
                     )
 
-                    if pendingResults.count >= requestedTopK {
+                    if pendingResults.count >= pendingLimit {
                         break
                     }
                 }
@@ -531,7 +535,7 @@ extension Wax {
                         )
                     )
 
-                    if pendingResults.count >= requestedTopK {
+                    if pendingResults.count >= pendingLimit {
                         break
                     }
                 }
@@ -588,6 +592,16 @@ extension Wax {
             scopeContext: request.scopeContext,
             maxWindow: min(max(request.topK * 3, 12), 48)
         )
+        if let trimmedQuery, !trimmedQuery.isEmpty {
+            filtered = Self.identifierExactMatchRerank(
+                results: filtered,
+                query: trimmedQuery,
+                maxWindow: min(max(request.topK * 3, 12), 48)
+            )
+        }
+        if filtered.count > requestedTopK {
+            filtered = Array(filtered.prefix(requestedTopK))
+        }
 
         if filtered.isEmpty, request.allowTimelineFallback {
             filtered = await timelineFallbackResults(request: request, filter: filter)
@@ -719,6 +733,60 @@ extension Wax {
         combined.append(contentsOf: results.dropFirst(cappedWindow).filter {
             !MemorySemantics.parse(metadata: $0.metadata, nowMs: nowMs).isExpired
         })
+        return combined
+    }
+
+    /// Query-side exact-substring boost for identifier-like queries (caps, hyphens, few tokens).
+    /// FTS `unicode61` splits hyphens, so similar prose can beat the unique token on BM25;
+    /// same-repo/project semantic rerank can then lift a neighbor. This pass runs after
+    /// semantic rerank so an exact phrase hit stays rank 1. Vector-only ranking is unchanged.
+    private static func identifierExactMatchRerank(
+        results: [SearchResponse.Result],
+        query: String,
+        maxWindow: Int
+    ) -> [SearchResponse.Result] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard RuleBasedQueryClassifier.isLexicalIdentifierQuery(needle) else { return results }
+        let cappedWindow = min(max(0, maxWindow), results.count)
+        guard cappedWindow > 1 else { return results }
+
+        let lowerNeedle = needle.lowercased()
+        // Larger than same-repo (0.9) + same-project (0.7) + decision (0.45) + durable (0.25).
+        let exactMatchBonus: Float = 5.0
+
+        let scoredHead = results.prefix(cappedWindow).enumerated().map { index, result -> (index: Int, composite: Float, matched: Bool, result: SearchResponse.Result) in
+            let haystack = dehighlightedPreviewText(result.previewText ?? "").lowercased()
+            let matched = !haystack.isEmpty && haystack.contains(lowerNeedle)
+            var updated = result
+            if matched {
+                updated.explanations = dedupedExplanations(result.explanations + ["exact identifier match"])
+            }
+            return (
+                index: index,
+                composite: result.score + (matched ? exactMatchBonus : 0),
+                matched: matched,
+                result: updated
+            )
+        }
+
+        guard scoredHead.contains(where: \.matched) else { return results }
+
+        let rankedHead = scoredHead.sorted { lhs, rhs in
+            if lhs.composite != rhs.composite { return lhs.composite > rhs.composite }
+            if lhs.result.score != rhs.result.score { return lhs.result.score > rhs.result.score }
+            return lhs.index < rhs.index
+        }.map { item -> SearchResponse.Result in
+            var result = item.result
+            result.score = item.composite
+            return result
+        }
+
+        if cappedWindow == results.count {
+            return rankedHead
+        }
+        var combined = rankedHead
+        combined.reserveCapacity(results.count)
+        combined.append(contentsOf: results.dropFirst(cappedWindow))
         return combined
     }
 

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -27,7 +27,6 @@ extension Wax {
 
         let trimmedQuery = request.query?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let identifierQuery = trimmedQuery.map(RuleBasedQueryClassifier.isLexicalIdentifierQuery) ?? false
         let queryType: QueryType
         if let trimmedQuery, !trimmedQuery.isEmpty {
             queryType = RuleBasedQueryClassifier.classify(trimmedQuery)
@@ -55,6 +54,12 @@ extension Wax {
             includeText = true
             includeVector = true
         }
+
+        // Identifier overfetch + exact-match rerank are text-lane only.
+        // vectorOnly must not widen the pending window or promote a buried exact frame.
+        let identifierWindow: Int? = (
+            includeText && (trimmedQuery.map(RuleBasedQueryClassifier.isLexicalIdentifierQuery) ?? false)
+        ) ? min(max(requestedTopK * 3, 12), 48) : nil
 
         let candidateLimit = Self.candidateLimit(for: requestedTopK, filter: filter)
         let cache = UnifiedSearchEngineCache.shared
@@ -462,9 +467,7 @@ extension Wax {
         }
 
         var pendingResults: [PendingResult] = []
-        let pendingLimit = identifierQuery
-            ? min(max(requestedTopK * 3, 12), 48)
-            : requestedTopK
+        let pendingLimit = identifierWindow ?? requestedTopK
         pendingResults.reserveCapacity(min(pendingLimit, baseResults.count))
 
         if !baseResults.isEmpty {
@@ -592,11 +595,11 @@ extension Wax {
             scopeContext: request.scopeContext,
             maxWindow: min(max(request.topK * 3, 12), 48)
         )
-        if let trimmedQuery, !trimmedQuery.isEmpty {
+        if let identifierWindow, let trimmedQuery {
             filtered = Self.identifierExactMatchRerank(
                 results: filtered,
                 query: trimmedQuery,
-                maxWindow: min(max(request.topK * 3, 12), 48)
+                maxWindow: identifierWindow
             )
         }
         if filtered.count > requestedTopK {
@@ -746,7 +749,7 @@ extension Wax {
         maxWindow: Int
     ) -> [SearchResponse.Result] {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard RuleBasedQueryClassifier.isLexicalIdentifierQuery(needle) else { return results }
+        guard !needle.isEmpty else { return results }
         let cappedWindow = min(max(0, maxWindow), results.count)
         guard cappedWindow > 1 else { return results }
 

--- a/Sources/WaxCLI/VectorHealthCommand.swift
+++ b/Sources/WaxCLI/VectorHealthCommand.swift
@@ -1,7 +1,6 @@
 import ArgumentParser
 import Foundation
 import Wax
-import WaxCore
 
 struct VectorHealthCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -86,7 +85,7 @@ private extension VectorHealthCommand {
 
     func checkPrimaryStore() async throws -> PrimaryStoreCheck {
         let url = try StoreSession.resolveURL(store.storePath)
-        try failFastIfStoreHeldByBroker(at: url)
+        try failFastIfStoreHeld(at: url)
         return try await StoreSession.withOpen(
             at: url,
             noEmbedder: store.noEmbedder,
@@ -149,14 +148,11 @@ private extension VectorHealthCommand {
         }
     }
 
-    func failFastIfStoreHeldByBroker(at url: URL) throws {
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        if let lock = try FileLock.tryAcquire(at: url, mode: .exclusive) {
-            try lock.release()
-            return
+    func failFastIfStoreHeld(at url: URL) throws {
+        guard try StoreLockProbe.tryExclusiveAccess(at: url) else {
+            throw CLIError(
+                "another process holds an exclusive lock on this store; if a broker is attached, use waxmcp stats / attach instead of waiting"
+            )
         }
-        throw CLIError(
-            "broker holds this store; use waxmcp stats / attach instead of waiting for an exclusive lock"
-        )
     }
 }

--- a/Sources/WaxCLI/VectorHealthCommand.swift
+++ b/Sources/WaxCLI/VectorHealthCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import Wax
+import WaxCore
 
 struct VectorHealthCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -85,6 +86,7 @@ private extension VectorHealthCommand {
 
     func checkPrimaryStore() async throws -> PrimaryStoreCheck {
         let url = try StoreSession.resolveURL(store.storePath)
+        try failFastIfStoreHeldByBroker(at: url)
         return try await StoreSession.withOpen(
             at: url,
             noEmbedder: store.noEmbedder,
@@ -145,5 +147,16 @@ private extension VectorHealthCommand {
                 topSources: topSources
             )
         }
+    }
+
+    func failFastIfStoreHeldByBroker(at url: URL) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        if let lock = try FileLock.tryAcquire(at: url, mode: .exclusive) {
+            try lock.release()
+            return
+        }
+        throw CLIError(
+            "broker holds this store; use waxmcp stats / attach instead of waiting for an exclusive lock"
+        )
     }
 }

--- a/Sources/WaxCore/Constants.swift
+++ b/Sources/WaxCore/Constants.swift
@@ -43,7 +43,7 @@ package enum Constants {
     /// Default WAL size used by tests/examples (256 MiB).
     package static let defaultWalSize: UInt64 = 256 * 1024 * 1024
 
-    /// WAL size for broker virtual session stores. Long-term stores keep `defaultWalSize`.
+    /// WAL size for new broker virtual session stores only; open keeps existing WAL. Long-term stores keep `defaultWalSize`.
     package static let sessionWalSize: UInt64 = 4 * 1024 * 1024
 
     // MARK: - Decoder Limits (recommended defaults)

--- a/Sources/WaxCore/Constants.swift
+++ b/Sources/WaxCore/Constants.swift
@@ -43,6 +43,9 @@ package enum Constants {
     /// Default WAL size used by tests/examples (256 MiB).
     package static let defaultWalSize: UInt64 = 256 * 1024 * 1024
 
+    /// WAL size for broker virtual session stores. Long-term stores keep `defaultWalSize`.
+    package static let sessionWalSize: UInt64 = 4 * 1024 * 1024
+
     // MARK: - Decoder Limits (recommended defaults)
 
     package static let maxStringBytes: Int = 16 * 1024 * 1024

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -13,7 +13,7 @@ enum MCPAgentInstructions {
         2) Call session_start once and keep the returned session_id for the session. The same agent_id+run_id resumes the active session.
         3) Before answering from memory, call recall (default) or search (raw ranked hits). recall with session_id merges that session with durable long-term memory.
         4) When you learn durable facts, call remember with concise factual content. Pass session_id as a top-level argument for session-scoped writes — never put session_id inside metadata.
-        5) Near session end, call handoff (content, optional project/pending_tasks/session_id), then session_end.
+        5) Near session end, call handoff (content, optional project/pending_tasks/session_id), then session_end. session_end `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
         Tool selection:
         - recall: assembled RAG context (preferred read path)

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -1502,10 +1502,14 @@ private extension WaxMCPTools {
         let args = CompatArguments(arguments)
         let sessionID = try compatParseSessionID(args)
         let result = try await sessionRegistry.end(sessionID: sessionID)
+        let remainingCount = await sessionRegistry.activeSessionIDs().count
         return jsonResult([
             "status": .string("ok"),
             "session_id": result.0.map { .string($0.uuidString) } ?? .null,
-            "active": .bool(result.1),
+            "ended": .bool(result.0 != nil),
+            "active": .bool(false),
+            "remaining_active": .bool(remainingCount > 0),
+            "active_session_count": .int(remainingCount),
         ])
     }
 

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -291,7 +291,8 @@ struct WaxCLIMemoryTests {
             let elapsed = start.duration(to: clock.now)
             #expect(elapsed < .seconds(1))
             let message = error.localizedDescription.lowercased()
-            #expect(message.contains("broker holds this store"))
+            #expect(message.contains("exclusive lock"))
+            #expect(message.contains("another process"))
             #expect(message.contains("waxmcp stats") || message.contains("attach"))
             #expect(message.contains("timed out waiting for exclusive lock") == false)
         }

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -266,6 +266,38 @@ struct WaxCLIMemoryTests {
         try await holder.close()
     }
 
+    @Test func vectorHealthFailsFastWhenStoreIsHeld() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-cli-vector-health-lock-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        config.enableStructuredMemory = true
+        config.rag.searchMode = .textOnly
+
+        let holder = try await MemoryOrchestrator(at: url, config: config)
+        let clock = ContinuousClock()
+        let start = clock.now
+        do {
+            let command = try VectorHealthCommand.parse([
+                "--store-path", url.path,
+                "--format", "json",
+            ])
+            try await command.runAsync()
+            Issue.record("expected vector-health to fail while the store is held")
+        } catch {
+            let elapsed = start.duration(to: clock.now)
+            #expect(elapsed < .seconds(1))
+            let message = error.localizedDescription.lowercased()
+            #expect(message.contains("broker holds this store"))
+            #expect(message.contains("waxmcp stats") || message.contains("attach"))
+            #expect(message.contains("timed out waiting for exclusive lock") == false)
+        }
+        try await holder.close()
+    }
+
     @Test func vectorRequiredOpenRejectsNoEmbedderFlag() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("wax-cli-require-vector-\(UUID().uuidString)")

--- a/Tests/WaxIntegrationTests/QueryClassifierTests.swift
+++ b/Tests/WaxIntegrationTests/QueryClassifierTests.swift
@@ -25,6 +25,8 @@ import Wax
 @Test func singleTokenIdentifierQueryClassifiesAsFactual() {
     #expect(RuleBasedQueryClassifier.classify("canary-token") == .factual)
     #expect(RuleBasedQueryClassifier.classify("user_id") == .factual)
+    #expect(RuleBasedQueryClassifier.classify("WAXSTRESS-DURABLE-CANARY-ALPHA-8821") == .factual)
+    #expect(RuleBasedQueryClassifier.isLexicalIdentifierQuery("WAXSTRESS-DURABLE-CANARY-ALPHA-8821"))
 }
 
 @Test func ordinarySingleWordStaysExploratory() {

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -1230,3 +1230,140 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await wax.close()
     }
 }
+
+/// Identifier-like queries (caps + hyphens) must rank the frame that contains the
+/// exact token first in text and hybrid. FTS `unicode61` splits hyphens, so similar
+/// “stress canary” prose can otherwise win BM25. Vector-only is intentionally
+/// unchecked: embeddings do not preserve unique hyphenated identifiers.
+@Test func hyphenatedIdentifierQueryRanksExactTokenFrameFirstInTextAndHybrid() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let text = try await wax.enableTextSearch()
+        let token = "WAXSTRESS-DURABLE-CANARY-ALPHA-8821"
+        let exactBody = "Durable canary frame records unique token \(token) for retrieval."
+        let neighborBody =
+            "Grok Wax MCP stress canary 20260819 notes a durable canary alpha stress test without the unique hyphenated identifier."
+
+        let neighborID = try await wax.put(
+            Data(neighborBody.utf8),
+            options: FrameMetaSubset(metadata: Metadata([
+                "wax.memory_type": "decision",
+                "wax.durability": "durable",
+                "wax.repo": "Wax",
+                "wax.project": "Wax",
+            ]))
+        )
+        try await text.index(frameId: neighborID, text: neighborBody)
+
+        let exactID = try await wax.put(
+            Data(exactBody.utf8),
+            options: FrameMetaSubset(metadata: Metadata([
+                "wax.memory_type": "note",
+                "wax.durability": "durable",
+                "wax.repo": "other-repo",
+                "wax.project": "other-project",
+            ]))
+        )
+        try await text.index(frameId: exactID, text: exactBody)
+        try await text.commit()
+
+        let textResponse = try await wax.search(
+            SearchRequest(
+                query: token,
+                mode: .textOnly,
+                topK: 5,
+                scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
+            )
+        )
+        #expect(textResponse.results.first?.frameId == exactID)
+
+        let hybridResponse = try await wax.search(
+            SearchRequest(
+                query: token,
+                embedding: [1.0, 0.0, 0.0, 0.0],
+                vectorEnginePreference: .cpuOnly,
+                mode: .hybrid(alpha: 0.5),
+                topK: 5,
+                scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
+            ),
+            engineOverrides: UnifiedSearchEngineOverrides(
+                textEngine: nil,
+                vectorEngine: DeterministicVectorResultsEngine(
+                    dimensions: 4,
+                    results: [(frameId: neighborID, score: 0.99)]
+                ),
+                structuredEngine: nil
+            )
+        )
+        #expect(hybridResponse.results.first?.frameId == exactID)
+
+        try await wax.close()
+    }
+}
+
+/// Fused hybrid ranking can bury an exclusive-text identifier under several
+/// same-repo vector neighbors. The exact-token pass must run on an overfetched
+/// window, not only the published topK cut.
+@Test func hyphenatedIdentifierQueryBeatsMultipleSameRepoHybridNeighbors() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let text = try await wax.enableTextSearch()
+        let token = "WAXSTRESS-DURABLE-CANARY-ALPHA-8821"
+        let neighborMeta = FrameMetaSubset(metadata: Metadata([
+            "wax.memory_type": "decision",
+            "wax.durability": "durable",
+            "wax.repo": "Wax",
+            "wax.project": "Wax",
+        ]))
+
+        var neighborIDs: [UInt64] = []
+        neighborIDs.reserveCapacity(6)
+        for index in 0..<6 {
+            let body =
+                "Grok Wax MCP stress canary neighbor \(index) records durable canary alpha stress notes without the unique hyphenated identifier."
+            let neighborID = try await wax.put(Data(body.utf8), options: neighborMeta)
+            try await text.index(frameId: neighborID, text: body)
+            neighborIDs.append(neighborID)
+        }
+
+        let exactBody = "Durable canary frame records unique token \(token) for retrieval."
+        let exactID = try await wax.put(
+            Data(exactBody.utf8),
+            options: FrameMetaSubset(metadata: Metadata([
+                "wax.memory_type": "note",
+                "wax.durability": "durable",
+                "wax.repo": "other-repo",
+                "wax.project": "other-project",
+            ]))
+        )
+        try await text.index(frameId: exactID, text: exactBody)
+        try await text.commit()
+
+        let vectorHits = neighborIDs.enumerated().map { index, frameId in
+            (frameId: frameId, score: Float(0.99) - Float(index) * 0.01)
+        }
+
+        let hybridResponse = try await wax.search(
+            SearchRequest(
+                query: token,
+                embedding: [1.0, 0.0, 0.0, 0.0],
+                vectorEnginePreference: .cpuOnly,
+                mode: .hybrid(alpha: 0.5),
+                topK: 5,
+                scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
+            ),
+            engineOverrides: UnifiedSearchEngineOverrides(
+                textEngine: nil,
+                vectorEngine: DeterministicVectorResultsEngine(
+                    dimensions: 4,
+                    results: vectorHits
+                ),
+                structuredEngine: nil
+            )
+        )
+        #expect(hybridResponse.results.count <= 5)
+        #expect(hybridResponse.results.first?.frameId == exactID)
+
+        try await wax.close()
+    }
+}

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -1367,3 +1367,69 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await wax.close()
     }
 }
+
+/// vectorOnly must not overfetch or exact-match-rerank an identifier query.
+/// A buried exact-token frame past the published topK cut stays unpublished.
+@Test func vectorOnlyIdentifierQueryDoesNotPromoteExactFramePastPublishedTopK() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let token = "WAXSTRESS-DURABLE-CANARY-ALPHA-8821"
+        let neighborMeta = FrameMetaSubset(metadata: Metadata([
+            "wax.memory_type": "decision",
+            "wax.durability": "durable",
+            "wax.repo": "Wax",
+            "wax.project": "Wax",
+        ]))
+
+        var neighborIDs: [UInt64] = []
+        neighborIDs.reserveCapacity(6)
+        for index in 0..<6 {
+            let body =
+                "Grok Wax MCP stress canary neighbor \(index) records durable canary alpha stress notes without the unique hyphenated identifier."
+            let neighborID = try await wax.put(Data(body.utf8), options: neighborMeta)
+            neighborIDs.append(neighborID)
+        }
+
+        let exactBody = "Durable canary frame records unique token \(token) for retrieval."
+        let exactID = try await wax.put(
+            Data(exactBody.utf8),
+            options: FrameMetaSubset(metadata: Metadata([
+                "wax.memory_type": "note",
+                "wax.durability": "durable",
+                "wax.repo": "other-repo",
+                "wax.project": "other-project",
+            ]))
+        )
+
+        var vectorHits = neighborIDs.enumerated().map { index, frameId in
+            (frameId: frameId, score: Float(0.99) - Float(index) * 0.01)
+        }
+        vectorHits.append((frameId: exactID, score: 0.01))
+
+        let response = try await wax.search(
+            SearchRequest(
+                query: token,
+                embedding: [1.0, 0.0, 0.0, 0.0],
+                vectorEnginePreference: .cpuOnly,
+                mode: .vectorOnly,
+                topK: 5,
+                scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
+            ),
+            engineOverrides: UnifiedSearchEngineOverrides(
+                textEngine: nil,
+                vectorEngine: DeterministicVectorResultsEngine(
+                    dimensions: 4,
+                    results: vectorHits
+                ),
+                structuredEngine: nil
+            )
+        )
+
+        #expect(response.results.count <= 5)
+        #expect(response.results.first?.frameId != exactID)
+        #expect(!response.results.contains { $0.frameId == exactID })
+        #expect(response.results.map(\.frameId) == Array(neighborIDs.prefix(5)))
+
+        try await wax.close()
+    }
+}

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -123,6 +123,103 @@ func sessionStartReusesActiveSessionForSameAgentAndRun() async throws {
     }
 }
 
+private let maxSessionWalBytes: UInt64 = 16 * 1024 * 1024
+
+private func waxFileSize(at path: String) throws -> UInt64 {
+    let attrs = try FileManager.default.attributesOfItem(atPath: path)
+    let size = try #require(attrs[.size] as? NSNumber)
+    return size.uint64Value
+}
+
+private func sessionWaxPaths(in sessionRoot: URL) throws -> [String] {
+    try FileManager.default.contentsOfDirectory(atPath: sessionRoot.path)
+        .filter { $0.hasSuffix(".wax") }
+        .map { sessionRoot.appendingPathComponent($0).path }
+}
+
+@Test
+func sessionStartCreatesSessionStoreWithSmallWal() async throws {
+    try await withIsolatedBroker { service, sessionRoot in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("wal-agent"),
+                "run_id": .string("wal-run"),
+            ]
+        ))
+        #expect(started.ok == true)
+        let payload = try requireObject(started.payload)
+        let storePath = try requireString(payload, "store_path")
+        let size = try waxFileSize(at: storePath)
+        #expect(size <= maxSessionWalBytes)
+        #expect(size != FrameStore.defaultWalSize)
+
+        let reused = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("wal-agent"),
+                "run_id": .string("wal-run"),
+            ]
+        ))
+        #expect(reused.ok == true)
+        let reusedPayload = try requireObject(reused.payload)
+        let startedID = try requireString(payload, "session_id")
+        #expect(try requireString(reusedPayload, "session_id") == startedID)
+        #expect(reusedPayload["resumed"]?.boolValue == true)
+        #expect(try requireString(reusedPayload, "store_path") == storePath)
+
+        let waxFiles = try sessionWaxPaths(in: sessionRoot)
+        #expect(waxFiles.count == 1)
+        #expect(try waxFileSize(at: storePath) <= maxSessionWalBytes)
+        for path in waxFiles {
+            #expect(try waxFileSize(at: path) <= maxSessionWalBytes)
+        }
+
+        let stats = await service.handle(.init(command: "stats"))
+        #expect(stats.ok == true)
+        let longTermPath = try requireString(try requireObject(stats.payload), "storePath")
+        #expect(try waxFileSize(at: longTermPath) > maxSessionWalBytes)
+    }
+}
+
+@Test
+func sessionEndMarksThatSessionInactiveWhenSiblingRemains() async throws {
+    try await withIsolatedBroker { service, _ in
+        let first = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("end-agent-a"),
+                "run_id": .string("end-run-a"),
+            ]
+        ))
+        #expect(first.ok == true)
+        let firstID = try requireString(try requireObject(first.payload), "session_id")
+
+        let second = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("end-agent-b"),
+                "run_id": .string("end-run-b"),
+            ]
+        ))
+        #expect(second.ok == true)
+        let secondID = try requireString(try requireObject(second.payload), "session_id")
+        #expect(firstID != secondID)
+
+        let ended = await service.handle(.init(
+            command: "session_end",
+            arguments: ["session_id": .string(firstID)]
+        ))
+        #expect(ended.ok == true, "session_end failed: \(ended.error ?? "nil")")
+        let payload = try requireObject(ended.payload)
+        #expect(try requireString(payload, "session_id") == firstID)
+        #expect(payload["ended"]?.boolValue == true)
+        #expect(payload["active"]?.boolValue == false)
+        #expect(payload["remaining_active"]?.boolValue == true)
+        #expect(payload["active_session_count"]?.intValue == 1)
+    }
+}
+
 @Test
 func sessionStartInfersProjectFromClientCwdNotBrokerBinary() async throws {
     try await withIsolatedBroker { service, _ in

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -4,6 +4,7 @@ import Testing
 #if MCPServer
 @testable import wax_mcp
 @testable import Wax
+@testable import WaxCore
 
 private func withIsolatedBroker<T>(
     _ body: (AgentBrokerService, URL) async throws -> T
@@ -123,18 +124,20 @@ func sessionStartReusesActiveSessionForSameAgentAndRun() async throws {
     }
 }
 
-private let maxSessionWalBytes: UInt64 = 16 * 1024 * 1024
-
 private func waxFileSize(at path: String) throws -> UInt64 {
     let attrs = try FileManager.default.attributesOfItem(atPath: path)
     let size = try #require(attrs[.size] as? NSNumber)
     return size.uint64Value
 }
 
-private func sessionWaxPaths(in sessionRoot: URL) throws -> [String] {
-    try FileManager.default.contentsOfDirectory(atPath: sessionRoot.path)
-        .filter { $0.hasSuffix(".wax") }
-        .map { sessionRoot.appendingPathComponent($0).path }
+/// Header region + footer + empty TOC. Not a 16 MiB cap.
+private let sessionWalLayoutSlack: UInt64 =
+    Constants.headerRegionSize + Constants.footerSize + 32 * 1024
+
+private func expectSessionStoreNearSessionWal(_ size: UInt64) {
+    let wal = Constants.sessionWalSize
+    #expect(size >= wal)
+    #expect(size <= wal + sessionWalLayoutSlack)
 }
 
 @Test
@@ -150,9 +153,7 @@ func sessionStartCreatesSessionStoreWithSmallWal() async throws {
         #expect(started.ok == true)
         let payload = try requireObject(started.payload)
         let storePath = try requireString(payload, "store_path")
-        let size = try waxFileSize(at: storePath)
-        #expect(size <= maxSessionWalBytes)
-        #expect(size != FrameStore.defaultWalSize)
+        expectSessionStoreNearSessionWal(try waxFileSize(at: storePath))
 
         let reused = await service.handle(.init(
             command: "session_start",
@@ -168,17 +169,32 @@ func sessionStartCreatesSessionStoreWithSmallWal() async throws {
         #expect(reusedPayload["resumed"]?.boolValue == true)
         #expect(try requireString(reusedPayload, "store_path") == storePath)
 
-        let waxFiles = try sessionWaxPaths(in: sessionRoot)
+        let waxFiles = try FileManager.default.contentsOfDirectory(atPath: sessionRoot.path)
+            .filter { $0.hasSuffix(".wax") }
         #expect(waxFiles.count == 1)
-        #expect(try waxFileSize(at: storePath) <= maxSessionWalBytes)
-        for path in waxFiles {
-            #expect(try waxFileSize(at: path) <= maxSessionWalBytes)
-        }
+        expectSessionStoreNearSessionWal(try waxFileSize(at: storePath))
 
         let stats = await service.handle(.init(command: "stats"))
         #expect(stats.ok == true)
         let longTermPath = try requireString(try requireObject(stats.payload), "storePath")
-        #expect(try waxFileSize(at: longTermPath) > maxSessionWalBytes)
+        let longTermSize = try waxFileSize(at: longTermPath)
+        #expect(longTermSize > Constants.sessionWalSize)
+        #expect(longTermSize >= Constants.defaultWalSize)
+    }
+}
+
+@Test
+func sessionEndIdleReportsConsistentKeys() async throws {
+    try await withIsolatedBroker { service, _ in
+        let ended = await service.handle(.init(command: "session_end"))
+        #expect(ended.ok == true, "idle session_end failed: \(ended.error ?? "nil")")
+        let payload = try requireObject(ended.payload)
+        #expect(payload["status"]?.stringValue == "ok")
+        #expect(payload["session_id"] == .null)
+        #expect(payload["ended"]?.boolValue == false)
+        #expect(payload["active"]?.boolValue == false)
+        #expect(payload["remaining_active"]?.boolValue == false)
+        #expect(payload["active_session_count"]?.intValue == 0)
     }
 }
 

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -370,6 +370,8 @@ func agentInstructionsDescribeSessionLifecycle() {
     #expect(text.contains("session_start"))
     #expect(text.contains("session_end"))
     #expect(text.contains("session_id"))
+    #expect(text.contains("remaining_active"))
+    #expect(text.contains("active_session_count"))
     #expect(text.contains("Do not manage SESSION_STORE"))
 }
 
@@ -3390,6 +3392,7 @@ func sessionEndReportsRemainingActiveSessions() async throws {
         #expect((ended["ended"] as? Bool) == true)
         #expect((ended["active"] as? Bool) == false)
         #expect((ended["remaining_active"] as? Bool) == true)
+        #expect((ended["active_session_count"] as? Int) == 1)
 
         let stats = await WaxMCPTools.handleCall(
             params: .init(name: "stats", arguments: [:]),
@@ -3400,6 +3403,24 @@ func sessionEndReportsRemainingActiveSessions() async throws {
         let session = statsJSON["session"] as? [String: Any]
         #expect((session?["activeSessionCount"] as? Int) == 1)
         #expect((session?["activeSessionIds"] as? [String]) == [sessionB])
+    }
+}
+
+@Test
+func sessionEndIdleMCPReportsConsistentKeys() async throws {
+    try await withMemory { memory in
+        let end = await WaxMCPTools.handleCall(
+            params: .init(name: "session_end", arguments: [:]),
+            memory: memory
+        )
+        #expect(end.isError != true)
+        let ended = try parseJSONText(in: end)
+        #expect((ended["status"] as? String) == "ok")
+        #expect(ended["session_id"] is NSNull)
+        #expect((ended["ended"] as? Bool) == false)
+        #expect((ended["active"] as? Bool) == false)
+        #expect((ended["remaining_active"] as? Bool) == false)
+        #expect((ended["active_session_count"] as? Int) == 0)
     }
 }
 

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -3387,7 +3387,9 @@ func sessionEndReportsRemainingActiveSessions() async throws {
         #expect(end.isError != true)
         let ended = try parseJSONText(in: end)
         #expect((ended["session_id"] as? String) == sessionA)
-        #expect((ended["active"] as? Bool) == true)
+        #expect((ended["ended"] as? Bool) == true)
+        #expect((ended["active"] as? Bool) == false)
+        #expect((ended["remaining_active"] as? Bool) == true)
 
         let stats = await WaxMCPTools.handleCall(
             params: .init(name: "stats", arguments: [:]),


### PR DESCRIPTION
## Summary
Hyphenated identifier queries (e.g. `WAXSTRESS-DURABLE-CANARY-ALPHA-8821`) now rank the exact-token frame first in text and hybrid search, without an FTS tokenizer migration. Broker virtual session stores are created with a 4 MiB WAL instead of the 256 MiB long-term default. `session_end` reports that session as ended even when siblings remain, and `wax-cli vector-health` fails immediately with an actionable message if another process holds the exclusive lock.

## What changed
- Query-side exact-substring bonus after semantic rerank; identifier queries overfetch `topK*3` (cap 48) then slice so fused hybrid neighbors cannot drop the exact frame before the bonus.
- `Constants.sessionWalSize` (4 MiB) is passed only through `openSessionMemory`. Long-term `defaultWalSize` is unchanged.
- `session_end` returns `ended: true`, `active: false` for that session, plus `remaining_active` / `active_session_count`.
- `vector-health` uses a non-blocking exclusive probe instead of a 5s lock wait.

## Test plan
- [x] `swift test --filter UnifiedSearch` (35 passed; XCTest benches skipped)
- [x] `swift test --filter TextSearch` (35 passed)
- [x] `swift test --filter BrokerSessionModelRegressionTests --traits MCPServer` (22 passed)
- [x] `swift test --filter hyphenatedIdentifierQuery` (2 passed)
- [x] `swift test --filter vectorHealthFailsFastWhenStoreIsHeld`
- [x] Manual temp store (not `~/.wax`): text + hybrid rank 1 = exact frame; new session `*.wax` size 4,202,679 (not 268,435,456)

Out of scope: waxmcp release, `~/.wax` wipe, Hermes plugin, public Swift API names, long-term WAL shrink.