### PR TITLE
refactor(broker): extract internal virtual session store

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,3 +7,11 @@ On-device memory for agents and apps: persist text (and experimental photo/video
 **RetrievalMode**:
 How a query is retrieved from Memory: text-only, vector-only, or hybrid. Hybrid may fall back to text; vector-only must not.
 _Avoid_: EmbeddingPolicy, QueryEmbeddingPolicy, DirectSearchMode, SearchMode (as the name hosts use)
+
+**Long-term Memory**:
+The store the broker keeps across virtual sessions. Distinct from a virtual session store.
+_Avoid_: default store, global Memory, durable store (as the store name; durable is a horizon)
+
+**Virtual session store**:
+A per-session memory store, distinct from long-term Memory, identified by `session_id`. It is its own store, not a metadata slice of long-term Memory. An omitted `session_id` means no virtual session: lookup does not infer one and does not create one. The same `agent_id` and `run_id` pair reuses the active store; one id is not enough; an ended store is not reused.
+_Avoid_: Compat session, MCP session registry, `metadata.session_id` (as the store)

--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -556,7 +556,9 @@ extension AgentBrokerService {
                 sessionMemory = active.memory
                 shouldClose = false
             } else {
-                sessionMemory = try await openSessionMemory(at: URL(fileURLWithPath: manifest.storePath))
+                sessionMemory = try await virtualSessions.openExistingSessionMemory(
+                    at: URL(fileURLWithPath: manifest.storePath)
+                )
                 shouldClose = true
             }
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -273,7 +273,6 @@ extension AgentBrokerService {
     static let maxGraphIdentifierBytes = 256
     static let maxGraphKindBytes = 64
     static let maxPromotionCandidates = BrokerPromotionSettings.maxCandidateLimit
-    package static let defaultSessionLeaseSeconds = 300
     static let maxCompactContextTokenBudget = 32_000
 
     enum MemoryHorizon: String {
@@ -1135,15 +1134,7 @@ extension AgentBrokerService {
             runID: requestedRunID,
             inferredScope: inferredScope
         )
-        return renderSessionLifecycleResult(
-            state: result.state,
-            resumed: result.resumed,
-            recoveredLease: result.recoveredLease
-        )
-    }
-
-    func findActiveSession(agentID: String, runID: String) throws -> BrokerSessionManifest? {
-        try virtualSessions.findActive(agentID: agentID, runID: runID)
+        return renderSessionLifecycleResult(result)
     }
 
     func sessionResume(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
@@ -1156,38 +1147,28 @@ extension AgentBrokerService {
             agentID: requestedAgentID,
             runID: requestedRunID
         )
-        return renderSessionLifecycleResult(
-            state: result.state,
-            resumed: result.resumed,
-            recoveredLease: result.recoveredLease
-        )
+        return renderSessionLifecycleResult(result)
     }
 
     func sessionEnd(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
-        let sessionID = try parseOptionalSessionID(args)
-        if let sessionID {
-            guard virtualSessions.live[sessionID] != nil else {
-                throw BrokerValidationError.invalid(
-                    "session_id is not active in this broker process; call session_start again"
-                )
-            }
-            try await settlePendingRememberWrites(sessionID: sessionID)
-        } else if virtualSessions.live.count == 1, let only = virtualSessions.live.keys.first {
-            try await settlePendingRememberWrites(sessionID: only)
+        let requested = try parseOptionalSessionID(args)
+        guard let target = try virtualSessions.peekEndTarget(sessionID: requested) else {
+            return sessionEndPayload(.idle)
         }
-        let result = try await virtualSessions.end(sessionID: sessionID)
-        return sessionEndPayload(sessionID: result.sessionID, ended: result.ended)
+        try await settlePendingRememberWrites(sessionID: target)
+        let result = try await virtualSessions.end(sessionID: target)
+        return sessionEndPayload(result)
     }
 
-    private func sessionEndPayload(sessionID: UUID?, ended: Bool) -> AgentBrokerValue {
+    private func sessionEndPayload(_ result: VirtualSessionStore.EndResult) -> AgentBrokerValue {
         .object([
             "status": .string("ok"),
-            "session_id": sessionID.map { .string($0.uuidString) } ?? .null,
-            "ended": .bool(ended),
+            "session_id": result.sessionID.map { .string($0.uuidString) } ?? .null,
+            "ended": .bool(result.ended),
             "active": .bool(false),
-            "remaining_active": .from(!activeSessions.isEmpty),
-            "active_session_count": .from(activeSessions.count),
+            "remaining_active": .from(result.remainingActive),
+            "active_session_count": .from(result.activeCount),
         ])
     }
 
@@ -1669,32 +1650,19 @@ extension AgentBrokerService {
         ])
     }
 
-    func resolveSessionManifest(
-        explicitSessionID: UUID?,
-        agentID: String?,
-        runID: String?
-    ) throws -> BrokerSessionManifest {
-        try virtualSessions.resolveManifest(
-            explicitSessionID: explicitSessionID,
-            agentID: agentID,
-            runID: runID
-        )
-    }
-
     private func renderSessionLifecycleResult(
-        state: SessionState,
-        resumed: Bool,
-        recoveredLease: Bool
+        _ result: VirtualSessionStore.LifecycleResult
     ) -> AgentBrokerValue {
-        .object([
+        let state = result.state
+        return .object([
             "status": .string("ok"),
             "session_id": .string(state.id.uuidString),
             "agent_id": .string(state.manifest.agentID),
             "run_id": .string(state.manifest.runID),
             "project": .from(state.manifest.project),
             "repo": .from(state.manifest.repo),
-            "resumed": .bool(resumed),
-            "recovered_lease": .bool(recoveredLease),
+            "resumed": .bool(result.resumed),
+            "recovered_lease": .bool(result.recoveredLease),
             "store_path": .string(state.storeURL.path),
             "event_log_path": .string(state.eventLogURL.path),
         ])
@@ -1740,32 +1708,31 @@ extension AgentBrokerService {
     }
 
     func recordHandoff(sessionID: UUID, content: String) async throws {
-        var state = try virtualSessions.requireLive(sessionID)
-        let nowMs = Self.nowMs()
-        state.manifest.lastHandoffAtMs = nowMs
-        state.manifest.latestHandoff = MemorySemantics.summarizeCandidate(content, maxLength: 220)
-        state.manifest.updatedAtMs = nowMs
+        let summary = MemorySemantics.summarizeCandidate(content, maxLength: 220)
         try await appendSessionEvent(
             sessionID: sessionID,
             kind: .handoff,
             payload: [
-                "summary": state.manifest.latestHandoff ?? "",
+                "summary": summary,
             ]
         )
-        try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-        try virtualSessions.replaceLive(state)
+        try virtualSessions.updateLive(sessionID) { state in
+            let nowMs = Self.nowMs()
+            state.manifest.lastHandoffAtMs = nowMs
+            state.manifest.latestHandoff = summary
+            state.manifest.updatedAtMs = nowMs
+        }
     }
 
     func recordCheckpoint(sessionID: UUID, summary: String, compactedText: String) async throws {
-        var state = try virtualSessions.requireLive(sessionID)
-        let nowMs = Self.nowMs()
-        state.manifest.lastCheckpointAtMs = nowMs
-        state.manifest.lastCompactionAtMs = nowMs
-        state.manifest.checkpointCount += 1
-        state.manifest.latestSummary = summary
-        state.manifest.updatedAtMs = nowMs
-        try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-        try virtualSessions.replaceLive(state)
+        try virtualSessions.updateLive(sessionID) { state in
+            let nowMs = Self.nowMs()
+            state.manifest.lastCheckpointAtMs = nowMs
+            state.manifest.lastCompactionAtMs = nowMs
+            state.manifest.checkpointCount += 1
+            state.manifest.latestSummary = summary
+            state.manifest.updatedAtMs = nowMs
+        }
         try await appendSessionEvent(
             sessionID: sessionID,
             kind: .checkpoint,
@@ -2405,7 +2372,7 @@ extension AgentBrokerService {
     }
 
     func openSessionMemory(at url: URL) async throws -> MemoryOrchestrator {
-        try await virtualSessions.openSessionMemory(at: url)
+        try await virtualSessions.openExistingSessionMemory(at: url)
     }
 
     func openAdhocMemory<T: Sendable>(
@@ -3174,7 +3141,7 @@ extension AgentBrokerService {
         }
     }
 
-    package static func nowMs() -> Int64 {
+    static func nowMs() -> Int64 {
         Int64(Date().timeIntervalSince1970 * 1000)
     }
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -2,14 +2,7 @@ import Foundation
 import WaxCore
 
 package actor AgentBrokerService {
-    struct SessionState: Sendable {
-        let id: UUID
-        var manifest: BrokerSessionManifest
-        let manifestURL: URL
-        let eventLogURL: URL
-        let storeURL: URL
-        let memory: MemoryOrchestrator
-    }
+    typealias SessionState = VirtualSessionStore.SessionState
 
     struct PendingRememberWrite: Sendable {
         let sessionID: UUID?
@@ -31,8 +24,11 @@ package actor AgentBrokerService {
     let readiness: EmbeddingReadiness
     let factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)?
     let brokerInstanceID = UUID().uuidString
-    var activeSessions: [UUID: SessionState] = [:]
+    let virtualSessions: VirtualSessionStore
     var pendingRememberWrites: [PendingRememberWrite] = []
+    var activeSessions: [UUID: SessionState] {
+        virtualSessions.live
+    }
 
     package init(
         storePath: String,
@@ -89,6 +85,29 @@ package actor AgentBrokerService {
         self.embeddingRequest = request
         self.readiness = readiness
         self.factoryOverride = factoryOverride
+        let capturedAccessStats = enableAccessStatsScoring
+        let capturedScope = scopeContext
+        let capturedRequest = request
+        let capturedReadiness = readiness
+        let capturedFactory = factoryOverride
+        self.virtualSessions = VirtualSessionStore(
+            sessionRootURL: sessionRootURL,
+            brokerInstanceID: brokerInstanceID,
+            openExisting: { url in
+                var sessionConfig = OrchestratorConfig.default
+                sessionConfig.enableStructuredMemory = false
+                sessionConfig.enableAccessStatsScoring = capturedAccessStats
+                sessionConfig.defaultScopeContext = capturedScope
+                return try await EmbeddingReadinessBinding.openOrchestrator(
+                    at: url,
+                    config: sessionConfig,
+                    request: capturedRequest,
+                    waxOptions: CommandLineEmbedderFactory.waxOptions(),
+                    readiness: capturedReadiness,
+                    factoryOverride: capturedFactory
+                )
+            }
+        )
         var config = OrchestratorConfig.default
         config.enableStructuredMemory = true
         config.enableAccessStatsScoring = enableAccessStatsScoring
@@ -120,11 +139,7 @@ package actor AgentBrokerService {
         } catch {
             pendingError = error
         }
-        for session in activeSessions.values {
-            try? await session.memory.flush()
-            try? await session.memory.close()
-        }
-        activeSessions.removeAll()
+        await virtualSessions.closeAll()
         try await longTermMemory.flush()
         try await longTermMemory.close()
         if let pendingError {
@@ -258,7 +273,7 @@ extension AgentBrokerService {
     static let maxGraphIdentifierBytes = 256
     static let maxGraphKindBytes = 64
     static let maxPromotionCandidates = BrokerPromotionSettings.maxCandidateLimit
-    static let defaultSessionLeaseSeconds = 300
+    package static let defaultSessionLeaseSeconds = 300
     static let maxCompactContextTokenBudget = 32_000
 
     enum MemoryHorizon: String {
@@ -1114,80 +1129,21 @@ extension AgentBrokerService {
             MemorySemantics.inferScopeContext(currentDirectoryPath: $0)
         } ?? scopeContext
 
-        if explicitSessionID == nil, let requestedAgentID, let requestedRunID,
-           let existing = try findActiveSession(agentID: requestedAgentID, runID: requestedRunID) {
-            return try await sessionResume(arguments: [
-                "session_id": .string(existing.sessionID.uuidString),
-            ])
-        }
-
-        let sessionID = explicitSessionID ?? UUID()
-        if let active = activeSessions[sessionID] {
-            return renderSessionLifecycleResult(state: active, resumed: true, recoveredLease: false)
-        }
-
-        let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
-        if FileManager.default.fileExists(atPath: manifestURL.path) {
-            throw BrokerValidationError.invalid("session_id already exists; use session_resume to reopen it")
-        }
-
-        let sessionURL = sessionRootURL.appendingPathComponent("\(sessionID.uuidString).wax")
-        let eventLogURL = BrokerSessionPersistence.eventLogURL(rootURL: sessionRootURL, sessionID: sessionID)
-        let memory = try await openSessionMemory(at: sessionURL)
-
-        let nowMs = Self.nowMs()
-        let agentID = requestedAgentID ?? inferredScope.repoName ?? "wax-agent"
-        let runID = requestedRunID ?? UUID().uuidString
-        let manifest = BrokerSessionManifest(
-            sessionID: sessionID,
-            agentID: agentID,
-            runID: runID,
-            project: inferredScope.projectName,
-            repo: inferredScope.repoName,
-            storePath: sessionURL.path,
-            eventLogPath: eventLogURL.path,
-            status: .active,
-            brokerLeaseOwnerID: brokerInstanceID,
-            leaseExpiresAtMs: nowMs + Int64(Self.defaultSessionLeaseSeconds * 1000),
-            createdAtMs: nowMs,
-            updatedAtMs: nowMs
+        let result = try await virtualSessions.start(
+            explicitSessionID: explicitSessionID,
+            agentID: requestedAgentID,
+            runID: requestedRunID,
+            inferredScope: inferredScope
         )
-        try BrokerSessionPersistence.appendEvent(
-            BrokerSessionEvent(
-                sessionID: sessionID,
-                agentID: agentID,
-                runID: runID,
-                timestampMs: nowMs,
-                kind: .started,
-                payload: [
-                    "project": manifest.project ?? "",
-                    "repo": manifest.repo ?? "",
-                ]
-            ),
-            to: eventLogURL
+        return renderSessionLifecycleResult(
+            state: result.state,
+            resumed: result.resumed,
+            recoveredLease: result.recoveredLease
         )
-        try BrokerSessionPersistence.saveManifest(manifest, to: manifestURL)
-        let state = SessionState(
-            id: sessionID,
-            manifest: manifest,
-            manifestURL: manifestURL,
-            eventLogURL: eventLogURL,
-            storeURL: sessionURL,
-            memory: memory
-        )
-        activeSessions[sessionID] = state
-        return renderSessionLifecycleResult(state: state, resumed: false, recoveredLease: false)
     }
 
     func findActiveSession(agentID: String, runID: String) throws -> BrokerSessionManifest? {
-        if let live = activeSessions.values.first(where: {
-            $0.manifest.agentID == agentID && $0.manifest.runID == runID
-        }) {
-            return live.manifest
-        }
-        return try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL).first { manifest in
-            manifest.status == .active && manifest.agentID == agentID && manifest.runID == runID
-        }
+        try virtualSessions.findActive(agentID: agentID, runID: runID)
     }
 
     func sessionResume(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
@@ -1195,96 +1151,33 @@ extension AgentBrokerService {
         let explicitSessionID = try parseOptionalSessionID(args)
         let requestedAgentID = try args.optionalString("agent_id")
         let requestedRunID = try args.optionalString("run_id")
-
-        let manifest = try resolveSessionManifest(
+        let result = try await virtualSessions.resume(
             explicitSessionID: explicitSessionID,
             agentID: requestedAgentID,
             runID: requestedRunID
         )
-        guard manifest.status == .active else {
-            throw BrokerValidationError.invalid("session_id has already been ended and cannot be resumed")
-        }
-
-        if let existing = activeSessions[manifest.sessionID] {
-            return renderSessionLifecycleResult(state: existing, resumed: true, recoveredLease: false)
-        }
-
-        let nowMs = Self.nowMs()
-        let recoveredLease = manifest.brokerLeaseOwnerID != nil && manifest.brokerLeaseOwnerID != brokerInstanceID
-        let memory = try await openSessionMemory(at: URL(fileURLWithPath: manifest.storePath))
-        var refreshed = manifest
-        refreshed.brokerLeaseOwnerID = brokerInstanceID
-        refreshed.leaseExpiresAtMs = nowMs + Int64(Self.defaultSessionLeaseSeconds * 1000)
-        refreshed.updatedAtMs = nowMs
-
-        let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
-        let eventLogURL = URL(fileURLWithPath: refreshed.eventLogPath)
-        try BrokerSessionPersistence.appendEvent(
-            BrokerSessionEvent(
-                sessionID: refreshed.sessionID,
-                agentID: refreshed.agentID,
-                runID: refreshed.runID,
-                timestampMs: nowMs,
-                kind: .resumed,
-                payload: [
-                    "recovered_lease": recoveredLease ? "true" : "false",
-                ]
-            ),
-            to: eventLogURL
+        return renderSessionLifecycleResult(
+            state: result.state,
+            resumed: result.resumed,
+            recoveredLease: result.recoveredLease
         )
-        try BrokerSessionPersistence.saveManifest(refreshed, to: manifestURL)
-        let state = SessionState(
-            id: refreshed.sessionID,
-            manifest: refreshed,
-            manifestURL: manifestURL,
-            eventLogURL: eventLogURL,
-            storeURL: URL(fileURLWithPath: refreshed.storePath),
-            memory: memory
-        )
-        activeSessions[refreshed.sessionID] = state
-        return renderSessionLifecycleResult(state: state, resumed: true, recoveredLease: recoveredLease)
     }
 
     func sessionEnd(arguments: [String: AgentBrokerValue]) async throws -> AgentBrokerValue {
         let args = BrokerArguments(arguments)
         let sessionID = try parseOptionalSessionID(args)
-        let target: UUID
-        switch (sessionID, activeSessions.count) {
-        case let (.some(explicit), _):
-            guard activeSessions[explicit] != nil else {
-                throw BrokerValidationError.invalid("session_id is not active in this broker process; call session_start again")
+        if let sessionID {
+            guard virtualSessions.live[sessionID] != nil else {
+                throw BrokerValidationError.invalid(
+                    "session_id is not active in this broker process; call session_start again"
+                )
             }
-            target = explicit
-        case (.none, 1):
-            target = activeSessions.keys.first!
-        case (.none, 0):
-            return sessionEndPayload(sessionID: nil, ended: false)
-        default:
-            throw BrokerValidationError.invalid("session_id is required when more than one session is active")
+            try await settlePendingRememberWrites(sessionID: sessionID)
+        } else if virtualSessions.live.count == 1, let only = virtualSessions.live.keys.first {
+            try await settlePendingRememberWrites(sessionID: only)
         }
-        if let state = activeSessions[target] {
-            try await settlePendingRememberWrites(sessionID: target)
-            var manifest = state.manifest
-            manifest.status = .ended
-            manifest.updatedAtMs = Self.nowMs()
-            manifest.brokerLeaseOwnerID = nil
-            manifest.leaseExpiresAtMs = nil
-            try BrokerSessionPersistence.saveManifest(manifest, to: state.manifestURL)
-            try BrokerSessionPersistence.appendEvent(
-                BrokerSessionEvent(
-                    sessionID: state.id,
-                    agentID: manifest.agentID,
-                    runID: manifest.runID,
-                    timestampMs: manifest.updatedAtMs,
-                    kind: .ended
-                ),
-                to: state.eventLogURL
-            )
-            try await state.memory.flush()
-            try await state.memory.close()
-            activeSessions.removeValue(forKey: target)
-        }
-        return sessionEndPayload(sessionID: target, ended: true)
+        let result = try await virtualSessions.end(sessionID: sessionID)
+        return sessionEndPayload(sessionID: result.sessionID, ended: result.ended)
     }
 
     private func sessionEndPayload(sessionID: UUID?, ended: Bool) -> AgentBrokerValue {
@@ -1781,21 +1674,11 @@ extension AgentBrokerService {
         agentID: String?,
         runID: String?
     ) throws -> BrokerSessionManifest {
-        if let explicitSessionID {
-            return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
-        }
-
-        let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
-        let filtered = manifests.filter { manifest in
-            guard manifest.status == .active else { return false }
-            if let agentID, manifest.agentID != agentID { return false }
-            if let runID, manifest.runID != runID { return false }
-            return true
-        }
-        guard let match = filtered.first else {
-            throw BrokerValidationError.invalid("No resumable session manifest matched the requested selectors")
-        }
-        return match
+        try virtualSessions.resolveManifest(
+            explicitSessionID: explicitSessionID,
+            agentID: agentID,
+            runID: runID
+        )
     }
 
     private func renderSessionLifecycleResult(
@@ -1818,14 +1701,7 @@ extension AgentBrokerService {
     }
 
     func refreshSessionManifest(_ sessionID: UUID) async throws {
-        guard var state = activeSessions[sessionID] else {
-            throw BrokerValidationError.invalid("session_id is not active in this broker process; call session_start again")
-        }
-        state.manifest.updatedAtMs = Self.nowMs()
-        state.manifest.brokerLeaseOwnerID = brokerInstanceID
-        state.manifest.leaseExpiresAtMs = state.manifest.updatedAtMs + Int64(Self.defaultSessionLeaseSeconds * 1000)
-        try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-        activeSessions[sessionID] = state
+        try virtualSessions.refreshManifest(sessionID)
     }
 
     func appendSessionEvent(
@@ -1833,20 +1709,7 @@ extension AgentBrokerService {
         kind: BrokerSessionEvent.Kind,
         payload: [String: String] = [:]
     ) async throws {
-        guard let state = activeSessions[sessionID] else {
-            throw BrokerValidationError.invalid("session_id is not active in this broker process; call session_start again")
-        }
-        try BrokerSessionPersistence.appendEvent(
-            BrokerSessionEvent(
-                sessionID: sessionID,
-                agentID: state.manifest.agentID,
-                runID: state.manifest.runID,
-                timestampMs: Self.nowMs(),
-                kind: kind,
-                payload: payload
-            ),
-            to: state.eventLogURL
-        )
+        try virtualSessions.appendEvent(sessionID: sessionID, kind: kind, payload: payload)
     }
 
     func recordRetrievalHits(
@@ -1877,9 +1740,7 @@ extension AgentBrokerService {
     }
 
     func recordHandoff(sessionID: UUID, content: String) async throws {
-        guard var state = activeSessions[sessionID] else {
-            throw BrokerValidationError.invalid("session_id is not active in this broker process; call session_start again")
-        }
+        var state = try virtualSessions.requireLive(sessionID)
         let nowMs = Self.nowMs()
         state.manifest.lastHandoffAtMs = nowMs
         state.manifest.latestHandoff = MemorySemantics.summarizeCandidate(content, maxLength: 220)
@@ -1892,13 +1753,11 @@ extension AgentBrokerService {
             ]
         )
         try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-        activeSessions[sessionID] = state
+        try virtualSessions.replaceLive(state)
     }
 
     func recordCheckpoint(sessionID: UUID, summary: String, compactedText: String) async throws {
-        guard var state = activeSessions[sessionID] else {
-            throw BrokerValidationError.invalid("session_id is not active in this broker process; call session_start again")
-        }
+        var state = try virtualSessions.requireLive(sessionID)
         let nowMs = Self.nowMs()
         state.manifest.lastCheckpointAtMs = nowMs
         state.manifest.lastCompactionAtMs = nowMs
@@ -1906,7 +1765,7 @@ extension AgentBrokerService {
         state.manifest.latestSummary = summary
         state.manifest.updatedAtMs = nowMs
         try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-        activeSessions[sessionID] = state
+        try virtualSessions.replaceLive(state)
         try await appendSessionEvent(
             sessionID: sessionID,
             kind: .checkpoint,
@@ -2533,44 +2392,20 @@ extension AgentBrokerService {
 
 
     func memory(for sessionID: UUID?) async throws -> MemoryOrchestrator {
-        guard let sessionID else {
+        switch try virtualSessions.lookup(sessionID) {
+        case .none:
             return longTermMemory
+        case .live(let memory):
+            return memory
         }
-        guard let session = activeSessions[sessionID] else {
-            throw BrokerValidationError.invalid("session_id is not active in this broker process; call session_start again")
-        }
-        return session.memory
     }
 
     func validateActiveSession(_ sessionID: UUID?) throws {
-        guard let sessionID else { return }
-        guard activeSessions[sessionID] != nil else {
-            throw BrokerValidationError.invalid("session_id is not active in this broker process; call session_start again")
-        }
+        try virtualSessions.validateActive(sessionID)
     }
 
     func openSessionMemory(at url: URL) async throws -> MemoryOrchestrator {
-        var config = OrchestratorConfig.default
-        config.enableStructuredMemory = false
-        config.enableAccessStatsScoring = enableAccessStatsScoring
-        config.defaultScopeContext = scopeContext
-        let waxOptions = CommandLineEmbedderFactory.waxOptions()
-        if !FileManager.default.fileExists(atPath: url.path) {
-            let created = try await Wax.create(
-                at: url,
-                walSize: Constants.sessionWalSize,
-                options: waxOptions
-            )
-            try await created.close()
-        }
-        return try await EmbeddingReadinessBinding.openOrchestrator(
-            at: url,
-            config: config,
-            request: embeddingRequest,
-            waxOptions: waxOptions,
-            readiness: readiness,
-            factoryOverride: factoryOverride
-        )
+        try await virtualSessions.openSessionMemory(at: url)
     }
 
     func openAdhocMemory<T: Sendable>(
@@ -3339,7 +3174,7 @@ extension AgentBrokerService {
         }
     }
 
-    static func nowMs() -> Int64 {
+    package static func nowMs() -> Int64 {
         Int64(Date().timeIntervalSince1970 * 1000)
     }
 

--- a/Sources/Wax/Broker/VirtualSessionStore.swift
+++ b/Sources/Wax/Broker/VirtualSessionStore.swift
@@ -16,23 +16,94 @@ package final class VirtualSessionStore: @unchecked Sendable {
         package let memory: MemoryOrchestrator
     }
 
-    package struct LifecycleResult: Sendable {
-        package let state: SessionState
-        package let resumed: Bool
-        package let recoveredLease: Bool
+    package enum LifecycleResult: Sendable {
+        case started(SessionState)
+        case resumed(SessionState, recoveredLease: Bool)
+
+        package var state: SessionState {
+            switch self {
+            case .started(let state), .resumed(let state, _):
+                return state
+            }
+        }
+
+        package var resumed: Bool {
+            switch self {
+            case .started:
+                return false
+            case .resumed:
+                return true
+            }
+        }
+
+        package var recoveredLease: Bool {
+            switch self {
+            case .started:
+                return false
+            case .resumed(_, let recoveredLease):
+                return recoveredLease
+            }
+        }
     }
 
-    package struct EndResult: Sendable {
-        package let sessionID: UUID?
-        package let ended: Bool
-        package let remainingActive: Bool
-        package let activeCount: Int
+    package enum EndResult: Sendable {
+        case idle
+        case ended(sessionID: UUID, remainingActive: Int)
+
+        package var sessionID: UUID? {
+            switch self {
+            case .idle:
+                return nil
+            case .ended(let sessionID, _):
+                return sessionID
+            }
+        }
+
+        package var ended: Bool {
+            switch self {
+            case .idle:
+                return false
+            case .ended:
+                return true
+            }
+        }
+
+        package var remainingActive: Bool {
+            activeCount > 0
+        }
+
+        package var activeCount: Int {
+            switch self {
+            case .idle:
+                return 0
+            case .ended(_, let remainingActive):
+                return remainingActive
+            }
+        }
     }
 
     package enum Lookup: Sendable {
         /// No virtual session. Caller uses long-term Memory.
         case none
         case live(MemoryOrchestrator)
+    }
+
+    private enum EndTarget {
+        case idle
+        case session(id: UUID, state: SessionState)
+        case missing(UUID)
+        case requireSessionID
+    }
+
+    private struct SessionPairKey: Hashable, Sendable {
+        var agentID: String
+        var runID: String
+    }
+
+    package static let defaultSessionLeaseSeconds = 300
+
+    package static func nowMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
     }
 
     package let sessionRootURL: URL
@@ -43,6 +114,8 @@ package final class VirtualSessionStore: @unchecked Sendable {
     private let openExisting: @Sendable (URL) async throws -> MemoryOrchestrator
     private let lock = NSLock()
     private var _live: [UUID: SessionState] = [:]
+    private var creatingPairs: Set<SessionPairKey> = []
+    private var pairWaiters: [SessionPairKey: [CheckedContinuation<LifecycleResult?, Error>]] = [:]
 
     package var live: [UUID: SessionState] {
         locked { _live }
@@ -51,8 +124,8 @@ package final class VirtualSessionStore: @unchecked Sendable {
     package init(
         sessionRootURL: URL,
         brokerInstanceID: String,
-        leaseSeconds: Int = AgentBrokerService.defaultSessionLeaseSeconds,
-        nowMs: @escaping @Sendable () -> Int64 = { AgentBrokerService.nowMs() },
+        leaseSeconds: Int = VirtualSessionStore.defaultSessionLeaseSeconds,
+        nowMs: @escaping @Sendable () -> Int64 = { VirtualSessionStore.nowMs() },
         waxOptions: WaxOptions = CommandLineEmbedderFactory.waxOptions(),
         openExisting: @escaping @Sendable (URL) async throws -> MemoryOrchestrator
     ) {
@@ -64,22 +137,26 @@ package final class VirtualSessionStore: @unchecked Sendable {
         self.openExisting = openExisting
     }
 
-    /// Open a session file. New files are created at `Constants.sessionWalSize`.
-    /// Existing files keep their WAL. Resume/reuse must pass `createIfMissing: false`.
-    package func openSessionMemory(at url: URL, createIfMissing: Bool = true) async throws -> MemoryOrchestrator {
-        let exists = FileManager.default.fileExists(atPath: url.path)
-        if !exists {
-            guard createIfMissing else {
-                throw BrokerValidationError.invalid(
-                    "session store is missing at \(url.lastPathComponent); call session_start again"
-                )
-            }
+    /// Create a session file at `Constants.sessionWalSize` when missing, then open it.
+    /// Only `start` mints. Existing files keep their WAL.
+    package func createSessionMemory(at url: URL) async throws -> MemoryOrchestrator {
+        if !FileManager.default.fileExists(atPath: url.path) {
             let created = try await Wax.create(
                 at: url,
                 walSize: Constants.sessionWalSize,
                 options: waxOptions
             )
             try await created.close()
+        }
+        return try await openExisting(url)
+    }
+
+    /// Open an existing session file. Missing files fail closed and do not mint.
+    package func openExistingSessionMemory(at url: URL) async throws -> MemoryOrchestrator {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw BrokerValidationError.invalid(
+                "session store is missing at \(url.lastPathComponent); call session_start again"
+            )
         }
         return try await openExisting(url)
     }
@@ -103,9 +180,279 @@ package final class VirtualSessionStore: @unchecked Sendable {
             )
         }
 
+        var claimedPair: SessionPairKey?
+        if let agentID, let runID {
+            if let waited = try await claimPairOrWait(agentID: agentID, runID: runID) {
+                if let explicitSessionID, explicitSessionID != waited.state.id {
+                    throw BrokerValidationError.invalid(
+                        "agent_id and run_id already have an active session; use session_resume"
+                    )
+                }
+                return waited
+            }
+            claimedPair = SessionPairKey(agentID: agentID, runID: runID)
+        }
+
+        do {
+            let result = try await mintNewSession(
+                explicitSessionID: explicitSessionID,
+                agentID: agentID,
+                runID: runID,
+                inferredScope: inferredScope
+            )
+            if let claimedPair {
+                completePairClaim(claimedPair, .success(result))
+            }
+            return result
+        } catch {
+            if let claimedPair {
+                completePairClaim(claimedPair, .failure(error))
+            }
+            throw error
+        }
+    }
+
+    package func resume(
+        explicitSessionID: UUID?,
+        agentID: String?,
+        runID: String?
+    ) async throws -> LifecycleResult {
+        let manifest = try resolveManifest(
+            explicitSessionID: explicitSessionID,
+            agentID: agentID,
+            runID: runID
+        )
+        guard manifest.status == .active else {
+            throw BrokerValidationError.invalid("session_id has already been ended and cannot be resumed")
+        }
+
+        if let existing = locked({ _live[manifest.sessionID] }) {
+            return .resumed(existing, recoveredLease: false)
+        }
+
+        let timestamp = nowMs()
+        let recoveredLease = manifest.brokerLeaseOwnerID != nil && manifest.brokerLeaseOwnerID != brokerInstanceID
+        let memory = try await openExistingSessionMemory(at: URL(fileURLWithPath: manifest.storePath))
+        do {
+            if let existing = locked({ _live[manifest.sessionID] }) {
+                try? await memory.close()
+                return .resumed(existing, recoveredLease: false)
+            }
+
+            var refreshed = manifest
+            refreshed.brokerLeaseOwnerID = brokerInstanceID
+            refreshed.leaseExpiresAtMs = timestamp + Int64(leaseSeconds * 1000)
+            refreshed.updatedAtMs = timestamp
+
+            let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
+            let eventLogURL = URL(fileURLWithPath: refreshed.eventLogPath)
+            try BrokerSessionPersistence.appendEvent(
+                BrokerSessionEvent(
+                    sessionID: refreshed.sessionID,
+                    agentID: refreshed.agentID,
+                    runID: refreshed.runID,
+                    timestampMs: timestamp,
+                    kind: .resumed,
+                    payload: [
+                        "recovered_lease": recoveredLease ? "true" : "false",
+                    ]
+                ),
+                to: eventLogURL
+            )
+            try BrokerSessionPersistence.saveManifest(refreshed, to: manifestURL)
+            let state = SessionState(
+                id: refreshed.sessionID,
+                manifest: refreshed,
+                manifestURL: manifestURL,
+                eventLogURL: eventLogURL,
+                storeURL: URL(fileURLWithPath: refreshed.storePath),
+                memory: memory
+            )
+            locked { _live[refreshed.sessionID] = state }
+            return .resumed(state, recoveredLease: recoveredLease)
+        } catch {
+            try? await memory.close()
+            throw error
+        }
+    }
+
+    /// Resolve which live session `end` would tear down, without mutating `_live`.
+    package func peekEndTarget(sessionID: UUID?) throws -> UUID? {
+        try locked {
+            switch endTarget(sessionID) {
+            case .idle:
+                return nil
+            case .session(let id, _):
+                return id
+            case .missing:
+                throw Self.notActiveError
+            case .requireSessionID:
+                throw Self.requireSessionIDError
+            }
+        }
+    }
+
+    package func end(sessionID: UUID?) async throws -> EndResult {
+        let evicted: (id: UUID, state: SessionState, remaining: Int)? = try locked {
+            switch endTarget(sessionID) {
+            case .idle:
+                return nil
+            case .missing:
+                throw Self.notActiveError
+            case .requireSessionID:
+                throw Self.requireSessionIDError
+            case .session(let id, var state):
+                let timestamp = nowMs()
+                state.manifest.status = .ended
+                state.manifest.updatedAtMs = timestamp
+                state.manifest.brokerLeaseOwnerID = nil
+                state.manifest.leaseExpiresAtMs = nil
+                try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
+                try BrokerSessionPersistence.appendEvent(
+                    BrokerSessionEvent(
+                        sessionID: state.id,
+                        agentID: state.manifest.agentID,
+                        runID: state.manifest.runID,
+                        timestampMs: timestamp,
+                        kind: .ended
+                    ),
+                    to: state.eventLogURL
+                )
+                _live.removeValue(forKey: id)
+                return (id, state, _live.count)
+            }
+        }
+
+        guard let evicted else {
+            return .idle
+        }
+        try await evicted.state.memory.flush()
+        try await evicted.state.memory.close()
+        return .ended(sessionID: evicted.id, remainingActive: evicted.remaining)
+    }
+
+    /// Lookup never infers or mints. Omitted `session_id` is no virtual session.
+    /// Unknown or not live here fails closed.
+    package func lookup(_ sessionID: UUID?) throws -> Lookup {
+        guard let sessionID else { return .none }
+        guard let state = locked({ _live[sessionID] }) else {
+            throw Self.notActiveError
+        }
+        return .live(state.memory)
+    }
+
+    package func validateActive(_ sessionID: UUID?) throws {
+        guard sessionID != nil else { return }
+        _ = try lookup(sessionID)
+    }
+
+    package func findActive(agentID: String, runID: String) throws -> BrokerSessionManifest? {
+        if let liveMatch = locked({ liveMatchLocked(agentID: agentID, runID: runID) }) {
+            return liveMatch.manifest
+        }
+        let matches = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL).filter { manifest in
+            manifest.status == .active && manifest.agentID == agentID && manifest.runID == runID
+        }
+        if matches.count > 1 {
+            throw BrokerValidationError.invalid("multiple active sessions matched agent_id and run_id")
+        }
+        return matches.first
+    }
+
+    package func resolveManifest(
+        explicitSessionID: UUID?,
+        agentID: String?,
+        runID: String?
+    ) throws -> BrokerSessionManifest {
+        if let explicitSessionID {
+            return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
+        }
+
+        let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
+        let filtered = manifests.filter { manifest in
+            guard manifest.status == .active else { return false }
+            if let agentID, manifest.agentID != agentID { return false }
+            if let runID, manifest.runID != runID { return false }
+            return true
+        }
+        guard filtered.count <= 1 else {
+            throw BrokerValidationError.invalid("multiple active sessions matched the requested selectors")
+        }
+        guard let match = filtered.first else {
+            throw BrokerValidationError.invalid("No resumable session manifest matched the requested selectors")
+        }
+        return match
+    }
+
+    package func refreshManifest(_ sessionID: UUID) throws {
+        try locked {
+            guard var state = _live[sessionID] else {
+                throw Self.notActiveError
+            }
+            state.manifest.updatedAtMs = nowMs()
+            state.manifest.brokerLeaseOwnerID = brokerInstanceID
+            state.manifest.leaseExpiresAtMs = state.manifest.updatedAtMs + Int64(leaseSeconds * 1000)
+            try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
+            _live[sessionID] = state
+        }
+    }
+
+    package func appendEvent(
+        sessionID: UUID,
+        kind: BrokerSessionEvent.Kind,
+        payload: [String: String] = [:]
+    ) throws {
+        let snapshot = try locked { () -> (agentID: String, runID: String, eventLogURL: URL) in
+            guard let state = _live[sessionID] else {
+                throw Self.notActiveError
+            }
+            return (state.manifest.agentID, state.manifest.runID, state.eventLogURL)
+        }
+        try BrokerSessionPersistence.appendEvent(
+            BrokerSessionEvent(
+                sessionID: sessionID,
+                agentID: snapshot.agentID,
+                runID: snapshot.runID,
+                timestampMs: nowMs(),
+                kind: kind,
+                payload: payload
+            ),
+            to: snapshot.eventLogURL
+        )
+    }
+
+    package func updateLive(_ sessionID: UUID, _ body: (inout SessionState) throws -> Void) throws {
+        try locked {
+            guard var state = _live[sessionID] else {
+                throw Self.notActiveError
+            }
+            try body(&state)
+            try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
+            _live[sessionID] = state
+        }
+    }
+
+    package func closeAll() async {
+        let sessions = locked { () -> [SessionState] in
+            let values = Array(_live.values)
+            _live.removeAll()
+            return values
+        }
+        for session in sessions {
+            try? await session.memory.flush()
+            try? await session.memory.close()
+        }
+    }
+
+    private func mintNewSession(
+        explicitSessionID: UUID?,
+        agentID: String?,
+        runID: String?,
+        inferredScope: MemoryScopeContext
+    ) async throws -> LifecycleResult {
         let sessionID = explicitSessionID ?? UUID()
         if let active = locked({ _live[sessionID] }) {
-            return LifecycleResult(state: active, resumed: true, recoveredLease: false)
+            return .resumed(active, recoveredLease: false)
         }
 
         let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
@@ -115,10 +462,10 @@ package final class VirtualSessionStore: @unchecked Sendable {
 
         let sessionURL = sessionRootURL.appendingPathComponent("\(sessionID.uuidString).wax")
         let eventLogURL = BrokerSessionPersistence.eventLogURL(rootURL: sessionRootURL, sessionID: sessionID)
-        let memory = try await openSessionMemory(at: sessionURL, createIfMissing: true)
+        let memory = try await createSessionMemory(at: sessionURL)
         do {
             if let agentID, let runID, let existing = try findActive(agentID: agentID, runID: runID) {
-                try? await memory.close()
+                await abandonUnusedSessionFile(at: sessionURL, sessionID: sessionID, memory: memory)
                 if let explicitSessionID, explicitSessionID != existing.sessionID {
                     throw BrokerValidationError.invalid(
                         "agent_id and run_id already have an active session; use session_resume"
@@ -132,7 +479,7 @@ package final class VirtualSessionStore: @unchecked Sendable {
             }
             if let active = locked({ _live[sessionID] }) {
                 try? await memory.close()
-                return LifecycleResult(state: active, resumed: true, recoveredLease: false)
+                return .resumed(active, recoveredLease: false)
             }
 
             let timestamp = nowMs()
@@ -175,260 +522,125 @@ package final class VirtualSessionStore: @unchecked Sendable {
                 storeURL: sessionURL,
                 memory: memory
             )
-            locked { _live[sessionID] = state }
-            return LifecycleResult(state: state, resumed: false, recoveredLease: false)
-        } catch {
+            try locked {
+                if let active = _live[sessionID] {
+                    throw PairInsertRace.alreadyLive(active)
+                }
+                if let agentID, let runID, let liveMatch = liveMatchLocked(agentID: agentID, runID: runID) {
+                    throw PairInsertRace.pairTaken(liveMatch)
+                }
+                _live[sessionID] = state
+            }
+            return .started(state)
+        } catch PairInsertRace.alreadyLive(let active) {
             try? await memory.close()
+            return .resumed(active, recoveredLease: false)
+        } catch PairInsertRace.pairTaken(let existing) {
+            await abandonUnusedSessionFile(at: sessionURL, sessionID: sessionID, memory: memory)
+            return try await resume(
+                explicitSessionID: existing.id,
+                agentID: nil,
+                runID: nil
+            )
+        } catch {
+            await abandonUnusedSessionFile(at: sessionURL, sessionID: sessionID, memory: memory)
             throw error
         }
     }
 
-    package func resume(
-        explicitSessionID: UUID?,
-        agentID: String?,
-        runID: String?
-    ) async throws -> LifecycleResult {
-        let manifest = try resolveManifest(
-            explicitSessionID: explicitSessionID,
-            agentID: agentID,
-            runID: runID
-        )
-        guard manifest.status == .active else {
-            throw BrokerValidationError.invalid("session_id has already been ended and cannot be resumed")
-        }
-
-        if let existing = locked({ _live[manifest.sessionID] }) {
-            return LifecycleResult(state: existing, resumed: true, recoveredLease: false)
-        }
-
-        let timestamp = nowMs()
-        let recoveredLease = manifest.brokerLeaseOwnerID != nil && manifest.brokerLeaseOwnerID != brokerInstanceID
-        let memory = try await openSessionMemory(
-            at: URL(fileURLWithPath: manifest.storePath),
-            createIfMissing: false
-        )
-        do {
-            if let existing = locked({ _live[manifest.sessionID] }) {
-                try? await memory.close()
-                return LifecycleResult(state: existing, resumed: true, recoveredLease: false)
+    private func claimPairOrWait(agentID: String, runID: String) async throws -> LifecycleResult? {
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            if let live = liveMatchLocked(agentID: agentID, runID: runID) {
+                lock.unlock()
+                continuation.resume(returning: .resumed(live, recoveredLease: false))
+                return
             }
-
-            var refreshed = manifest
-            refreshed.brokerLeaseOwnerID = brokerInstanceID
-            refreshed.leaseExpiresAtMs = timestamp + Int64(leaseSeconds * 1000)
-            refreshed.updatedAtMs = timestamp
-
-            let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
-            let eventLogURL = URL(fileURLWithPath: refreshed.eventLogPath)
-            try BrokerSessionPersistence.appendEvent(
-                BrokerSessionEvent(
-                    sessionID: refreshed.sessionID,
-                    agentID: refreshed.agentID,
-                    runID: refreshed.runID,
-                    timestampMs: timestamp,
-                    kind: .resumed,
-                    payload: [
-                        "recovered_lease": recoveredLease ? "true" : "false",
-                    ]
-                ),
-                to: eventLogURL
-            )
-            try BrokerSessionPersistence.saveManifest(refreshed, to: manifestURL)
-            let state = SessionState(
-                id: refreshed.sessionID,
-                manifest: refreshed,
-                manifestURL: manifestURL,
-                eventLogURL: eventLogURL,
-                storeURL: URL(fileURLWithPath: refreshed.storePath),
-                memory: memory
-            )
-            locked { _live[refreshed.sessionID] = state }
-            return LifecycleResult(state: state, resumed: true, recoveredLease: recoveredLease)
-        } catch {
-            try? await memory.close()
-            throw error
-        }
-    }
-
-    package func end(sessionID: UUID?) async throws -> EndResult {
-        let snapshot: (target: UUID, state: SessionState)?
-        switch (sessionID, locked({ _live.count })) {
-        case let (.some(explicit), _):
-            guard let state = locked({ _live[explicit] }) else {
-                throw BrokerValidationError.invalid(
-                    "session_id is not active in this broker process; call session_start again"
-                )
+            let key = SessionPairKey(agentID: agentID, runID: runID)
+            if creatingPairs.contains(key) {
+                pairWaiters[key, default: []].append(continuation)
+                lock.unlock()
+                return
             }
-            snapshot = (explicit, state)
-        case (.none, 1):
-            let only = locked { _live.first! }
-            snapshot = (only.key, only.value)
-        case (.none, 0):
-            return EndResult(sessionID: nil, ended: false, remainingActive: false, activeCount: 0)
-        default:
-            throw BrokerValidationError.invalid("session_id is required when more than one session is active")
+            creatingPairs.insert(key)
+            lock.unlock()
+            continuation.resume(returning: nil)
         }
-
-        let target = snapshot!.target
-        let state = snapshot!.state
-        var manifest = state.manifest
-        manifest.status = .ended
-        manifest.updatedAtMs = nowMs()
-        manifest.brokerLeaseOwnerID = nil
-        manifest.leaseExpiresAtMs = nil
-        try BrokerSessionPersistence.saveManifest(manifest, to: state.manifestURL)
-        try BrokerSessionPersistence.appendEvent(
-            BrokerSessionEvent(
-                sessionID: state.id,
-                agentID: manifest.agentID,
-                runID: manifest.runID,
-                timestampMs: manifest.updatedAtMs,
-                kind: .ended
-            ),
-            to: state.eventLogURL
-        )
-        try await state.memory.flush()
-        try await state.memory.close()
-        let remaining = locked { () -> Int in
-            _live.removeValue(forKey: target)
-            return _live.count
-        }
-        return EndResult(
-            sessionID: target,
-            ended: true,
-            remainingActive: remaining > 0,
-            activeCount: remaining
-        )
     }
 
-    /// Lookup never infers or mints. Omitted `session_id` is no virtual session.
-    /// Unknown or not live here fails closed.
-    package func lookup(_ sessionID: UUID?) throws -> Lookup {
-        guard let sessionID else { return .none }
-        guard let state = locked({ _live[sessionID] }) else {
-            throw BrokerValidationError.invalid(
-                "session_id is not active in this broker process; call session_start again"
-            )
-        }
-        return .live(state.memory)
-    }
-
-    package func validateActive(_ sessionID: UUID?) throws {
-        guard sessionID != nil else { return }
-        _ = try lookup(sessionID)
-    }
-
-    package func requireLive(_ sessionID: UUID) throws -> SessionState {
-        guard let state = locked({ _live[sessionID] }) else {
-            throw BrokerValidationError.invalid(
-                "session_id is not active in this broker process; call session_start again"
-            )
-        }
-        return state
-    }
-
-    package func findActive(agentID: String, runID: String) throws -> BrokerSessionManifest? {
-        if let liveMatch = locked({
-            _live.values.first(where: {
-                $0.manifest.agentID == agentID && $0.manifest.runID == runID
-            })
-        }) {
-            return liveMatch.manifest
-        }
-        let matches = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL).filter { manifest in
-            manifest.status == .active && manifest.agentID == agentID && manifest.runID == runID
-        }
-        if matches.count > 1 {
-            throw BrokerValidationError.invalid("multiple active sessions matched agent_id and run_id")
-        }
-        return matches.first
-    }
-
-    package func resolveManifest(
-        explicitSessionID: UUID?,
-        agentID: String?,
-        runID: String?
-    ) throws -> BrokerSessionManifest {
-        if let explicitSessionID {
-            return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
-        }
-
-        let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
-        let filtered = manifests.filter { manifest in
-            guard manifest.status == .active else { return false }
-            if let agentID, manifest.agentID != agentID { return false }
-            if let runID, manifest.runID != runID { return false }
-            return true
-        }
-        guard filtered.count <= 1 else {
-            throw BrokerValidationError.invalid("multiple active sessions matched the requested selectors")
-        }
-        guard let match = filtered.first else {
-            throw BrokerValidationError.invalid("No resumable session manifest matched the requested selectors")
-        }
-        return match
-    }
-
-    package func refreshManifest(_ sessionID: UUID) throws {
-        try locked {
-            guard var state = _live[sessionID] else {
-                throw BrokerValidationError.invalid(
-                    "session_id is not active in this broker process; call session_start again"
-                )
+    private func completePairClaim(_ key: SessionPairKey, _ result: Result<LifecycleResult, Error>) {
+        lock.lock()
+        creatingPairs.remove(key)
+        let waiters = pairWaiters.removeValue(forKey: key) ?? []
+        lock.unlock()
+        switch result {
+        case .success(let lifecycle):
+            let shared: LifecycleResult = .resumed(lifecycle.state, recoveredLease: false)
+            for waiter in waiters {
+                waiter.resume(returning: shared)
             }
-            state.manifest.updatedAtMs = nowMs()
-            state.manifest.brokerLeaseOwnerID = brokerInstanceID
-            state.manifest.leaseExpiresAtMs = state.manifest.updatedAtMs + Int64(leaseSeconds * 1000)
-            try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-            _live[sessionID] = state
+        case .failure(let error):
+            for waiter in waiters {
+                waiter.resume(throwing: error)
+            }
         }
     }
 
-    package func appendEvent(
+    private func endTarget(_ sessionID: UUID?) -> EndTarget {
+        if let sessionID {
+            if let state = _live[sessionID] {
+                return .session(id: sessionID, state: state)
+            }
+            return .missing(sessionID)
+        }
+        if _live.isEmpty {
+            return .idle
+        }
+        if let only = _live.first, _live.count == 1 {
+            return .session(id: only.key, state: only.value)
+        }
+        return .requireSessionID
+    }
+
+    private func liveMatchLocked(agentID: String, runID: String) -> SessionState? {
+        _live.values.first(where: {
+            $0.manifest.agentID == agentID && $0.manifest.runID == runID
+        })
+    }
+
+    private func abandonUnusedSessionFile(
+        at url: URL,
         sessionID: UUID,
-        kind: BrokerSessionEvent.Kind,
-        payload: [String: String] = [:]
-    ) throws {
-        let state = try requireLive(sessionID)
-        try BrokerSessionPersistence.appendEvent(
-            BrokerSessionEvent(
-                sessionID: sessionID,
-                agentID: state.manifest.agentID,
-                runID: state.manifest.runID,
-                timestampMs: nowMs(),
-                kind: kind,
-                payload: payload
-            ),
-            to: state.eventLogURL
+        memory: MemoryOrchestrator
+    ) async {
+        try? await memory.close()
+        let stillLive = locked { _live[sessionID] != nil }
+        guard !stillLive else { return }
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(
+            at: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
         )
-    }
-
-    package func replaceLive(_ state: SessionState) throws {
-        try locked {
-            guard _live[state.id] != nil else {
-                throw BrokerValidationError.invalid(
-                    "session_id is not active in this broker process; call session_start again"
-                )
-            }
-            _live[state.id] = state
-        }
-    }
-
-    package func closeAll() async {
-        let sessions = locked { () -> [SessionState] in
-            let values = Array(_live.values)
-            _live.removeAll()
-            return values
-        }
-        for session in sessions {
-            try? await session.memory.flush()
-            try? await session.memory.close()
-        }
+        try? FileManager.default.removeItem(
+            at: BrokerSessionPersistence.eventLogURL(rootURL: sessionRootURL, sessionID: sessionID)
+        )
     }
 
     private func locked<T>(_ body: () throws -> T) rethrows -> T {
         lock.lock()
         defer { lock.unlock() }
         return try body()
+    }
+
+    private static var notActiveError: BrokerValidationError {
+        .invalid("session_id is not active in this broker process; call session_start again")
+    }
+
+    private static var requireSessionIDError: BrokerValidationError {
+        .invalid("session_id is required when more than one session is active")
+    }
+
+    private enum PairInsertRace: Error {
+        case alreadyLive(SessionState)
+        case pairTaken(SessionState)
     }
 }

--- a/Sources/Wax/Broker/VirtualSessionStore.swift
+++ b/Sources/Wax/Broker/VirtualSessionStore.swift
@@ -1,0 +1,434 @@
+import Foundation
+import WaxCore
+
+/// Internal virtual-session module: lifecycle, reuse, lease, session-file create, and
+/// `session_id` routing. Omitted `session_id` is not a virtual session. Not public API.
+///
+/// `@unchecked Sendable` plus `NSLock` because async open hops off the owning
+/// `AgentBrokerService` actor. Every `live` read/write goes through the lock.
+package final class VirtualSessionStore: @unchecked Sendable {
+    package struct SessionState: Sendable {
+        package let id: UUID
+        package var manifest: BrokerSessionManifest
+        package let manifestURL: URL
+        package let eventLogURL: URL
+        package let storeURL: URL
+        package let memory: MemoryOrchestrator
+    }
+
+    package struct LifecycleResult: Sendable {
+        package let state: SessionState
+        package let resumed: Bool
+        package let recoveredLease: Bool
+    }
+
+    package struct EndResult: Sendable {
+        package let sessionID: UUID?
+        package let ended: Bool
+        package let remainingActive: Bool
+        package let activeCount: Int
+    }
+
+    package enum Lookup: Sendable {
+        /// No virtual session. Caller uses long-term Memory.
+        case none
+        case live(MemoryOrchestrator)
+    }
+
+    package let sessionRootURL: URL
+    package let brokerInstanceID: String
+    private let leaseSeconds: Int
+    private let nowMs: @Sendable () -> Int64
+    private let waxOptions: WaxOptions
+    private let openExisting: @Sendable (URL) async throws -> MemoryOrchestrator
+    private let lock = NSLock()
+    private var _live: [UUID: SessionState] = [:]
+
+    package var live: [UUID: SessionState] {
+        locked { _live }
+    }
+
+    package init(
+        sessionRootURL: URL,
+        brokerInstanceID: String,
+        leaseSeconds: Int = AgentBrokerService.defaultSessionLeaseSeconds,
+        nowMs: @escaping @Sendable () -> Int64 = { AgentBrokerService.nowMs() },
+        waxOptions: WaxOptions = CommandLineEmbedderFactory.waxOptions(),
+        openExisting: @escaping @Sendable (URL) async throws -> MemoryOrchestrator
+    ) {
+        self.sessionRootURL = sessionRootURL
+        self.brokerInstanceID = brokerInstanceID
+        self.leaseSeconds = leaseSeconds
+        self.nowMs = nowMs
+        self.waxOptions = waxOptions
+        self.openExisting = openExisting
+    }
+
+    /// Open a session file. New files are created at `Constants.sessionWalSize`.
+    /// Existing files keep their WAL. Resume/reuse must pass `createIfMissing: false`.
+    package func openSessionMemory(at url: URL, createIfMissing: Bool = true) async throws -> MemoryOrchestrator {
+        let exists = FileManager.default.fileExists(atPath: url.path)
+        if !exists {
+            guard createIfMissing else {
+                throw BrokerValidationError.invalid(
+                    "session store is missing at \(url.lastPathComponent); call session_start again"
+                )
+            }
+            let created = try await Wax.create(
+                at: url,
+                walSize: Constants.sessionWalSize,
+                options: waxOptions
+            )
+            try await created.close()
+        }
+        return try await openExisting(url)
+    }
+
+    package func start(
+        explicitSessionID: UUID?,
+        agentID: String?,
+        runID: String?,
+        inferredScope: MemoryScopeContext
+    ) async throws -> LifecycleResult {
+        if let agentID, let runID, let existing = try findActive(agentID: agentID, runID: runID) {
+            if let explicitSessionID, explicitSessionID != existing.sessionID {
+                throw BrokerValidationError.invalid(
+                    "agent_id and run_id already have an active session; use session_resume"
+                )
+            }
+            return try await resume(
+                explicitSessionID: existing.sessionID,
+                agentID: nil,
+                runID: nil
+            )
+        }
+
+        let sessionID = explicitSessionID ?? UUID()
+        if let active = locked({ _live[sessionID] }) {
+            return LifecycleResult(state: active, resumed: true, recoveredLease: false)
+        }
+
+        let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
+        if FileManager.default.fileExists(atPath: manifestURL.path) {
+            throw BrokerValidationError.invalid("session_id already exists; use session_resume to reopen it")
+        }
+
+        let sessionURL = sessionRootURL.appendingPathComponent("\(sessionID.uuidString).wax")
+        let eventLogURL = BrokerSessionPersistence.eventLogURL(rootURL: sessionRootURL, sessionID: sessionID)
+        let memory = try await openSessionMemory(at: sessionURL, createIfMissing: true)
+        do {
+            if let agentID, let runID, let existing = try findActive(agentID: agentID, runID: runID) {
+                try? await memory.close()
+                if let explicitSessionID, explicitSessionID != existing.sessionID {
+                    throw BrokerValidationError.invalid(
+                        "agent_id and run_id already have an active session; use session_resume"
+                    )
+                }
+                return try await resume(
+                    explicitSessionID: existing.sessionID,
+                    agentID: nil,
+                    runID: nil
+                )
+            }
+            if let active = locked({ _live[sessionID] }) {
+                try? await memory.close()
+                return LifecycleResult(state: active, resumed: true, recoveredLease: false)
+            }
+
+            let timestamp = nowMs()
+            let resolvedAgentID = agentID ?? inferredScope.repoName ?? "wax-agent"
+            let resolvedRunID = runID ?? UUID().uuidString
+            let manifest = BrokerSessionManifest(
+                sessionID: sessionID,
+                agentID: resolvedAgentID,
+                runID: resolvedRunID,
+                project: inferredScope.projectName,
+                repo: inferredScope.repoName,
+                storePath: sessionURL.path,
+                eventLogPath: eventLogURL.path,
+                status: .active,
+                brokerLeaseOwnerID: brokerInstanceID,
+                leaseExpiresAtMs: timestamp + Int64(leaseSeconds * 1000),
+                createdAtMs: timestamp,
+                updatedAtMs: timestamp
+            )
+            try BrokerSessionPersistence.appendEvent(
+                BrokerSessionEvent(
+                    sessionID: sessionID,
+                    agentID: resolvedAgentID,
+                    runID: resolvedRunID,
+                    timestampMs: timestamp,
+                    kind: .started,
+                    payload: [
+                        "project": manifest.project ?? "",
+                        "repo": manifest.repo ?? "",
+                    ]
+                ),
+                to: eventLogURL
+            )
+            try BrokerSessionPersistence.saveManifest(manifest, to: manifestURL)
+            let state = SessionState(
+                id: sessionID,
+                manifest: manifest,
+                manifestURL: manifestURL,
+                eventLogURL: eventLogURL,
+                storeURL: sessionURL,
+                memory: memory
+            )
+            locked { _live[sessionID] = state }
+            return LifecycleResult(state: state, resumed: false, recoveredLease: false)
+        } catch {
+            try? await memory.close()
+            throw error
+        }
+    }
+
+    package func resume(
+        explicitSessionID: UUID?,
+        agentID: String?,
+        runID: String?
+    ) async throws -> LifecycleResult {
+        let manifest = try resolveManifest(
+            explicitSessionID: explicitSessionID,
+            agentID: agentID,
+            runID: runID
+        )
+        guard manifest.status == .active else {
+            throw BrokerValidationError.invalid("session_id has already been ended and cannot be resumed")
+        }
+
+        if let existing = locked({ _live[manifest.sessionID] }) {
+            return LifecycleResult(state: existing, resumed: true, recoveredLease: false)
+        }
+
+        let timestamp = nowMs()
+        let recoveredLease = manifest.brokerLeaseOwnerID != nil && manifest.brokerLeaseOwnerID != brokerInstanceID
+        let memory = try await openSessionMemory(
+            at: URL(fileURLWithPath: manifest.storePath),
+            createIfMissing: false
+        )
+        do {
+            if let existing = locked({ _live[manifest.sessionID] }) {
+                try? await memory.close()
+                return LifecycleResult(state: existing, resumed: true, recoveredLease: false)
+            }
+
+            var refreshed = manifest
+            refreshed.brokerLeaseOwnerID = brokerInstanceID
+            refreshed.leaseExpiresAtMs = timestamp + Int64(leaseSeconds * 1000)
+            refreshed.updatedAtMs = timestamp
+
+            let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
+            let eventLogURL = URL(fileURLWithPath: refreshed.eventLogPath)
+            try BrokerSessionPersistence.appendEvent(
+                BrokerSessionEvent(
+                    sessionID: refreshed.sessionID,
+                    agentID: refreshed.agentID,
+                    runID: refreshed.runID,
+                    timestampMs: timestamp,
+                    kind: .resumed,
+                    payload: [
+                        "recovered_lease": recoveredLease ? "true" : "false",
+                    ]
+                ),
+                to: eventLogURL
+            )
+            try BrokerSessionPersistence.saveManifest(refreshed, to: manifestURL)
+            let state = SessionState(
+                id: refreshed.sessionID,
+                manifest: refreshed,
+                manifestURL: manifestURL,
+                eventLogURL: eventLogURL,
+                storeURL: URL(fileURLWithPath: refreshed.storePath),
+                memory: memory
+            )
+            locked { _live[refreshed.sessionID] = state }
+            return LifecycleResult(state: state, resumed: true, recoveredLease: recoveredLease)
+        } catch {
+            try? await memory.close()
+            throw error
+        }
+    }
+
+    package func end(sessionID: UUID?) async throws -> EndResult {
+        let snapshot: (target: UUID, state: SessionState)?
+        switch (sessionID, locked({ _live.count })) {
+        case let (.some(explicit), _):
+            guard let state = locked({ _live[explicit] }) else {
+                throw BrokerValidationError.invalid(
+                    "session_id is not active in this broker process; call session_start again"
+                )
+            }
+            snapshot = (explicit, state)
+        case (.none, 1):
+            let only = locked { _live.first! }
+            snapshot = (only.key, only.value)
+        case (.none, 0):
+            return EndResult(sessionID: nil, ended: false, remainingActive: false, activeCount: 0)
+        default:
+            throw BrokerValidationError.invalid("session_id is required when more than one session is active")
+        }
+
+        let target = snapshot!.target
+        let state = snapshot!.state
+        var manifest = state.manifest
+        manifest.status = .ended
+        manifest.updatedAtMs = nowMs()
+        manifest.brokerLeaseOwnerID = nil
+        manifest.leaseExpiresAtMs = nil
+        try BrokerSessionPersistence.saveManifest(manifest, to: state.manifestURL)
+        try BrokerSessionPersistence.appendEvent(
+            BrokerSessionEvent(
+                sessionID: state.id,
+                agentID: manifest.agentID,
+                runID: manifest.runID,
+                timestampMs: manifest.updatedAtMs,
+                kind: .ended
+            ),
+            to: state.eventLogURL
+        )
+        try await state.memory.flush()
+        try await state.memory.close()
+        let remaining = locked { () -> Int in
+            _live.removeValue(forKey: target)
+            return _live.count
+        }
+        return EndResult(
+            sessionID: target,
+            ended: true,
+            remainingActive: remaining > 0,
+            activeCount: remaining
+        )
+    }
+
+    /// Lookup never infers or mints. Omitted `session_id` is no virtual session.
+    /// Unknown or not live here fails closed.
+    package func lookup(_ sessionID: UUID?) throws -> Lookup {
+        guard let sessionID else { return .none }
+        guard let state = locked({ _live[sessionID] }) else {
+            throw BrokerValidationError.invalid(
+                "session_id is not active in this broker process; call session_start again"
+            )
+        }
+        return .live(state.memory)
+    }
+
+    package func validateActive(_ sessionID: UUID?) throws {
+        guard sessionID != nil else { return }
+        _ = try lookup(sessionID)
+    }
+
+    package func requireLive(_ sessionID: UUID) throws -> SessionState {
+        guard let state = locked({ _live[sessionID] }) else {
+            throw BrokerValidationError.invalid(
+                "session_id is not active in this broker process; call session_start again"
+            )
+        }
+        return state
+    }
+
+    package func findActive(agentID: String, runID: String) throws -> BrokerSessionManifest? {
+        if let liveMatch = locked({
+            _live.values.first(where: {
+                $0.manifest.agentID == agentID && $0.manifest.runID == runID
+            })
+        }) {
+            return liveMatch.manifest
+        }
+        let matches = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL).filter { manifest in
+            manifest.status == .active && manifest.agentID == agentID && manifest.runID == runID
+        }
+        if matches.count > 1 {
+            throw BrokerValidationError.invalid("multiple active sessions matched agent_id and run_id")
+        }
+        return matches.first
+    }
+
+    package func resolveManifest(
+        explicitSessionID: UUID?,
+        agentID: String?,
+        runID: String?
+    ) throws -> BrokerSessionManifest {
+        if let explicitSessionID {
+            return try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: explicitSessionID)
+        }
+
+        let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
+        let filtered = manifests.filter { manifest in
+            guard manifest.status == .active else { return false }
+            if let agentID, manifest.agentID != agentID { return false }
+            if let runID, manifest.runID != runID { return false }
+            return true
+        }
+        guard filtered.count <= 1 else {
+            throw BrokerValidationError.invalid("multiple active sessions matched the requested selectors")
+        }
+        guard let match = filtered.first else {
+            throw BrokerValidationError.invalid("No resumable session manifest matched the requested selectors")
+        }
+        return match
+    }
+
+    package func refreshManifest(_ sessionID: UUID) throws {
+        try locked {
+            guard var state = _live[sessionID] else {
+                throw BrokerValidationError.invalid(
+                    "session_id is not active in this broker process; call session_start again"
+                )
+            }
+            state.manifest.updatedAtMs = nowMs()
+            state.manifest.brokerLeaseOwnerID = brokerInstanceID
+            state.manifest.leaseExpiresAtMs = state.manifest.updatedAtMs + Int64(leaseSeconds * 1000)
+            try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
+            _live[sessionID] = state
+        }
+    }
+
+    package func appendEvent(
+        sessionID: UUID,
+        kind: BrokerSessionEvent.Kind,
+        payload: [String: String] = [:]
+    ) throws {
+        let state = try requireLive(sessionID)
+        try BrokerSessionPersistence.appendEvent(
+            BrokerSessionEvent(
+                sessionID: sessionID,
+                agentID: state.manifest.agentID,
+                runID: state.manifest.runID,
+                timestampMs: nowMs(),
+                kind: kind,
+                payload: payload
+            ),
+            to: state.eventLogURL
+        )
+    }
+
+    package func replaceLive(_ state: SessionState) throws {
+        try locked {
+            guard _live[state.id] != nil else {
+                throw BrokerValidationError.invalid(
+                    "session_id is not active in this broker process; call session_start again"
+                )
+            }
+            _live[state.id] = state
+        }
+    }
+
+    package func closeAll() async {
+        let sessions = locked { () -> [SessionState] in
+            let values = Array(_live.values)
+            _live.removeAll()
+            return values
+        }
+        for session in sessions {
+            try? await session.memory.flush()
+            try? await session.memory.close()
+        }
+    }
+
+    private func locked<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
+    }
+}

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -330,94 +330,8 @@ private enum ToolValidationError: LocalizedError {
     }
 }
 
-// Compatibility path for the existing direct-memory unit tests. Production MCP calls go
-// through the broker-backed overload above; this shim keeps the current test suite usable
-// while the tests are migrated to broker semantics.
-private actor CompatSessionRegistryPool {
-    private var registries: [ObjectIdentifier: CompatSessionRegistry] = [:]
-
-    func registry(for memory: MemoryOrchestrator) -> CompatSessionRegistry {
-        let key = ObjectIdentifier(memory)
-        if let existing = registries[key] {
-            return existing
-        }
-        let created = CompatSessionRegistry()
-        registries[key] = created
-        return created
-    }
-}
-
-private actor CompatSessionRegistry {
-    private struct CompatRecallTracker: Sendable {
-        var recallCount: Int = 0
-        var queryHashes: Set<String> = []
-        var lastRetrievedAtMs: Int64?
-        var scoreTotal: Float = 0
-    }
-
-    private var activeSessions: Set<UUID> = []
-    private var recallTrackers: [UUID: [UInt64: CompatRecallTracker]] = [:]
-
-    func start() -> UUID {
-        let sessionID = UUID()
-        activeSessions.insert(sessionID)
-        return sessionID
-    }
-
-    func end(sessionID: UUID?) throws -> (UUID?, Bool) {
-        if let sessionID {
-            guard activeSessions.remove(sessionID) != nil else {
-                throw ToolValidationError.invalid("session_id is not active in this server process; call wax_session_start again")
-            }
-            recallTrackers.removeValue(forKey: sessionID)
-            return (sessionID, !activeSessions.isEmpty)
-        }
-
-        switch activeSessions.count {
-        case 0:
-            return (nil, false)
-        case 1:
-            return (activeSessions.removeFirst(), false)
-        default:
-            throw ToolValidationError.invalid("session_id is required when more than one MCP session is active")
-        }
-    }
-
-    func isActive(_ sessionID: UUID) -> Bool {
-        activeSessions.contains(sessionID)
-    }
-
-    func activeSessionIDs() -> [UUID] {
-        Array(activeSessions)
-    }
-
-    func recordRetrievalHit(sessionID: UUID, frameID: UInt64, query: String, score: Float) {
-        var sessionTrackers = recallTrackers[sessionID, default: [:]]
-        var tracker = sessionTrackers[frameID, default: CompatRecallTracker()]
-        tracker.recallCount += 1
-        tracker.queryHashes.insert(WaxMCPTools.stableHash(query.lowercased()))
-        tracker.lastRetrievedAtMs = max(tracker.lastRetrievedAtMs ?? 0, WaxMCPTools.nowMs())
-        tracker.scoreTotal += score
-        sessionTrackers[frameID] = tracker
-        recallTrackers[sessionID] = sessionTrackers
-    }
-
-    func recallSignals(for sessionID: UUID) -> [UInt64: BrokerSessionRecallSignals] {
-        let sessionTrackers = recallTrackers[sessionID, default: [:]]
-        return sessionTrackers.reduce(into: [:]) { partial, entry in
-            let tracker = entry.value
-            partial[entry.key] = BrokerSessionRecallSignals(
-                recallCount: tracker.recallCount,
-                uniqueQueryCount: tracker.queryHashes.count,
-                lastRetrievedAtMs: tracker.lastRetrievedAtMs,
-                averageScore: tracker.recallCount > 0 ? (tracker.scoreTotal / Float(tracker.recallCount)) : 0
-            )
-        }
-    }
-}
-
-private let compatSessionRegistries = CompatSessionRegistryPool()
-
+// Direct-memory helper for argument-shape and structured-memory unit tests.
+// Session lifecycle and session_id routing belong to AgentBrokerService.handle.
 extension WaxMCPTools {
     static func handleCall(
         params: CallTool.Parameters,
@@ -426,7 +340,6 @@ extension WaxMCPTools {
         noEmbedder: Bool = false,
         embedderChoice: String = "minilm"
     ) async -> CallTool.Result {
-        let sessionRegistry = await compatSessionRegistries.registry(for: memory)
         do {
             if let migration = migratedName(for: params.name) {
                 return errorResult(
@@ -439,24 +352,46 @@ extension WaxMCPTools {
             try validateArgumentSurface(name: normalizedName, arguments: params.arguments)
 
             switch normalizedName {
+            case "session_start", "session_resume", "session_end", "session_synthesize":
+                return errorResult(
+                    message: "session lifecycle requires the broker",
+                    code: "invalid_arguments"
+                )
+            default:
+                break
+            }
+            if let sessionValue = params.arguments?["session_id"] {
+                guard case .string(let raw) = sessionValue, UUID(uuidString: raw) != nil else {
+                    return errorResult(
+                        message: "session_id must be a valid UUID",
+                        code: "invalid_arguments"
+                    )
+                }
+                return errorResult(
+                    message: "session_id requires the broker",
+                    code: "invalid_arguments"
+                )
+            }
+
+            switch normalizedName {
             case "memory_append":
-                return try await compatRemember(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatRemember(params.arguments, memory: memory)
             case "memory_search":
-                return try await compatMemorySearch(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatMemorySearch(params.arguments, memory: memory)
             case "memory_get":
-                return try await compatMemoryGet(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatMemoryGet(params.arguments, memory: memory)
             case "remember":
-                return try await compatRemember(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatRemember(params.arguments, memory: memory)
             case "recall":
-                return try await compatRecall(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatRecall(params.arguments, memory: memory)
             case "search":
-                return try await compatSearch(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatSearch(params.arguments, memory: memory)
             case "session_synthesize":
-                return try await compatSessionSynthesize(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatSessionSynthesize(params.arguments, memory: memory)
             case "memory_promote":
-                return try await compatMemoryPromote(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatMemoryPromote(params.arguments, memory: memory)
             case "promote":
-                return try await compatPromote(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatPromote(params.arguments, memory: memory)
             case "memory_health":
                 return try await compatMemoryHealth(memory)
             case "knowledge_capture":
@@ -466,23 +401,17 @@ extension WaxMCPTools {
             case "flush":
                 return try await compatFlush(memory)
             case "stats":
-                return try await compatStats(memory, sessionRegistry: sessionRegistry)
-            case "session_start":
-                return await compatSessionStart(sessionRegistry)
-            case "session_resume":
-                return try await compatSessionResume(params.arguments, sessionRegistry: sessionRegistry)
-            case "session_end":
-                return try await compatSessionEnd(params.arguments, sessionRegistry: sessionRegistry)
+                return try await compatStats(memory)
             case "handoff":
-                return try await compatHandoff(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatHandoff(params.arguments, memory: memory)
             case "handoff_latest":
                 return try await compatHandoffLatest(params.arguments, memory: memory)
             case "compact_context":
-                return try await compatCompactContext(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatCompactContext(params.arguments, memory: memory)
             case "markdown_export":
-                return try await compatMarkdownExport(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatMarkdownExport(params.arguments, memory: memory)
             case "markdown_sync":
-                return try await compatMarkdownSync(params.arguments, memory: memory, sessionRegistry: sessionRegistry)
+                return try await compatMarkdownSync(params.arguments, memory: memory)
             case "entity_upsert" where structuredMemoryEnabled:
                 return try await compatEntityUpsert(params.arguments, memory: memory)
             case "fact_assert" where structuredMemoryEnabled:
@@ -640,13 +569,6 @@ private extension WaxMCPTools {
         return sessionID
     }
 
-    static func compatValidateActiveSession(_ sessionID: UUID?, in registry: CompatSessionRegistry) async throws {
-        guard let sessionID else { return }
-        guard await registry.isActive(sessionID) else {
-            throw ToolValidationError.invalid("session_id is not active in this server process; call wax_session_start again")
-        }
-    }
-
     static func compatCoerceMetadata(_ object: [String: Value]?) throws -> [String: String] {
         guard let object else { return [:] }
         return try object.reduce(into: [String: String]()) { partial, entry in
@@ -713,30 +635,6 @@ private extension WaxMCPTools {
         }
         let canonicalFrameID = try await memory.canonicalDocumentFrameID(for: frameID)
         return documentByFrameID[canonicalFrameID]
-    }
-
-    static func compatResolveSessionID(_ explicit: UUID?, sessionRegistry: CompatSessionRegistry) async throws -> UUID? {
-        if let explicit { return explicit }
-        let active = await sessionRegistry.activeSessionIDs().sorted { $0.uuidString < $1.uuidString }
-        return active.count == 1 ? active.first : nil
-    }
-
-    static func compatResolveSessionID(
-        _ explicit: UUID?,
-        requiringUnambiguousWorkingMemory includeWorking: Bool,
-        sessionRegistry: CompatSessionRegistry
-    ) async throws -> UUID? {
-        if let explicit { return explicit }
-        guard includeWorking else { return nil }
-        let active = await sessionRegistry.activeSessionIDs().sorted { $0.uuidString < $1.uuidString }
-        switch active.count {
-        case 0:
-            return nil
-        case 1:
-            return active.first
-        default:
-            throw ToolValidationError.invalid("session_id is required when more than one session is active")
-        }
     }
 
     static func compatPromotionProposalValue(_ proposal: BrokerPromotionProposal) -> Value {
@@ -861,9 +759,6 @@ private extension WaxMCPTools {
                 timeBeforeMs = Int64(value)
             }
         }
-        if let sessionID {
-            metadataEntries["session_id"] = sessionID.uuidString
-        }
         let metadataFilter: MetadataFilter? = (!metadataEntries.isEmpty || !labels.isEmpty)
             ? MetadataFilter(requiredEntries: metadataEntries, requiredLabels: labels)
             : nil
@@ -899,17 +794,15 @@ private extension WaxMCPTools {
         )
     }
 
-    static func compatRemember(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatRemember(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let content = try args.requiredString("content")
-        let sessionID = try compatParseSessionID(args)
-        try await compatValidateActiveSession(sessionID, in: sessionRegistry)
         let rawMetadata = try compatCoerceMetadata(try args.optionalObject("metadata"))
         var metadata = rawMetadata
         if metadata["session_id"] != nil {
             throw ToolValidationError.invalid("metadata.session_id is reserved; use top-level session_id")
         }
-        metadata = try compatNormalizedMetadata(args: args, metadata: metadata, sessionID: sessionID)
+        metadata = try compatNormalizedMetadata(args: args, metadata: metadata, sessionID: nil)
         try compatValidateDurableWrite(content: content, metadata: metadata)
         let before = await memory.runtimeStats()
         try await memory.remember(content, metadata: metadata)
@@ -926,7 +819,7 @@ private extension WaxMCPTools {
         ])
     }
 
-    static func compatRecall(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatRecall(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let query = try args.requiredString("query")
         let limit = try args.optionalInt("limit") ?? 5
@@ -934,7 +827,6 @@ private extension WaxMCPTools {
             throw ToolValidationError.invalid("limit must be between 1 and 100")
         }
         let filters = try compatParseSearchFilters(args)
-        try await compatValidateActiveSession(filters.sessionID, in: sessionRegistry)
         let requestedTopK = try args.optionalInt("search_top_k") ?? (try args.optionalInt("topK"))
         let effectiveTopK = requestedTopK ?? limit
         guard (1...200).contains(effectiveTopK) else {
@@ -944,34 +836,14 @@ private extension WaxMCPTools {
             modeRaw: try args.optionalString("mode") ?? "hybrid",
             alpha: try args.optionalDouble("alpha")
         )
-        let sessionExecution = try await memory.recallExecution(
+        let execution = try await memory.recallExecution(
             query: query,
             mode: mode,
             frameFilter: filters.frameFilter,
             timeRange: filters.timeRange,
             topK: effectiveTopK
         )
-        let durableExecution: MemoryOrchestrator.RecallExecution
-        if filters.sessionID != nil {
-            durableExecution = try await memory.recallExecution(
-                query: query,
-                mode: mode,
-                frameFilter: nil,
-                timeRange: filters.timeRange,
-                topK: effectiveTopK
-            )
-        } else {
-            durableExecution = sessionExecution
-        }
-        let durableItems = filters.sessionID == nil
-            ? durableExecution.context.items
-            : durableExecution.context.items.filter { $0.metadata["session_id"] == nil }
-        let selected = AgentBrokerService.mergeRecallItems(
-            sessionItems: filters.sessionID == nil ? [] : sessionExecution.context.items,
-            durableItems: durableItems,
-            limit: limit
-        )
-        let execution = sessionExecution
+        let selected = Array(execution.context.items.prefix(limit))
         let context = RAGContext(
             query: query,
             items: selected,
@@ -1000,16 +872,6 @@ private extension WaxMCPTools {
                 "explanations": .array(item.explanations.map(Value.string)),
             ]
         }
-        if let sessionID = filters.sessionID {
-            for item in selected {
-                await sessionRegistry.recordRetrievalHit(
-                    sessionID: sessionID,
-                    frameID: item.frameId,
-                    query: query,
-                    score: item.score
-                )
-            }
-        }
         return textWithJSONResourceResult(
             text: lines.joined(separator: "\n"),
             payload: [
@@ -1028,7 +890,7 @@ private extension WaxMCPTools {
         )
     }
 
-    static func compatSearch(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatSearch(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let query = try args.requiredString("query")
         let topK = try args.optionalInt("topK") ?? 10
@@ -1036,7 +898,6 @@ private extension WaxMCPTools {
             throw ToolValidationError.invalid("topK must be between 1 and 200")
         }
         let filters = try compatParseSearchFilters(args)
-        try await compatValidateActiveSession(filters.sessionID, in: sessionRegistry)
         let mode = try compatSearchMode(
             modeRaw: try args.optionalString("mode") ?? "text",
             alpha: try args.optionalDouble("alpha")
@@ -1059,16 +920,6 @@ private extension WaxMCPTools {
                 "explanations": .array(hit.explanations.map(Value.string)),
             ]
         }
-        if let sessionID = filters.sessionID {
-            for hit in execution.hits {
-                await sessionRegistry.recordRetrievalHit(
-                    sessionID: sessionID,
-                    frameID: hit.frameId,
-                    query: query,
-                    score: hit.score
-                )
-            }
-        }
         let displayText = rows.isEmpty ? "No results." : rows.compactMap(encodeJSON).joined(separator: "\n")
         return textWithJSONResourceResult(
             text: displayText,
@@ -1085,7 +936,7 @@ private extension WaxMCPTools {
         )
     }
 
-    static func compatMemorySearch(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatMemorySearch(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let query = try args.requiredString("query")
         let topK = try args.optionalInt("topK") ?? 10
@@ -1095,12 +946,6 @@ private extension WaxMCPTools {
         let includeWorking = try args.optionalBool("include_working") ?? true
         let includeEpisodic = try args.optionalBool("include_episodic") ?? true
         let includeDurable = try args.optionalBool("include_durable") ?? true
-        let sessionID = try await compatResolveSessionID(
-            try compatParseSessionID(args),
-            requiringUnambiguousWorkingMemory: includeWorking,
-            sessionRegistry: sessionRegistry
-        )
-        try await compatValidateActiveSession(sessionID, in: sessionRegistry)
         let mode = try compatSearchMode(
             modeRaw: try args.optionalString("mode") ?? "text",
             alpha: try args.optionalDouble("alpha")
@@ -1116,45 +961,18 @@ private extension WaxMCPTools {
         )
         let documents = try await memory.corpusSourceDocuments()
         let documentByFrameID = Dictionary(uniqueKeysWithValues: documents.map { ($0.frameId, $0) })
-        let activeSessionIDs = Set(await sessionRegistry.activeSessionIDs().map(\.uuidString))
 
         var results: [Value] = []
-        var workingHitsToRecord: [(frameID: UInt64, score: Float)] = []
         for hit in execution.hits {
+            guard includeDurable else { continue }
             guard let document = try await compatDocument(
                 for: hit.frameId,
                 in: documentByFrameID,
                 memory: memory
             ) else { continue }
-            let documentSessionID = document.metadata["session_id"]
-            let horizon: String
-            let memoryID: String
-
-            if let documentSessionID {
-                if activeSessionIDs.contains(documentSessionID) {
-                    guard includeWorking else { continue }
-                    horizon = "working"
-                } else {
-                    guard includeEpisodic else { continue }
-                    horizon = "episodic"
-                }
-                memoryID = "\(horizon):\(documentSessionID):\(document.frameId)"
-            } else {
-                guard includeDurable else { continue }
-                horizon = "durable"
-                memoryID = "durable:\(document.frameId)"
-            }
-
-            if let sessionID, horizon == "working", documentSessionID != sessionID.uuidString {
-                continue
-            }
-            if let sessionID, horizon == "working", documentSessionID == sessionID.uuidString {
-                workingHitsToRecord.append((frameID: document.frameId, score: hit.score))
-            }
-
             results.append([
-                "memory_id": .string(memoryID),
-                "horizon": .string(horizon),
+                "memory_id": .string("durable:\(document.frameId)"),
+                "horizon": .string("durable"),
                 "frame_id": .int(Int(document.frameId)),
                 "score": .double(Double(hit.score)),
                 "preview": .string(hit.previewText ?? document.text),
@@ -1167,23 +985,13 @@ private extension WaxMCPTools {
                 break
             }
         }
-        if let sessionID {
-            for hit in workingHitsToRecord {
-                await sessionRegistry.recordRetrievalHit(
-                    sessionID: sessionID,
-                    frameID: hit.frameID,
-                    query: query,
-                    score: hit.score
-                )
-            }
-        }
 
         let displayText = results.isEmpty ? "No results." : results.compactMap(encodeJSON).joined(separator: "\n")
         return textWithJSONResourceResult(
             text: displayText,
             payload: [
                 "query": .string(query),
-                "session_id": sessionID.map { .string($0.uuidString) } ?? .null,
+                "session_id": .null,
                 "topK": .int(topK),
                 "requested_mode": .string(execution.requestedModeSummary),
                 "effective_mode": .string(execution.effectiveModeSummary),
@@ -1201,7 +1009,7 @@ private extension WaxMCPTools {
         min(1_000, max(topK * 5, topK + 200))
     }
 
-    static func compatMemoryGet(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatMemoryGet(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let memoryID = try args.requiredString("memory_id")
         let parts = memoryID.split(separator: ":").map(String.init)
@@ -1219,20 +1027,7 @@ private extension WaxMCPTools {
             }
             document = match
         case "working", "episodic":
-            guard parts.count == 3,
-                  let sessionID = UUID(uuidString: parts[1]),
-                  let frameID = UInt64(parts[2]) else {
-                throw ToolValidationError.invalid("Unknown session memory_id")
-            }
-            if horizon == "working" {
-                try await compatValidateActiveSession(sessionID, in: sessionRegistry)
-            }
-            guard let match = documents.first(where: {
-                $0.frameId == frameID && $0.metadata["session_id"] == sessionID.uuidString
-            }) else {
-                throw ToolValidationError.invalid("Unknown session memory_id")
-            }
-            document = match
+            throw ToolValidationError.invalid("session memory_id requires the broker")
         default:
             throw ToolValidationError.invalid("memory_id horizon must be one of: working, episodic, durable")
         }
@@ -1262,18 +1057,16 @@ private extension WaxMCPTools {
         )
     }
 
-    static func compatPromote(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatPromote(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         var normalized = arguments ?? [:]
         if normalized["approve"] == nil {
             normalized["approve"] = .bool(true)
         }
-        return try await compatMemoryPromote(normalized, memory: memory, sessionRegistry: sessionRegistry)
+        return try await compatMemoryPromote(normalized, memory: memory)
     }
 
-    static func compatStats(_ memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatStats(_ memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let stats = await memory.runtimeStats()
-        let activeSessions = await sessionRegistry.activeSessionIDs().sorted { $0.uuidString < $1.uuidString }
-        let primarySessionID = activeSessions.count == 1 ? activeSessions.first : nil
         return jsonResult([
             "frameCount": .int(Int(stats.frameCount)),
             "pendingFrames": .int(Int(stats.pendingFrames)),
@@ -1285,99 +1078,44 @@ private extension WaxMCPTools {
             ),
             "queryEmbeddingCircuitOpen": .bool(stats.queryEmbeddingCircuitOpen),
             "session": [
-                "active": .bool(!activeSessions.isEmpty),
-                "session_id": primarySessionID.map { .string($0.uuidString) } ?? .null,
-                "activeSessionCount": .int(activeSessions.count),
-                "activeSessionIds": .array(activeSessions.map { .string($0.uuidString) }),
-                "sessionFrameCount": .int(primarySessionID == nil ? 0 : Int(stats.frameCount)),
+                "active": .bool(false),
+                "session_id": .null,
+                "activeSessionCount": .int(0),
+                "activeSessionIds": .array([]),
+                "sessionFrameCount": .int(0),
             ],
         ])
     }
 
-    static func compatSessionSynthesize(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
-        let args = CompatArguments(arguments)
-        let sessionID = try await compatResolveSessionID(try compatParseSessionID(args), sessionRegistry: sessionRegistry)
-        guard let sessionID else {
-            throw ToolValidationError.invalid("session_id is required when no active session is available")
-        }
-        let documents = try await memory.corpusSourceDocuments().filter { $0.metadata["session_id"] == sessionID.uuidString }
-        let longTermDocuments = try await memory.corpusSourceDocuments().filter { $0.metadata["session_id"] == nil }
-        let recallSignals = await sessionRegistry.recallSignals(for: sessionID)
-        let synthesis = BrokerMemoryInsights.synthesizeSession(
-            documents: documents,
-            scope: MemorySemantics.inferScopeContext(),
-            longTermDocuments: longTermDocuments,
-            recallSignalsByFrameID: recallSignals
-        )
-        return textWithJSONResourceResult(
-            text: synthesis.summary,
-            payload: [
-                "session_id": .string(sessionID.uuidString),
-                "summary": .string(synthesis.summary),
-                "handoff": .string(synthesis.handoff),
-                "lessons": .array(synthesis.lessons.map(Value.string)),
-                "decisions": .array(synthesis.decisions.map(Value.string)),
-                "preferences": .array(synthesis.preferences.map(Value.string)),
-                "constraints": .array(synthesis.constraints.map(Value.string)),
-                "durable_candidates": .array(synthesis.durableCandidates.map(compatPromotionProposalValue)),
-            ],
-            uri: "wax://tool/session-synthesize-summary"
-        )
+    static func compatSessionSynthesize(_ arguments: [String: Value]?, memory _: MemoryOrchestrator) async throws -> CallTool.Result {
+        throw ToolValidationError.invalid("session_id is required when no active session is available")
     }
 
-    static func compatMemoryPromote(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatMemoryPromote(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
-        let sessionID = try await compatResolveSessionID(try compatParseSessionID(args), sessionRegistry: sessionRegistry)
         let explicitContent = try args.optionalString("content")
         let frameID = try args.optionalInt("frame_id").map(UInt64.init)
         let approve = try args.optionalBool("approve") ?? false
 
-        var sourceMetadata: [String: String] = [:]
-        let content: String
-        if let explicitContent, !explicitContent.isEmpty {
-            content = explicitContent
-        } else {
-            guard let sessionID else {
-                throw ToolValidationError.invalid("Provide content or an active session_id for promotion")
-            }
-            let documents = try await memory.corpusSourceDocuments()
-                .filter { $0.metadata["session_id"] == sessionID.uuidString }
-            let document = if let frameID {
-                documents.first { $0.frameId == frameID }
-            } else {
-                documents.sorted { $0.timestampMs > $1.timestampMs }.first
-            }
-            guard let document else {
-                throw ToolValidationError.invalid("No promotable session memory was found")
-            }
-            content = document.text
-            sourceMetadata = document.metadata
+        guard let content = explicitContent, !content.isEmpty else {
+            throw ToolValidationError.invalid("Provide content or an active session_id for promotion")
         }
 
-        var metadata = try compatCoerceMetadata(try args.optionalObject("metadata")).merging(sourceMetadata) { current, _ in current }
+        var metadata = try compatCoerceMetadata(try args.optionalObject("metadata"))
         metadata = try compatNormalizedMetadata(args: args, metadata: metadata, sessionID: nil)
-        if let sessionID {
-            metadata[MemoryMetadataKeys.promotedFromSession] = sessionID.uuidString
-            metadata.removeValue(forKey: "session_id")
-        }
         if let frameID {
             metadata[MemoryMetadataKeys.promotedFromFrame] = String(frameID)
         }
 
-        let longTermDocuments = try await memory.corpusSourceDocuments().filter { $0.metadata["session_id"] == nil }
-        let recallSignalsByFrameID: [UInt64: BrokerSessionRecallSignals] = if let sessionID {
-            await sessionRegistry.recallSignals(for: sessionID)
-        } else {
-            [:]
-        }
+        let longTermDocuments = try await memory.corpusSourceDocuments()
         let proposal = BrokerMemoryInsights.proposePromotion(
             content: content,
             metadata: metadata,
-            sessionID: sessionID,
+            sessionID: nil,
             sourceFrameID: frameID,
             scope: MemorySemantics.inferScopeContext(),
             longTermDocuments: longTermDocuments,
-            recallSignals: frameID.flatMap { recallSignalsByFrameID[$0] }
+            recallSignals: nil
         )
         if approve, proposal.shouldWrite {
             let writeSemantics = MemoryWriteSemantics(
@@ -1477,69 +1215,23 @@ private extension WaxMCPTools {
         ])
     }
 
-    static func compatSessionStart(_ sessionRegistry: CompatSessionRegistry) async -> CallTool.Result {
-        let value = await sessionRegistry.start()
-        return jsonResult([
-            "status": .string("ok"),
-            "session_id": .string(value.uuidString),
-        ])
-    }
-
-    static func compatSessionResume(_ arguments: [String: Value]?, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatCompactContext(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
-        guard let sessionID = try compatParseSessionID(args) else {
-            throw ToolValidationError.invalid("session_id is required in compatibility mode")
-        }
-        try await compatValidateActiveSession(sessionID, in: sessionRegistry)
-        return jsonResult([
-            "status": .string("ok"),
-            "session_id": .string(sessionID.uuidString),
-            "resumed": .bool(true),
-        ])
-    }
-
-    static func compatSessionEnd(_ arguments: [String: Value]?, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
-        let args = CompatArguments(arguments)
-        let sessionID = try compatParseSessionID(args)
-        let result = try await sessionRegistry.end(sessionID: sessionID)
-        let remainingCount = await sessionRegistry.activeSessionIDs().count
-        return jsonResult([
-            "status": .string("ok"),
-            "session_id": result.0.map { .string($0.uuidString) } ?? .null,
-            "ended": .bool(result.0 != nil),
-            "active": .bool(false),
-            "remaining_active": .bool(remainingCount > 0),
-            "active_session_count": .int(remainingCount),
-        ])
-    }
-
-    static func compatCompactContext(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
-        let args = CompatArguments(arguments)
-        let sessionID = try await compatResolveSessionID(
-            try compatParseSessionID(args),
-            requiringUnambiguousWorkingMemory: true,
-            sessionRegistry: sessionRegistry
-        )
-        try await compatValidateActiveSession(sessionID, in: sessionRegistry)
         let query = try args.requiredString("query")
         let limit = min(try args.optionalInt("max_items") ?? 6, 12)
         let mode = try compatSearchMode(
             modeRaw: try args.optionalString("mode") ?? "hybrid",
             alpha: try args.optionalDouble("alpha")
         )
-        let frameFilter = sessionID.map {
-            FrameFilter(metadataFilter: MetadataFilter(requiredEntries: ["session_id": $0.uuidString]))
-        }
         let execution = try await memory.recallExecution(
             query: query,
             mode: mode,
-            frameFilter: frameFilter,
+            frameFilter: nil,
             timeRange: nil,
             topK: limit
         )
         let documents = try await memory.corpusSourceDocuments()
         let documentByFrameID = Dictionary(uniqueKeysWithValues: documents.map { ($0.frameId, $0) })
-        let activeSessionIDs = Set(await sessionRegistry.activeSessionIDs().map(\.uuidString))
         var encodedItems: [Value] = []
         var itemTexts: [String] = []
         for item in execution.context.items.prefix(limit) {
@@ -1548,21 +1240,10 @@ private extension WaxMCPTools {
                 in: documentByFrameID,
                 memory: memory
             ) else { continue }
-            let documentSessionID = document.metadata["session_id"]
-            let horizon: String
-            let memoryID: String
-            if let documentSessionID {
-                let isWorking = activeSessionIDs.contains(documentSessionID)
-                horizon = isWorking ? "working" : "episodic"
-                memoryID = "\(horizon):\(documentSessionID):\(document.frameId)"
-            } else {
-                horizon = "durable"
-                memoryID = "durable:\(document.frameId)"
-            }
             itemTexts.append(item.text)
             encodedItems.append([
-                "memory_id": .string(memoryID),
-                "horizon": .string(horizon),
+                "memory_id": .string("durable:\(document.frameId)"),
+                "horizon": .string("durable"),
                 "frame_id": .int(Int(document.frameId)),
                 "preview": .string(item.text),
             ])
@@ -1574,7 +1255,7 @@ private extension WaxMCPTools {
             text: compactedText,
             payload: [
                 "query": .string(query),
-                "session_id": sessionID.map { .string($0.uuidString) } ?? .null,
+                "session_id": .null,
                 "used_tokens": .int(execution.context.totalTokens),
                 "summary": .string(itemTexts.first ?? "No compacted context available."),
                 "short_context": .array(encodedItems),
@@ -1586,7 +1267,7 @@ private extension WaxMCPTools {
         )
     }
 
-    static func compatMarkdownExport(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry _: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatMarkdownExport(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let outputDir = try args.requiredString("output_dir")
         let outputURL = URL(fileURLWithPath: outputDir, isDirectory: true).standardizedFileURL
@@ -1616,7 +1297,7 @@ private extension WaxMCPTools {
         ])
     }
 
-    static func compatMarkdownSync(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry _: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatMarkdownSync(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let rootDir = try args.requiredString("root_dir")
         let dryRun = try args.optionalBool("dry_run") ?? false
@@ -1683,11 +1364,9 @@ private extension WaxMCPTools {
         ])
     }
 
-    static func compatHandoff(_ arguments: [String: Value]?, memory: MemoryOrchestrator, sessionRegistry: CompatSessionRegistry) async throws -> CallTool.Result {
+    static func compatHandoff(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {
         let args = CompatArguments(arguments)
         let content = try args.requiredString("content")
-        let sessionID = try compatParseSessionID(args)
-        try await compatValidateActiveSession(sessionID, in: sessionRegistry)
         let project = try args.optionalString("project")
         let pendingTasks = try args.optionalStringArray("pending_tasks") ?? []
         let commit = try args.optionalBool("commit") ?? true
@@ -1695,7 +1374,7 @@ private extension WaxMCPTools {
             content: content,
             project: project,
             pendingTasks: pendingTasks,
-            sessionId: sessionID,
+            sessionId: nil,
             commit: commit
         )
         return jsonResult([

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -386,8 +386,6 @@ extension WaxMCPTools {
                 return try await compatRecall(params.arguments, memory: memory)
             case "search":
                 return try await compatSearch(params.arguments, memory: memory)
-            case "session_synthesize":
-                return try await compatSessionSynthesize(params.arguments, memory: memory)
             case "memory_promote":
                 return try await compatMemoryPromote(params.arguments, memory: memory)
             case "promote":
@@ -1085,10 +1083,6 @@ private extension WaxMCPTools {
                 "sessionFrameCount": .int(0),
             ],
         ])
-    }
-
-    static func compatSessionSynthesize(_ arguments: [String: Value]?, memory _: MemoryOrchestrator) async throws -> CallTool.Result {
-        throw ToolValidationError.invalid("session_id is required when no active session is available")
     }
 
     static func compatMemoryPromote(_ arguments: [String: Value]?, memory: MemoryOrchestrator) async throws -> CallTool.Result {

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -883,6 +883,288 @@ func requireVectorOpenPreservesLockUnavailableError() async throws {
     }
 }
 
+@Test
+func handleRejectsInvalidSessionIDUUID() async throws {
+    try await withIsolatedBroker { service, _ in
+        let rejected = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string("x"),
+                "mode": .string("text"),
+                "session_id": .string("not-a-uuid"),
+            ]
+        ))
+        #expect(rejected.ok == false)
+        #expect((rejected.error ?? "").contains("session_id must be a valid UUID"))
+    }
+}
+
+@Test
+func sessionStartDoesNotImplicitlyScopeUnscopedWrites() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("scope-agent"),
+                "run_id": .string("scope-run"),
+            ]
+        ))
+        #expect(started.ok == true)
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("GLOBAL_IMPLICIT_SCOPE_GUARD")]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("SESSION_EXPLICIT_SCOPE_GUARD"),
+                "session_id": .string(sessionID),
+            ]
+        ))).ok == true)
+
+        let scoped = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string("GLOBAL_IMPLICIT_SCOPE_GUARD"),
+                "mode": .string("text"),
+                "topK": .int(10),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        #expect(scoped.ok == true)
+        let scopedTexts = resultTexts(try requireObject(scoped.payload))
+        #expect(scopedTexts.contains { $0.contains("GLOBAL_IMPLICIT_SCOPE_GUARD") } == false)
+
+        let unscoped = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string("GLOBAL_IMPLICIT_SCOPE_GUARD"),
+                "mode": .string("text"),
+                "topK": .int(10),
+            ]
+        ))
+        #expect(unscoped.ok == true)
+        let unscopedTexts = resultTexts(try requireObject(unscoped.payload))
+        #expect(unscopedTexts.contains { $0.contains("GLOBAL_IMPLICIT_SCOPE_GUARD") })
+    }
+}
+
+@Test
+func endedSessionIDIsRejectedOnLaterScopedBrokerCalls() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("ended-agent"),
+                "run_id": .string("ended-run"),
+            ]
+        ))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        #expect((await service.handle(.init(
+            command: "session_end",
+            arguments: ["session_id": .string(sessionID)]
+        ))).ok == true)
+
+        let remember = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("should fail after end"),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        #expect(remember.ok == false)
+        #expect((remember.error ?? "").contains("session_id is not active"))
+
+        let search = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string("should fail after end"),
+                "mode": .string("text"),
+                "topK": .int(5),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        #expect(search.ok == false)
+        #expect((search.error ?? "").contains("session_id is not active"))
+    }
+}
+
+@Test
+func sessionEndRequiresSessionIDWhenMultipleSessionsAreActive() async throws {
+    try await withIsolatedBroker { service, _ in
+        #expect((await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("multi-end-a"),
+                "run_id": .string("run-a"),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("multi-end-b"),
+                "run_id": .string("run-b"),
+            ]
+        ))).ok == true)
+
+        let ended = await service.handle(.init(command: "session_end"))
+        #expect(ended.ok == false)
+        #expect((ended.error ?? "").contains("session_id is required"))
+    }
+}
+
+@Test
+func memorySearchWorkingOnlyExcludesDurableHits() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("filter-agent"),
+                "run_id": .string("filter-run"),
+            ]
+        ))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        let query = "F033_POST_FILTER_ANCHOR"
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("\(query) \(query) \(query) durable result should be filtered out"),
+                "memory_type": .string("fact"),
+                "durability": .string("durable"),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("\(query) working result should survive filtering"),
+                "session_id": .string(sessionID),
+            ]
+        ))).ok == true)
+
+        let search = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "topK": .int(1),
+                "session_id": .string(sessionID),
+                "include_working": .bool(true),
+                "include_episodic": .bool(false),
+                "include_durable": .bool(false),
+            ]
+        ))
+        #expect(search.ok == true, "memory_search failed: \(search.error ?? "nil")")
+        let texts = resultTexts(try requireObject(search.payload))
+        #expect(texts.count == 1)
+        #expect(texts.contains { $0.contains("working result should survive filtering") })
+        #expect(texts.contains { $0.contains("durable result should be filtered out") } == false)
+    }
+}
+
+@Test
+func sessionSynthesizeAndPromoteFlowWorksOnBroker() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("synth-agent"),
+                "run_id": .string("synth-run"),
+            ]
+        ))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "session_id": .string(sessionID),
+                "content": .string("Decision: Wax should default repo-scoped recall before global recall."),
+            ]
+        ))).ok == true)
+
+        let synthesize = await service.handle(.init(
+            command: "session_synthesize",
+            arguments: ["session_id": .string(sessionID)]
+        ))
+        #expect(synthesize.ok == true, "session_synthesize failed: \(synthesize.error ?? "nil")")
+        let candidates = try requireObject(synthesize.payload)["durable_candidates"]?.arrayValue ?? []
+        #expect(!candidates.isEmpty)
+
+        let promote = await service.handle(.init(
+            command: "memory_promote",
+            arguments: [
+                "session_id": .string(sessionID),
+                "approve": .bool(true),
+            ]
+        ))
+        #expect(promote.ok == true, "memory_promote failed: \(promote.error ?? "nil")")
+    }
+}
+
+@Test
+func memoryPromotePreservesLockedOverrideOnBroker() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("lock-agent"),
+                "run_id": .string("lock-run"),
+            ]
+        ))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "session_id": .string(sessionID),
+                "content": .string("Decision: keep broker-backed promotion overrides intact."),
+            ]
+        ))).ok == true)
+
+        let promote = await service.handle(.init(
+            command: "memory_promote",
+            arguments: [
+                "session_id": .string(sessionID),
+                "approve": .bool(true),
+                "locked": .bool(true),
+            ]
+        ))
+        #expect(promote.ok == true, "memory_promote failed: \(promote.error ?? "nil")")
+        let metadata = try requireObject(try requireObject(promote.payload)["metadata"] ?? .null)
+        #expect(metadata["wax.durability"]?.stringValue == "locked")
+    }
+}
+
+@Test
+func handoffRoundTripWorksOnBroker() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("handoff-agent"),
+                "run_id": .string("handoff-run"),
+            ]
+        ))
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        #expect((await service.handle(.init(
+            command: "handoff",
+            arguments: [
+                "content": .string("Carry over refactor checkpoints"),
+                "session_id": .string(sessionID),
+                "project": .string("wax"),
+                "pending_tasks": .array([.string("add graph tests"), .string("measure ranking drift")]),
+            ]
+        ))).ok == true)
+
+        let latest = await service.handle(.init(
+            command: "handoff_latest",
+            arguments: ["project": .string("wax")]
+        ))
+        #expect(latest.ok == true)
+        #expect(try requireObject(latest.payload)["content"]?.stringValue?.contains("Carry over refactor checkpoints") == true)
+    }
+}
+
 private func recallItem(frameId: UInt64, score: Float, text: String) -> RAGContext.Item {
     RAGContext.Item(
         kind: .snippet,

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -1528,26 +1528,29 @@ func openClawPackageDeclaresSDKPeerDependency() throws {
     #expect(devDependencies["openclaw"] as? String == ">=2026.3.24-beta.2")
 }
 
-@Test
-func sessionEndRequiresSessionIDWhenMultipleSessionsActive() async throws {
-    try await withMemory { memory in
-        let first = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        let second = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(first.isError != true)
-        #expect(second.isError != true)
 
-        let end = await WaxMCPTools.handleCall(
-            params: .init(name: "session_end", arguments: [:]),
+@Test
+func directMemoryHelperRejectsSessionLifecycle() async throws {
+    try await withMemory { memory in
+        let start = await WaxMCPTools.handleCall(
+            params: .init(name: "session_start", arguments: [:]),
             memory: memory
         )
-        #expect(end.isError == true)
-        #expect(firstText(in: end).contains("session_id is required"))
+        #expect(start.isError == true)
+        #expect(firstText(in: start).contains("session lifecycle requires the broker"))
+
+        let remember = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "remember",
+                arguments: [
+                    "content": "session_id is not a metadata tag on this helper",
+                    "session_id": .string(UUID().uuidString),
+                ]
+            ),
+            memory: memory
+        )
+        #expect(remember.isError == true)
+        #expect(firstText(in: remember).contains("session_id requires the broker"))
     }
 }
 
@@ -1592,126 +1595,6 @@ func toolsRememberRecallSearchFlushStatsHappyPath() async throws {
     }
 }
 
-@Test
-func memorySearchOverfetchesBeforeHorizonFiltering() async throws {
-    try await withMemory { memory in
-        let started = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(started.isError != true)
-        let startedPayload = try parseJSONText(in: started)
-        let sessionID = try #require(startedPayload["session_id"] as? String)
-        let query = "F033_POST_FILTER_ANCHOR"
-
-        let durable = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": .string("\(query) \(query) \(query) durable result should be filtered out"),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(durable.isError != true)
-
-        let working = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "memory_append",
-                arguments: [
-                    "content": .string("\(query) working result should survive filtering"),
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(working.isError != true)
-
-        let search = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "memory_search",
-                arguments: [
-                    "query": .string(query),
-                    "mode": .string("text"),
-                    "topK": .int(1),
-                    "session_id": .string(sessionID),
-                    "include_working": .bool(true),
-                    "include_episodic": .bool(false),
-                    "include_durable": .bool(false),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(search.isError != true)
-        let payload = try parseJSONResource(in: search, uriSuffix: "memory-search-summary")
-        let results = try #require(payload["results"] as? [[String: Any]])
-        #expect(results.count == 1)
-        #expect(results.first?["horizon"] as? String == "working")
-        #expect((results.first?["preview"] as? String)?.contains("working result should survive filtering") == true)
-    }
-}
-
-@Test
-func memorySearchOverfetchesAcrossManyFilteredHits() async throws {
-    try await withMemory { memory in
-        let started = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(started.isError != true)
-        let startedPayload = try parseJSONText(in: started)
-        let sessionID = try #require(startedPayload["session_id"] as? String)
-        let query = "F033_MANY_FILTERED_ANCHOR"
-
-        for index in 0..<40 {
-            let durable = await WaxMCPTools.handleCall(
-                params: .init(
-                    name: "remember",
-                    arguments: [
-                        "content": .string("\(query) \(query) \(query) \(query) durable filtered result \(index)"),
-                    ]
-                ),
-                memory: memory
-            )
-            #expect(durable.isError != true)
-        }
-
-        for index in 0..<2 {
-            let working = await WaxMCPTools.handleCall(
-                params: .init(
-                    name: "memory_append",
-                    arguments: [
-                        "content": .string("\(query) working survivor \(index)"),
-                        "session_id": .string(sessionID),
-                    ]
-                ),
-                memory: memory
-            )
-            #expect(working.isError != true)
-        }
-
-        let search = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "memory_search",
-                arguments: [
-                    "query": .string(query),
-                    "mode": .string("text"),
-                    "topK": .int(2),
-                    "session_id": .string(sessionID),
-                    "include_working": .bool(true),
-                    "include_episodic": .bool(false),
-                    "include_durable": .bool(false),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(search.isError != true)
-        let payload = try parseJSONResource(in: search, uriSuffix: "memory-search-summary")
-        let results = try #require(payload["results"] as? [[String: Any]])
-        #expect(results.count == 2)
-        #expect(results.allSatisfy { ($0["horizon"] as? String) == "working" })
-    }
-}
 
 @Test
 func corpusSearchBuildsAcrossSessionStoresAndReturnsProvenance() async throws {
@@ -2763,188 +2646,6 @@ func markdownExportSanitizesDailySourceDateFilenames() async throws {
     }
 }
 
-@Test
-func sessionStartEndAndScopedRecallSearchWork() async throws {
-    try await withMemory { memory in
-        let start = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(start.isError != true)
-        let startJSON = try parseJSONText(in: start)
-        let sessionID = try requireString(startJSON, key: "session_id")
-
-        _ = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: ["content": "GLOBAL_ONLY_ABC anchor for unscoped search"]
-            ),
-            memory: memory
-        )
-        _ = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": "SESSION_ONLY_XYZ anchor for scoped search",
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        let scopedRecall = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "recall",
-                arguments: ["query": "SESSION_ONLY_XYZ", "session_id": .string(sessionID), "limit": 10]
-            ),
-            memory: memory
-        )
-        #expect(scopedRecall.isError != true)
-        let scopedRecallText = firstText(in: scopedRecall)
-        #expect(scopedRecallText.contains("SESSION_ONLY_XYZ"))
-        #expect(scopedRecallText.contains("GLOBAL_") && scopedRecallText.contains("ABC"))
-
-        let unscopedSearch = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "search",
-                arguments: ["query": "GLOBAL_ONLY_ABC", "mode": "text", "topK": 10]
-            ),
-            memory: memory
-        )
-        #expect(unscopedSearch.isError != true)
-        let unscopedSearchPayload = try parseJSONResource(in: unscopedSearch, uriSuffix: "/search-summary")
-        let unscopedResults = try requireArray(unscopedSearchPayload, key: "results")
-        #expect(unscopedResults.contains { (($0 as? [String: Any])?["preview"] as? String)?.contains("GLOBAL") == true })
-
-        let scopedSearch = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "search",
-                arguments: [
-                    "query": "GLOBAL_ONLY_ABC",
-                    "mode": "text",
-                    "topK": .int(10),
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(scopedSearch.isError != true)
-        let scopedSearchPayload = try parseJSONResource(in: scopedSearch, uriSuffix: "/search-summary")
-        let scopedResults = try requireArray(scopedSearchPayload, key: "results")
-        #expect(!scopedResults.contains { (($0 as? [String: Any])?["preview"] as? String)?.contains("GLOBAL_ONLY_ABC") == true })
-
-        let end = await WaxMCPTools.handleCall(
-            params: .init(name: "session_end", arguments: [:]),
-            memory: memory
-        )
-        #expect(end.isError != true)
-    }
-}
-
-@Test
-func compatMemorySearchRequiresSessionIDWhenMultipleActiveSessionsIncludeWorking() async throws {
-    try await withMemory { memory in
-        let first = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        let firstID = try requireString(try parseJSONText(in: first), key: "session_id")
-
-        let second = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        let secondID = try requireString(try parseJSONText(in: second), key: "session_id")
-        let marker = "F034_COMPAT_WORKING_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
-
-        _ = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": .string("\(marker) first session working memory"),
-                    "session_id": .string(firstID),
-                ]
-            ),
-            memory: memory
-        )
-        _ = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": .string("\(marker) second session working memory"),
-                    "session_id": .string(secondID),
-                ]
-            ),
-            memory: memory
-        )
-
-        let ambiguous = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "memory_search",
-                arguments: [
-                    "query": .string(marker),
-                    "mode": .string("text"),
-                    "include_working": .bool(true),
-                    "include_episodic": .bool(false),
-                    "include_durable": .bool(false),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(ambiguous.isError == true)
-        #expect(firstText(in: ambiguous).contains("session_id is required when more than one"))
-
-        let explicit = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "memory_search",
-                arguments: [
-                    "query": .string(marker),
-                    "session_id": .string(firstID),
-                    "mode": .string("text"),
-                    "include_working": .bool(true),
-                    "include_episodic": .bool(false),
-                    "include_durable": .bool(false),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(explicit.isError != true)
-        let explicitPayload = try parseJSONResource(in: explicit, uriSuffix: "memory-search-summary")
-        let results = try #require(explicitPayload["results"] as? [[String: Any]])
-        #expect(results.contains { ($0["text"] as? String)?.contains("first session working memory") == true })
-        #expect(results.allSatisfy { ($0["memory_id"] as? String)?.contains(firstID) == true })
-        #expect(!firstText(in: explicit).contains("second session working memory"))
-    }
-}
-
-@Test
-func compatCompactContextRequiresSessionIDWhenMultipleSessionsAreActive() async throws {
-    try await withMemory { memory in
-        let first = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        _ = try requireString(try parseJSONText(in: first), key: "session_id")
-
-        let second = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        _ = try requireString(try parseJSONText(in: second), key: "session_id")
-
-        let compact = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "compact_context",
-                arguments: [
-                    "query": .string("F034_COMPAT_COMPACT"),
-                    "mode": .string("text"),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(compact.isError == true)
-        #expect(firstText(in: compact).contains("session_id is required when more than one"))
-    }
-}
 
 @Test
 func brokerMemorySearchRequiresSessionIDWhenMultipleActiveSessionsIncludeWorking() async throws {
@@ -3102,68 +2803,6 @@ func brokerCLIPathResolvesSiblingWhenLaunchedViaPath() throws {
     #expect(resolved == cliPath.path)
 }
 
-@Test
-func sessionStartDoesNotImplicitlyScopeWrites() async throws {
-    try await withMemory { memory in
-        let start = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(start.isError != true)
-        let started = try parseJSONText(in: start)
-        let sessionID = try requireString(started, key: "session_id")
-
-        let globalWrite = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: ["content": "GLOBAL_IMPLICIT_SCOPE_GUARD"]
-            ),
-            memory: memory
-        )
-        #expect(globalWrite.isError != true)
-
-        let scopedWrite = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": "SESSION_EXPLICIT_SCOPE_GUARD",
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(scopedWrite.isError != true)
-
-        let scopedSearch = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "search",
-                arguments: [
-                    "query": "GLOBAL_IMPLICIT_SCOPE_GUARD",
-                    "mode": "text",
-                    "topK": 10,
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(scopedSearch.isError != true)
-        let scopedPayload = try parseJSONResource(in: scopedSearch, uriSuffix: "/search-summary")
-        let scopedResults = try requireArray(scopedPayload, key: "results")
-        #expect(!scopedResults.contains { (($0 as? [String: Any])?["preview"] as? String)?.contains("GLOBAL_IMPLICIT_SCOPE_GUARD") == true })
-
-        let unscopedSearch = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "search",
-                arguments: ["query": "GLOBAL_IMPLICIT_SCOPE_GUARD", "mode": "text", "topK": 10]
-            ),
-            memory: memory
-        )
-        #expect(unscopedSearch.isError != true)
-        let unscopedPayload = try parseJSONResource(in: unscopedSearch, uriSuffix: "/search-summary")
-        let unscopedResults = try requireArray(unscopedPayload, key: "results")
-        #expect(!unscopedResults.isEmpty)
-    }
-}
 
 @Test
 func rememberRejectsMetadataSessionID() async throws {
@@ -3183,246 +2822,6 @@ func rememberRejectsMetadataSessionID() async throws {
     }
 }
 
-@Test
-func endedSessionIDIsRejectedOnLaterScopedCalls() async throws {
-    try await withMemory { memory in
-        let start = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(start.isError != true)
-        let started = try parseJSONText(in: start)
-        let sessionID = try requireString(started, key: "session_id")
-
-        let end = await WaxMCPTools.handleCall(
-            params: .init(name: "session_end", arguments: ["session_id": .string(sessionID)]),
-            memory: memory
-        )
-        #expect(end.isError != true)
-
-        let remember = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": "should fail after end",
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(remember.isError == true)
-        #expect(firstText(in: remember).contains("session_id is not active"))
-
-        let search = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "search",
-                arguments: [
-                    "query": "should fail after end",
-                    "mode": "text",
-                    "topK": 5,
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(search.isError == true)
-        #expect(firstText(in: search).contains("session_id is not active"))
-    }
-}
-
-@Test
-func compatMemoryGetReadsEpisodicIDsReturnedByMemorySearch() async throws {
-    try await withMemory { memory in
-        let start = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(start.isError != true)
-        let sessionID = try requireString(try parseJSONText(in: start), key: "session_id")
-
-        let remember = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": .string("EPISODIC_MEMORY_GET_ROUNDTRIP compatibility memory should remain readable after the session ends."),
-                    "session_id": .string(sessionID),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(remember.isError != true)
-
-        let end = await WaxMCPTools.handleCall(
-            params: .init(name: "session_end", arguments: ["session_id": .string(sessionID)]),
-            memory: memory
-        )
-        #expect(end.isError != true)
-
-        let document = try #require(try await memory.corpusSourceDocuments().first(where: {
-            $0.metadata["session_id"] == sessionID &&
-            $0.text.contains("EPISODIC_MEMORY_GET_ROUNDTRIP")
-        }))
-        let memoryID = "episodic:\(sessionID):\(document.frameId)"
-
-        let get = await WaxMCPTools.handleCall(
-            params: .init(name: "memory_get", arguments: ["memory_id": .string(memoryID)]),
-            memory: memory
-        )
-        #expect(get.isError != true)
-        #expect(firstText(in: get).contains("EPISODIC_MEMORY_GET_ROUNDTRIP"))
-    }
-}
-
-@Test
-func compatCompactContextScopesToRequestedSession() async throws {
-    try await withMemory { memory in
-        let startA = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(startA.isError != true)
-        let sessionA = try requireString(try parseJSONText(in: startA), key: "session_id")
-
-        let startB = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(startB.isError != true)
-        let sessionB = try requireString(try parseJSONText(in: startB), key: "session_id")
-
-        _ = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": .string("COMPACT_CONTEXT_SCOPE_MARKER durable memory must stay out of session A checkpoints."),
-                ]
-            ),
-            memory: memory
-        )
-        _ = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": .string("COMPACT_CONTEXT_SCOPE_MARKER session A memory must remain in session A checkpoints."),
-                    "session_id": .string(sessionA),
-                ]
-            ),
-            memory: memory
-        )
-        _ = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "remember",
-                arguments: [
-                    "content": .string("COMPACT_CONTEXT_SCOPE_MARKER session B memory must not leak into session A checkpoints."),
-                    "session_id": .string(sessionB),
-                ]
-            ),
-            memory: memory
-        )
-
-        let compact = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "compact_context",
-                arguments: [
-                    "query": .string("COMPACT_CONTEXT_SCOPE_MARKER"),
-                    "session_id": .string(sessionA),
-                    "mode": .string("text"),
-                    "max_items": .int(6),
-                ]
-            ),
-            memory: memory
-        )
-        #expect(compact.isError != true)
-        let payload = try parseJSONResource(in: compact, uriSuffix: "/compact-context-summary")
-        let shortContext = try requireArray(payload, key: "short_context")
-        #expect(!shortContext.isEmpty)
-        #expect(shortContext.contains { entry in
-            guard let object = try? requireObject(entry) else { return false }
-            return (object["preview"] as? String)?.contains("session A memory must remain") == true
-        })
-        #expect(!shortContext.contains { entry in
-            guard let object = try? requireObject(entry) else { return false }
-            return (object["preview"] as? String)?.contains("durable memory must stay out") == true
-        })
-        #expect(!shortContext.contains { entry in
-            guard let object = try? requireObject(entry) else { return false }
-            return (object["preview"] as? String)?.contains("session B memory must not leak") == true
-        })
-        #expect(shortContext.allSatisfy { entry in
-            guard let object = try? requireObject(entry),
-                  let memoryID = object["memory_id"] as? String else { return false }
-            return memoryID.hasPrefix("working:\(sessionA):")
-        })
-
-        let firstItem = try #require(shortContext.compactMap { try? requireObject($0) }.first)
-        let memoryID = try requireString(firstItem, key: "memory_id")
-        let get = await WaxMCPTools.handleCall(
-            params: .init(name: "memory_get", arguments: ["memory_id": .string(memoryID)]),
-            memory: memory
-        )
-        #expect(get.isError != true)
-        #expect(firstText(in: get).contains("session A memory must remain"))
-    }
-}
-
-@Test
-func sessionEndReportsRemainingActiveSessions() async throws {
-    try await withMemory { memory in
-        let startA = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(startA.isError != true)
-        let sessionA = try requireString(try parseJSONText(in: startA), key: "session_id")
-
-        let startB = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(startB.isError != true)
-        let sessionB = try requireString(try parseJSONText(in: startB), key: "session_id")
-
-        let end = await WaxMCPTools.handleCall(
-            params: .init(name: "session_end", arguments: ["session_id": .string(sessionA)]),
-            memory: memory
-        )
-        #expect(end.isError != true)
-        let ended = try parseJSONText(in: end)
-        #expect((ended["session_id"] as? String) == sessionA)
-        #expect((ended["ended"] as? Bool) == true)
-        #expect((ended["active"] as? Bool) == false)
-        #expect((ended["remaining_active"] as? Bool) == true)
-        #expect((ended["active_session_count"] as? Int) == 1)
-
-        let stats = await WaxMCPTools.handleCall(
-            params: .init(name: "stats", arguments: [:]),
-            memory: memory
-        )
-        #expect(stats.isError != true)
-        let statsJSON = try parseJSONText(in: stats)
-        let session = statsJSON["session"] as? [String: Any]
-        #expect((session?["activeSessionCount"] as? Int) == 1)
-        #expect((session?["activeSessionIds"] as? [String]) == [sessionB])
-    }
-}
-
-@Test
-func sessionEndIdleMCPReportsConsistentKeys() async throws {
-    try await withMemory { memory in
-        let end = await WaxMCPTools.handleCall(
-            params: .init(name: "session_end", arguments: [:]),
-            memory: memory
-        )
-        #expect(end.isError != true)
-        let ended = try parseJSONText(in: end)
-        #expect((ended["status"] as? String) == "ok")
-        #expect(ended["session_id"] is NSNull)
-        #expect((ended["ended"] as? Bool) == false)
-        #expect((ended["active"] as? Bool) == false)
-        #expect((ended["remaining_active"] as? Bool) == false)
-        #expect((ended["active_session_count"] as? Int) == 0)
-    }
-}
 
 @Test
 func statsReportQueryEmbeddingAvailableWithoutIdentityMetadata() async throws {
@@ -3553,57 +2952,6 @@ func recallJSONResourceIncludesStructuredResults() async throws {
     }
 }
 
-@Test
-func handoffRoundTripAndStatsSessionBlockWork() async throws {
-    try await withMemory { memory in
-        let start = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        #expect(start.isError != true)
-        let started = try parseJSONText(in: start)
-        let sessionID = try requireString(started, key: "session_id")
-
-        let handoff = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "handoff",
-                arguments: [
-                    "content": "Carry over refactor checkpoints",
-                    "session_id": .string(sessionID),
-                    "project": "wax",
-                    "pending_tasks": ["add graph tests", "measure ranking drift"],
-                ]
-            ),
-            memory: memory
-        )
-        #expect(handoff.isError != true)
-
-        let latest = await WaxMCPTools.handleCall(
-            params: .init(
-                name: "handoff_latest",
-                arguments: ["project": "wax"]
-            ),
-            memory: memory
-        )
-        #expect(latest.isError != true)
-        let latestJSON = try parseJSONText(in: latest)
-        #expect((latestJSON["content"] as? String)?.contains("Carry over refactor checkpoints") == true)
-
-        let stats = await WaxMCPTools.handleCall(
-            params: .init(name: "stats", arguments: [:]),
-            memory: memory
-        )
-        #expect(stats.isError != true)
-        let statsJSON = try parseJSONText(in: stats)
-        guard let session = statsJSON["session"] as? [String: Any] else {
-            Issue.record("Expected session block in wax_stats response")
-            return
-        }
-        #expect((session["active"] as? Bool) == true)
-        #expect((session["session_id"] as? String) == sessionID)
-        #expect((session["sessionFrameCount"] as? Int ?? 0) >= 1)
-    }
-}
 
 @Test
 func graphToolsRoundTripWorks() async throws {
@@ -4039,67 +3387,6 @@ func rememberSearchAndRecallExposeTypedExplainableMemory() async throws {
     }
 }
 
-@Test
-func sessionSynthesizeAndPromoteFlowWorks() async throws {
-    try await withMemory { memory in
-        let started = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        let startedJSON = try parseJSONText(in: started)
-        let sessionID = try #require(startedJSON["session_id"] as? String)
-
-        let remember = await WaxMCPTools.handleCall(
-            params: .init(name: "remember", arguments: [
-                "session_id": .string(sessionID),
-                "content": .string("Decision: Wax should default repo-scoped recall before global recall."),
-            ]),
-            memory: memory
-        )
-        #expect(remember.isError != true)
-
-        let synthesize = await WaxMCPTools.handleCall(
-            params: .init(name: "session_synthesize", arguments: [
-                "session_id": .string(sessionID),
-            ]),
-            memory: memory
-        )
-        #expect(synthesize.isError != true)
-        let synthesizeJSON = try parseJSONResource(in: synthesize, uriSuffix: "session-synthesize-summary")
-        let candidates = synthesizeJSON["durable_candidates"] as? [[String: Any]] ?? []
-        #expect(!candidates.isEmpty)
-        #expect(candidates.contains { ($0["suggested_type"] as? String) == "decision" })
-
-        let promote = await WaxMCPTools.handleCall(
-            params: .init(name: "memory_promote", arguments: [
-                "session_id": .string(sessionID),
-                "approve": .bool(true),
-            ]),
-            memory: memory
-        )
-        #expect(promote.isError != true)
-        let promoteJSON = try parseJSONText(in: promote)
-        #expect((promoteJSON["written"] as? Bool) == true)
-        let promoteMetadata = try #require(promoteJSON["metadata"] as? [String: Any])
-        #expect(promoteMetadata["wax.promoted_from_session"] as? String == sessionID)
-        #expect(promoteMetadata["session_id"] == nil)
-
-        let search = await WaxMCPTools.handleCall(
-            params: .init(name: "search", arguments: [
-                "query": .string("repo-scoped recall"),
-                "mode": .string("text"),
-            ]),
-            memory: memory
-        )
-        let searchJSON = try parseJSONResource(in: search, uriSuffix: "search-summary")
-        let results = searchJSON["results"] as? [[String: Any]] ?? []
-        let durableHit = results.first {
-            (($0["metadata"] as? [String: Any])?["wax.memory_type"] as? String == "decision")
-                && (($0["metadata"] as? [String: Any])?["wax.reviewed"] as? String == "true")
-        }
-        #expect(durableHit != nil)
-    }
-}
 
 @Test
 func brokerMarkdownSyncRejectsSecretLikeDurableMemoryImports() async throws {
@@ -4870,11 +4157,11 @@ func brokerSessionStartAppendsStartedEventBeforeSavingManifest() throws {
         .deletingLastPathComponent()
 
     let source = try String(
-        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/AgentBrokerService.swift"),
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/VirtualSessionStore.swift"),
         encoding: .utf8
     )
-    let start = try #require(source.range(of: "func sessionStart(arguments: [String: AgentBrokerValue])"))
-    let resume = try #require(source[start.upperBound...].range(of: "func sessionResume(arguments: [String: AgentBrokerValue])"))
+    let start = try #require(source.range(of: "package func start("))
+    let resume = try #require(source[start.upperBound...].range(of: "package func resume("))
     let body = source[start.lowerBound..<resume.lowerBound]
 
     let appendEvent = try #require(body.range(of: "BrokerSessionPersistence.appendEvent("))
@@ -4890,11 +4177,11 @@ func brokerSessionResumeAppendsResumedEventBeforeSavingLease() throws {
         .deletingLastPathComponent()
 
     let source = try String(
-        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/AgentBrokerService.swift"),
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/VirtualSessionStore.swift"),
         encoding: .utf8
     )
-    let start = try #require(source.range(of: "func sessionResume(arguments: [String: AgentBrokerValue])"))
-    let end = try #require(source[start.upperBound...].range(of: "func sessionEnd(arguments: [String: AgentBrokerValue])"))
+    let start = try #require(source.range(of: "package func resume("))
+    let end = try #require(source[start.upperBound...].range(of: "package func end("))
     let body = source[start.lowerBound..<end.lowerBound]
 
     let appendEvent = try #require(body.range(of: "BrokerSessionPersistence.appendEvent("))
@@ -4910,18 +4197,18 @@ func brokerSessionEndKeepsActiveSessionUntilPersistenceSucceeds() throws {
         .deletingLastPathComponent()
 
     let source = try String(
-        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/AgentBrokerService.swift"),
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/VirtualSessionStore.swift"),
         encoding: .utf8
     )
-    let start = try #require(source.range(of: "func sessionEnd(arguments: [String: AgentBrokerValue])"))
-    let end = try #require(source[start.upperBound...].range(of: "func handoff(arguments: [String: AgentBrokerValue])"))
+    let start = try #require(source.range(of: "package func end("))
+    let end = try #require(source[start.upperBound...].range(of: "package func lookup("))
     let body = source[start.lowerBound..<end.lowerBound]
 
     let saveManifest = try #require(body.range(of: "BrokerSessionPersistence.saveManifest(manifest, to: state.manifestURL)"))
     let appendEvent = try #require(body.range(of: "BrokerSessionPersistence.appendEvent("))
     let flush = try #require(body.range(of: "try await state.memory.flush()"))
     let close = try #require(body.range(of: "try await state.memory.close()"))
-    let remove = try #require(body.range(of: "activeSessions.removeValue(forKey: target)"))
+    let remove = try #require(body.range(of: "live.removeValue(forKey: target)"))
 
     #expect(saveManifest.lowerBound < remove.lowerBound)
     #expect(appendEvent.lowerBound < remove.lowerBound)
@@ -5712,94 +4999,6 @@ func brokerMemoryPromoteRejectsStaleSessionBeforeDurableWrite() async throws {
     }
 }
 
-@Test
-func memorySearchSignalsInfluenceCompatSessionSynthesis() async throws {
-    try await withMemory { memory in
-        let started = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        let startedJSON = try parseJSONText(in: started)
-        let sessionID = try #require(startedJSON["session_id"] as? String)
-
-        let remember = await WaxMCPTools.handleCall(
-            params: .init(name: "remember", arguments: [
-                "session_id": .string(sessionID),
-                "content": .string("Decision: memory_search retrieval signals should influence synthesis and promotion."),
-            ]),
-            memory: memory
-        )
-        #expect(remember.isError != true)
-
-        for query in ["retrieval signals", "synthesis promotion"] {
-            let search = await WaxMCPTools.handleCall(
-                params: .init(name: "memory_search", arguments: [
-                    "query": .string(query),
-                    "session_id": .string(sessionID),
-                    "mode": .string("text"),
-                    "topK": .int(5),
-                    "include_working": .bool(true),
-                    "include_episodic": .bool(false),
-                    "include_durable": .bool(false),
-                ]),
-                memory: memory
-            )
-            #expect(search.isError != true)
-        }
-
-        let synthesize = await WaxMCPTools.handleCall(
-            params: .init(name: "session_synthesize", arguments: [
-                "session_id": .string(sessionID),
-            ]),
-            memory: memory
-        )
-        #expect(synthesize.isError != true)
-        let synthesizeJSON = try parseJSONResource(in: synthesize, uriSuffix: "session-synthesize-summary")
-        let candidates = synthesizeJSON["durable_candidates"] as? [[String: Any]] ?? []
-        let matchingCandidate = candidates.first {
-            (($0["summary"] as? String) ?? "").contains("memory_search retrieval signals")
-        }
-        let matching = try #require(matchingCandidate)
-        #expect((matching["recall_count"] as? Int ?? 0) >= 2)
-        #expect((matching["unique_query_count"] as? Int ?? 0) >= 2)
-        #expect((matching["average_relevance_score"] as? Double ?? 0) > 0)
-    }
-}
-
-@Test
-func memoryPromotePreservesLockedOverride() async throws {
-    try await withMemory { memory in
-        let started = await WaxMCPTools.handleCall(
-            params: .init(name: "session_start", arguments: [:]),
-            memory: memory
-        )
-        let startedJSON = try parseJSONText(in: started)
-        let sessionID = try #require(startedJSON["session_id"] as? String)
-
-        let remember = await WaxMCPTools.handleCall(
-            params: .init(name: "remember", arguments: [
-                "session_id": .string(sessionID),
-                "content": .string("Decision: keep broker-backed promotion overrides intact."),
-            ]),
-            memory: memory
-        )
-        #expect(remember.isError != true)
-
-        let promote = await WaxMCPTools.handleCall(
-            params: .init(name: "memory_promote", arguments: [
-                "session_id": .string(sessionID),
-                "approve": .bool(true),
-                "locked": .bool(true),
-            ]),
-            memory: memory
-        )
-        #expect(promote.isError != true)
-        let promoteJSON = try parseJSONText(in: promote)
-        let metadata = try #require(promoteJSON["metadata"] as? [String: Any])
-        #expect(metadata["wax.durability"] as? String == "locked")
-        #expect(metadata["wax.reviewed"] as? String == "true")
-    }
-}
 
 @Test
 func knowledgeCaptureAndMemoryHealthWork() async throws {

--- a/Tests/WaxTests/VirtualSessionStoreTests.swift
+++ b/Tests/WaxTests/VirtualSessionStoreTests.swift
@@ -322,4 +322,121 @@ struct VirtualSessionStoreTests {
             #expect(ended.activeCount == 1)
         }
     }
+
+    @Test
+    func refreshDuringEndLeavesDiskEndedAndSamePairStartMintsNewID() async throws {
+        try await withVirtualSessionStore { store, root in
+            let first = try await startSession(store, agentID: "end-race-agent", runID: "end-race-run")
+            let sessionID = first.state.id
+
+            let endTask = Task { try await store.end(sessionID: sessionID) }
+            for _ in 0..<200 {
+                try? store.refreshManifest(sessionID)
+            }
+            let ended = try await endTask.value
+            #expect(ended.ended == true)
+
+            let manifest = try BrokerSessionPersistence.loadManifest(rootURL: root, sessionID: sessionID)
+            #expect(manifest.status == .ended)
+
+            do {
+                try store.refreshManifest(sessionID)
+                Issue.record("refresh after end should fail closed")
+            } catch {
+                #expect(error.localizedDescription.contains("session_id is not active"))
+            }
+
+            do {
+                _ = try store.lookup(sessionID)
+                Issue.record("ended session_id should fail closed after evict")
+            } catch {
+                #expect(error.localizedDescription.contains("session_id is not active"))
+            }
+
+            let second = try await startSession(store, agentID: "end-race-agent", runID: "end-race-run")
+            #expect(second.state.id != sessionID)
+            #expect(second.resumed == false)
+        }
+    }
+
+    @Test
+    func concurrentSamePairStartsShareOneStoreAndOneActiveManifest() async throws {
+        try await withVirtualSessionStore { store, root in
+            async let firstStart = startSession(store, agentID: "race-agent", runID: "race-run")
+            async let secondStart = startSession(store, agentID: "race-agent", runID: "race-run")
+            let first = try await firstStart
+            let second = try await secondStart
+
+            #expect(first.state.id == second.state.id)
+            let waxFiles = try FileManager.default.contentsOfDirectory(atPath: root.path)
+                .filter { $0.hasSuffix(".wax") }
+            #expect(waxFiles.count == 1)
+            let activeManifests = try BrokerSessionPersistence.listManifests(rootURL: root)
+                .filter { $0.status == .active }
+            #expect(activeManifests.count == 1)
+            #expect(activeManifests.first?.sessionID == first.state.id)
+        }
+    }
+
+    @Test
+    func resumeDoesNotMintWhenSessionWaxIsMissing() async throws {
+        try await withVirtualSessionStore { store, root in
+            let started = try await startSession(store, agentID: "missing-wax-agent", runID: "missing-wax-run")
+            let sessionID = started.state.id
+            let storeURL = started.state.storeURL
+            await store.closeAll()
+            try FileManager.default.removeItem(at: storeURL)
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: BrokerSessionPersistence.manifestURL(rootURL: root, sessionID: sessionID).path
+                )
+            )
+
+            do {
+                _ = try await store.resume(
+                    explicitSessionID: sessionID,
+                    agentID: nil,
+                    runID: nil
+                )
+                Issue.record("resume should throw when .wax is missing")
+            } catch {
+                #expect(error.localizedDescription.contains("session store is missing"))
+            }
+
+            let waxFiles = try FileManager.default.contentsOfDirectory(atPath: root.path)
+                .filter { $0.hasSuffix(".wax") }
+            #expect(waxFiles.isEmpty)
+        }
+    }
+
+    @Test
+    func openExistingSessionMemoryDoesNotMint() async throws {
+        try await withVirtualSessionStore { store, root in
+            let missing = root.appendingPathComponent("ghost.wax")
+            do {
+                _ = try await store.openExistingSessionMemory(at: missing)
+                Issue.record("openExistingSessionMemory should throw when the file is missing")
+            } catch {
+                #expect(error.localizedDescription.contains("session store is missing"))
+            }
+            #expect(!FileManager.default.fileExists(atPath: missing.path))
+        }
+    }
+
+    @Test
+    func peekEndTargetAgreesWithEndAndDoesNotTearDown() async throws {
+        try await withVirtualSessionStore { store, _ in
+            #expect(try store.peekEndTarget(sessionID: nil) == nil)
+
+            let started = try await startSession(store, agentID: "peek-agent", runID: "peek-run")
+            #expect(try store.peekEndTarget(sessionID: nil) == started.state.id)
+            #expect(try store.peekEndTarget(sessionID: started.state.id) == started.state.id)
+            #expect(store.live[started.state.id] != nil)
+
+            let ended = try await store.end(sessionID: try store.peekEndTarget(sessionID: nil))
+            #expect(ended.sessionID == started.state.id)
+            #expect(ended.ended == true)
+            #expect(store.live.isEmpty)
+        }
+    }
 }

--- a/Tests/WaxTests/VirtualSessionStoreTests.swift
+++ b/Tests/WaxTests/VirtualSessionStoreTests.swift
@@ -1,0 +1,325 @@
+import Foundation
+import Testing
+@testable import Wax
+
+private func withVirtualSessionStore<T>(
+    brokerInstanceID: String = UUID().uuidString,
+    sessionRootURL: URL? = nil,
+    removeRootOnExit: Bool = true,
+    _ body: (VirtualSessionStore, URL) async throws -> T
+) async throws -> T {
+    let rootURL: URL
+    let owned: Bool
+    if let sessionRootURL {
+        rootURL = sessionRootURL
+        owned = false
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    } else {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-virtual-session-\(UUID().uuidString)", isDirectory: true)
+        owned = true
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    }
+
+    let store = VirtualSessionStore(
+        sessionRootURL: rootURL,
+        brokerInstanceID: brokerInstanceID,
+        openExisting: { url in
+            var config = OrchestratorConfig.default
+            config.enableVectorSearch = false
+            config.enableStructuredMemory = false
+            return try await MemoryOrchestrator(at: url, config: config)
+        }
+    )
+    do {
+        let result = try await body(store, rootURL)
+        await store.closeAll()
+        if owned, removeRootOnExit {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+        return result
+    } catch {
+        await store.closeAll()
+        if owned, removeRootOnExit {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+        throw error
+    }
+}
+
+private func startSession(
+    _ store: VirtualSessionStore,
+    agentID: String,
+    runID: String,
+    cwd: String? = nil
+) async throws -> VirtualSessionStore.LifecycleResult {
+    let scope: MemoryScopeContext
+    if let cwd {
+        scope = MemorySemantics.inferScopeContext(currentDirectoryPath: cwd)
+    } else {
+        scope = MemorySemantics.inferScopeContext()
+    }
+    return try await store.start(
+        explicitSessionID: nil,
+        agentID: agentID,
+        runID: runID,
+        inferredScope: scope
+    )
+}
+
+private func waxFileSize(at url: URL) throws -> UInt64 {
+    let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+    let size = try #require(attrs[.size] as? NSNumber)
+    return size.uint64Value
+}
+
+struct VirtualSessionStoreTests {
+    @Test
+    func omittedSessionIDIsNoVirtualSessionEvenWhenOneIsLive() async throws {
+        try await withVirtualSessionStore { store, _ in
+            _ = try await startSession(store, agentID: "lookup-agent", runID: "lookup-run")
+            switch try store.lookup(nil) {
+            case .none:
+                break
+            case .live:
+                Issue.record("omitted session_id inferred a virtual session")
+            }
+        }
+    }
+
+    @Test
+    func unknownSessionIDFailsClosedWithoutCreatingAStore() async throws {
+        try await withVirtualSessionStore { store, root in
+            let unknown = UUID()
+            do {
+                _ = try store.lookup(unknown)
+                Issue.record("unknown session_id should fail closed")
+            } catch {
+                #expect(error.localizedDescription.contains("session_id is not active"))
+            }
+            let waxFiles = try FileManager.default.contentsOfDirectory(atPath: root.path)
+                .filter { $0.hasSuffix(".wax") }
+            #expect(waxFiles.isEmpty)
+        }
+    }
+
+    @Test
+    func startCreatesADistinctStoreNearFourMebibytes() async throws {
+        try await withVirtualSessionStore { store, root in
+            let started = try await startSession(store, agentID: "wal-agent", runID: "wal-run")
+            #expect(started.resumed == false)
+            let size = try waxFileSize(at: started.state.storeURL)
+            #expect(size >= 4 * 1024 * 1024)
+            #expect(size < 16 * 1024 * 1024)
+
+            switch try store.lookup(started.state.id) {
+            case .none:
+                Issue.record("live session_id should route to the virtual session store")
+            case .live:
+                break
+            }
+
+            let waxFiles = try FileManager.default.contentsOfDirectory(atPath: root.path)
+                .filter { $0.hasSuffix(".wax") }
+            #expect(waxFiles.count == 1)
+        }
+    }
+
+    @Test
+    func sameAgentAndRunPairReusesTheActiveStore() async throws {
+        try await withVirtualSessionStore { store, root in
+            let first = try await startSession(store, agentID: "same-agent", runID: "same-run")
+            let second = try await startSession(store, agentID: "same-agent", runID: "same-run")
+            #expect(second.state.id == first.state.id)
+            #expect(second.resumed == true)
+            #expect(second.recoveredLease == false)
+            let waxFiles = try FileManager.default.contentsOfDirectory(atPath: root.path)
+                .filter { $0.hasSuffix(".wax") }
+            #expect(waxFiles.count == 1)
+        }
+    }
+
+    @Test
+    func agentIDAloneDoesNotReuse() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let first = try await startSession(store, agentID: "solo-agent", runID: "run-a")
+            let second = try await startSession(store, agentID: "solo-agent", runID: "run-b")
+            #expect(second.state.id != first.state.id)
+            #expect(second.resumed == false)
+        }
+    }
+
+    @Test
+    func endedStoreIsNotReusedByTheSameAgentAndRunPair() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let first = try await startSession(store, agentID: "ended-agent", runID: "ended-run")
+            let ended = try await store.end(sessionID: first.state.id)
+            #expect(ended.ended == true)
+
+            do {
+                _ = try store.lookup(first.state.id)
+                Issue.record("ended session_id should fail closed")
+            } catch {
+                #expect(error.localizedDescription.contains("session_id is not active"))
+            }
+
+            let second = try await startSession(store, agentID: "ended-agent", runID: "ended-run")
+            #expect(second.state.id != first.state.id)
+            #expect(second.resumed == false)
+        }
+    }
+
+    @Test
+    func resumeStealsAForeignLeaseAndReportsRecoveredLease() async throws {
+        try await withVirtualSessionStore(brokerInstanceID: "owner-a") { firstStore, root in
+            let started = try await startSession(firstStore, agentID: "lease-agent", runID: "lease-run")
+            await firstStore.closeAll()
+
+            try await withVirtualSessionStore(
+                brokerInstanceID: "owner-b",
+                sessionRootURL: root,
+                removeRootOnExit: false
+            ) { secondStore, _ in
+                let resumed = try await secondStore.resume(
+                    explicitSessionID: started.state.id,
+                    agentID: nil,
+                    runID: nil
+                )
+                #expect(resumed.state.id == started.state.id)
+                #expect(resumed.resumed == true)
+                #expect(resumed.recoveredLease == true)
+                #expect(resumed.state.manifest.brokerLeaseOwnerID == "owner-b")
+            }
+        }
+    }
+
+    @Test
+    func startWithSameAgentAndRunOnANewProcessResumesAndStealsTheLease() async throws {
+        try await withVirtualSessionStore(brokerInstanceID: "owner-a") { firstStore, root in
+            _ = try await startSession(firstStore, agentID: "pair-agent", runID: "pair-run")
+            await firstStore.closeAll()
+
+            try await withVirtualSessionStore(
+                brokerInstanceID: "owner-b",
+                sessionRootURL: root,
+                removeRootOnExit: false
+            ) { secondStore, _ in
+                let reused = try await startSession(secondStore, agentID: "pair-agent", runID: "pair-run")
+                #expect(reused.resumed == true)
+                #expect(reused.recoveredLease == true)
+            }
+        }
+    }
+
+    @Test
+    func sessionEndWithoutIDEndsTheSoleLiveSession() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let started = try await startSession(store, agentID: "sole-agent", runID: "sole-run")
+            let ended = try await store.end(sessionID: nil)
+            #expect(ended.ended == true)
+            #expect(ended.sessionID == started.state.id)
+            #expect(ended.remainingActive == false)
+            #expect(ended.activeCount == 0)
+        }
+    }
+
+    @Test
+    func sessionEndWithoutIDIsIdleWhenNothingIsLive() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let ended = try await store.end(sessionID: nil)
+            #expect(ended.ended == false)
+            #expect(ended.sessionID == nil)
+            #expect(ended.activeCount == 0)
+        }
+    }
+
+    @Test
+    func lookupOfADiskActiveSessionNotLiveHereFailsClosed() async throws {
+        try await withVirtualSessionStore(brokerInstanceID: "owner-a") { firstStore, root in
+            let started = try await startSession(firstStore, agentID: "away-agent", runID: "away-run")
+            let sessionID = started.state.id
+            await firstStore.closeAll()
+
+            try await withVirtualSessionStore(
+                brokerInstanceID: "owner-b",
+                sessionRootURL: root,
+                removeRootOnExit: false
+            ) { secondStore, _ in
+                do {
+                    _ = try secondStore.lookup(sessionID)
+                    Issue.record("not-live-here session_id should fail closed")
+                } catch {
+                    #expect(error.localizedDescription.contains("session_id is not active"))
+                }
+                #expect(secondStore.live.isEmpty)
+            }
+        }
+    }
+
+    @Test
+    func startWithAnExistingSessionIDRequiresResume() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let started = try await startSession(store, agentID: "exists-agent", runID: "exists-run")
+            await store.closeAll()
+            do {
+                _ = try await store.start(
+                    explicitSessionID: started.state.id,
+                    agentID: "other-agent",
+                    runID: "other-run",
+                    inferredScope: MemorySemantics.inferScopeContext()
+                )
+                Issue.record("existing session_id should require session_resume")
+            } catch {
+                #expect(error.localizedDescription.contains("use session_resume"))
+            }
+        }
+    }
+
+    @Test
+    func resumeOfAnEndedSessionFailsClosed() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let started = try await startSession(store, agentID: "ended-resume-agent", runID: "ended-resume-run")
+            _ = try await store.end(sessionID: started.state.id)
+            do {
+                _ = try await store.resume(
+                    explicitSessionID: started.state.id,
+                    agentID: nil,
+                    runID: nil
+                )
+                Issue.record("ended session_id should not resume")
+            } catch {
+                #expect(error.localizedDescription.contains("already been ended"))
+            }
+        }
+    }
+
+    @Test
+    func endOfASessionThatIsNotLiveHereFailsClosed() async throws {
+        try await withVirtualSessionStore { store, _ in
+            do {
+                _ = try await store.end(sessionID: UUID())
+                Issue.record("unknown session_id should not end")
+            } catch {
+                #expect(error.localizedDescription.contains("session_id is not active"))
+            }
+        }
+    }
+
+    @Test
+    func sessionEndWithoutIDRequiresAnIDWhenMoreThanOneIsLive() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let first = try await startSession(store, agentID: "multi-a", runID: "run-a")
+            _ = try await startSession(store, agentID: "multi-b", runID: "run-b")
+            do {
+                _ = try await store.end(sessionID: nil)
+                Issue.record("session_end without session_id should fail when two sessions are live")
+            } catch {
+                #expect(error.localizedDescription.contains("session_id is required when more than one"))
+            }
+            let ended = try await store.end(sessionID: first.state.id)
+            #expect(ended.ended == true)
+            #expect(ended.remainingActive == true)
+            #expect(ended.activeCount == 1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts virtual session lifecycle out of `AgentBrokerService` into a package-only `VirtualSessionStore`.

- Session start/resume/end, `agent_id`+`run_id` reuse, lease steal (`recovered_lease`), and 4 MiB session WAL create live in the new module.
- Lookup never infers or mints: omitted `session_id` is long-term Memory; unknown or not-live-here fails closed.
- Deletes `CompatSessionRegistry`. MCP/CLI stay adapters over `AgentBrokerService.handle`. No new MCP tool and no public Swift type.
- `CONTEXT.md` records the virtual session store / long-term Memory language.

## Test plan

- [x] `swift test --filter VirtualSessionStoreTests` (15 passed)
- [x] `swift test --traits MCPServer --filter BrokerSessionModelRegressionTests` (38 passed)
- [x] `swift test --filter 'WaxPublicDocsTests|DocsPasteHarnessTests|PackageTraitManifestTests|VirtualSessionStoreTests'` (33 passed)
- [ ] Full `wax-mcp` process suite (stdio/HTTP) not re-run