### PR TITLE
refactor(search): plan MATCH in UnifiedSearch ranking

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,3 +7,15 @@ On-device memory for agents and apps: persist text (and experimental photo/video
 **RetrievalMode**:
 How a query is retrieved from Memory: text-only, vector-only, or hybrid. Hybrid may fall back to text; vector-only must not.
 _Avoid_: EmbeddingPolicy, QueryEmbeddingPolicy, DirectSearchMode, SearchMode (as the name hosts use)
+
+**Ranking**:
+Plans the text-lane query (AND first, then OR fallback) and orders hits. Owns the published score.
+_Avoid_: treating the text engine as the planner; calling AND/OR planning retrieval
+
+**Match execute**:
+The text-lane execute: run a planned MATCH string and return BM25 hits. Does not re-plan AND/OR.
+_Avoid_: query planning in the text engine; calling this RetrievalMode
+
+**Recall assembly**:
+Builds RAGContext from already-ranked hits (token budget, expansion, surrogates). May apply a later answer-focused rerank. Not Ranking.
+_Avoid_: treating Memory.search as Ranking’s test surface

--- a/Sources/Wax/UnifiedSearch/HybridSearch.swift
+++ b/Sources/Wax/UnifiedSearch/HybridSearch.swift
@@ -1,47 +1,5 @@
-/// Hybrid search fusion algorithms.
+/// Hybrid search fusion helpers used by UnifiedSearch ranking.
 package enum HybridSearch {
-    /// Reciprocal Rank Fusion (RRF) to combine ranked lists.
-    ///
-    /// Notes (v1):
-    /// - RRF is rank-based (it ignores the raw score scales from BM25 vs vector distance).
-    /// - Two-list `rrfFusion` then maps those ranks onto `0...1` without changing order.
-    /// - Exclusive-text floor is off unless the caller passes `applyFloor: true` (factual path).
-    /// - OR-fallback-only text rank-1 is never floored, even on the factual path.
-    /// - Provide deterministic tie-break rules so outputs are stable.
-    package static func rrfFusion(
-        textResults: [(UInt64, Float)],
-        vectorResults: [(UInt64, Float)],
-        k: Int = 60,
-        alpha: Float = 0.5,
-        applyFloor: Bool = false,
-        textRank1IsORFallbackOnly: Bool = false
-    ) -> [(UInt64, Float)] {
-        let clampedAlpha = min(1, max(0, alpha))
-        let textWeight = textResults.isEmpty ? 0 : clampedAlpha
-        let vectorWeight = vectorResults.isEmpty ? 0 : (1 - clampedAlpha)
-        var merged = rrfFusion(
-            lists: [
-                (weight: textWeight, frameIds: textResults.map(\.0)),
-                (weight: vectorWeight, frameIds: vectorResults.map(\.0)),
-            ],
-            k: k
-        )
-        applyExclusiveTextRank1Floor(
-            merged: &merged,
-            textFrameIds: textResults.map(\.0),
-            vectorFrameIds: vectorResults.map(\.0),
-            applyFloor: applyFloor,
-            textRank1IsORFallbackOnly: textRank1IsORFallbackOnly
-        )
-        // Publish 0–1 scores that preserve RRF (+ floor) order so callers can threshold.
-        publishNormalizedRRFScores(
-            &merged,
-            k: k,
-            totalWeight: textWeight + vectorWeight
-        )
-        return merged
-    }
-
     /// Maps raw RRF (`weight / (k + rank)`) onto `0...1` without changing order.
     /// `totalWeight` is the sum of lane weights that contributed to fusion.
     package static func publishNormalizedRRFScores(
@@ -98,34 +56,6 @@ package enum HybridSearch {
               textIndex > vectorIndex
         else { return nil }
         return (textIndex, vectorIndex)
-    }
-
-    /// Multi-list weighted RRF (e.g., text + vector + timeline).
-    package static func rrfFusion(
-        lists: [(weight: Float, frameIds: [UInt64])],
-        k: Int = 60
-    ) -> [(UInt64, Float)] {
-        let kConstant = max(0, k)
-        var scores: [UInt64: Float] = [:]
-        var bestRank: [UInt64: Int] = [:]
-
-        for list in lists {
-            guard list.weight > 0 else { continue }
-            for (rank, frameId) in list.frameIds.enumerated() {
-                let rrfScore = list.weight / Float(kConstant + rank + 1)
-                scores[frameId, default: 0] += rrfScore
-                bestRank[frameId] = min(bestRank[frameId] ?? Int.max, rank + 1)
-            }
-        }
-
-        return scores.map { (frameId: $0.key, score: $0.value) }
-            .sorted { a, b in
-                if a.score != b.score { return a.score > b.score }
-                let ra = bestRank[a.frameId] ?? Int.max
-                let rb = bestRank[b.frameId] ?? Int.max
-                if ra != rb { return ra < rb }
-                return a.frameId < b.frameId
-            }
     }
 }
 

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -137,11 +137,7 @@ extension Wax {
             }
 
             do {
-                let base = if primaryQuery == trimmedQuery {
-                    try await textEngine.search(query: primaryQuery, topK: candidateLimit)
-                } else {
-                    try await textEngine.search(matchQuery: primaryQuery, topK: candidateLimit)
-                }
+                let base = try await textEngine.search(matchQuery: primaryQuery, topK: candidateLimit)
                 guard let fallbackQuery, fallbackQuery != primaryQuery else {
                     return (Array(base.prefix(candidateLimit)), false)
                 }
@@ -887,7 +883,6 @@ extension Wax {
     }
 
     private static func primaryFTSQuery(from query: String, maxTokens: Int = 16) -> String? {
-        guard requiresSafeFTSNormalization(query) else { return query }
         let tokens = normalizedFTSTokens(from: query, maxTokens: maxTokens)
         let quotedTokens = tokens.map { token -> String in
             let escaped = token.replacingOccurrences(of: "\"", with: "\"\"")
@@ -1311,12 +1306,6 @@ extension Wax {
 
     private static func termContainsDigits(_ text: String) -> Bool {
         text.unicodeScalars.contains { CharacterSet.decimalDigits.contains($0) }
-    }
-
-    private static func requiresSafeFTSNormalization(_ query: String) -> Bool {
-        query.unicodeScalars.contains { scalar in
-            scalar.isASCII && asciiPunctuationScalars.contains(scalar)
-        }
     }
 
     private static let ftsStopWords: Set<String> = [

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -105,7 +105,11 @@ extension Wax {
             guard includeText, let textEngine, let trimmedQuery, !trimmedQuery.isEmpty else {
                 return ([], false)
             }
-            let primaryQuery = Self.primaryFTSQuery(from: trimmedQuery) ?? trimmedQuery
+            // Empty MATCH plans (stopwords / operators only) must not fall back to
+            // the raw user string — FTS5 would interpret AND/OR/NOT/NEAR as syntax.
+            guard let primaryQuery = Self.primaryFTSQuery(from: trimmedQuery) else {
+                return ([], false)
+            }
             let fallbackQuery = Self.orExpandedQuery(from: trimmedQuery)
             let queryTokenCount = Self.normalizedFTSTokens(from: trimmedQuery, maxTokens: 16).count
 
@@ -867,9 +871,24 @@ extension Wax {
         return results.map { scoredAsORFallbackOnly($0, tokenCount: tokenCount) }
     }
 
-    private static func orExpandedQuery(from query: String, maxTokens: Int = 16) -> String? {
-        let tokens = normalizedFTSTokens(from: query, maxTokens: maxTokens)
-        let quotedTokens = tokens.map { token -> String in
+    private enum FTSMatchJoin {
+        case andLike
+        case or
+
+        var separator: String {
+            switch self {
+            case .andLike: " "
+            case .or: " OR "
+            }
+        }
+    }
+
+    private static func plannedFTSQuery(
+        from query: String,
+        join: FTSMatchJoin,
+        maxTokens: Int = 16
+    ) -> String? {
+        let quotedTokens = normalizedFTSTokens(from: query, maxTokens: maxTokens).map { token -> String in
             let escaped = token.replacingOccurrences(of: "\"", with: "\"\"")
             return "\"\(escaped)\""
         }
@@ -879,23 +898,15 @@ extension Wax {
         }
         let clauses = quotedPhrases + quotedTokens
         guard !clauses.isEmpty else { return nil }
-        return clauses.joined(separator: " OR ")
+        return clauses.joined(separator: join.separator)
+    }
+
+    private static func orExpandedQuery(from query: String, maxTokens: Int = 16) -> String? {
+        plannedFTSQuery(from: query, join: .or, maxTokens: maxTokens)
     }
 
     private static func primaryFTSQuery(from query: String, maxTokens: Int = 16) -> String? {
-        let tokens = normalizedFTSTokens(from: query, maxTokens: maxTokens)
-        let quotedTokens = tokens.map { token -> String in
-            let escaped = token.replacingOccurrences(of: "\"", with: "\"\"")
-            return "\"\(escaped)\""
-        }
-        let quotedPhrases = normalizedQuotedPhrases(from: query).map { phrase -> String in
-            let escaped = phrase.replacingOccurrences(of: "\"", with: "\"\"")
-            return "\"\(escaped)\""
-        }
-        let clauses = quotedPhrases + quotedTokens
-        guard !clauses.isEmpty else { return nil }
-        // Use AND-like semantics for the first pass; fallback can broaden with OR.
-        return clauses.joined(separator: " ")
+        plannedFTSQuery(from: query, join: .andLike, maxTokens: maxTokens)
     }
 
     private struct RRFFusedCandidate {
@@ -1312,6 +1323,8 @@ extension Wax {
         "a", "an", "and", "are", "at", "did", "do", "for", "from", "in", "is", "of",
         "on", "or", "the", "to", "what", "when", "where", "which", "who", "with",
         "date",
+        // Bare FTS5 operators must not become MATCH terms (or leftover syntax).
+        "not", "near",
     ]
 
     private static func normalizedFTSTokens(from query: String, maxTokens: Int) -> [String] {

--- a/Tests/WaxIntegrationTests/DeterminismPropertyTests.swift
+++ b/Tests/WaxIntegrationTests/DeterminismPropertyTests.swift
@@ -4,41 +4,6 @@ import Wax
 import WaxCore
 
 @Test
-func rrfFusionIsIdempotentForSameInputs() {
-    let lists: [(weight: Float, frameIds: [UInt64])] = [
-        (weight: 1.0, frameIds: [1, 2, 3, 4, 5]),
-        (weight: 0.5, frameIds: [3, 4, 5, 6, 7]),
-        (weight: 0.2, frameIds: [5, 2, 8]),
-    ]
-
-    let resultA = HybridSearch.rrfFusion(lists: lists, k: 60)
-    let resultB = HybridSearch.rrfFusion(lists: lists, k: 60)
-
-    let idsA = resultA.map { $0.0 }
-    let idsB = resultB.map { $0.0 }
-    #expect(idsA == idsB)
-
-    let scoresA = resultA.map { $0.1 }
-    let scoresB = resultB.map { $0.1 }
-    #expect(scoresA.count == scoresB.count)
-    for (lhs, rhs) in zip(scoresA, scoresB) {
-        #expect(abs(lhs - rhs) < 1e-9)
-    }
-}
-
-@Test
-func rrfFusionIsOrderIndependentForListPermutation() {
-    let listA: (weight: Float, frameIds: [UInt64]) = (weight: 1.0, frameIds: [1, 2, 3, 4])
-    let listB: (weight: Float, frameIds: [UInt64]) = (weight: 0.5, frameIds: [3, 4, 5])
-    let listC: (weight: Float, frameIds: [UInt64]) = (weight: 0.25, frameIds: [2, 6])
-
-    let abc = HybridSearch.rrfFusion(lists: [listA, listB, listC], k: 60)
-    let cba = HybridSearch.rrfFusion(lists: [listC, listB, listA], k: 60)
-
-    #expect(Set(abc.map(\.0)) == Set(cba.map(\.0)))
-}
-
-@Test
 func tokenCountIsSubadditiveWithinSmallConstant() async throws {
     let counter = try await TokenCounter.shared()
     let first = "Hello world from Swift."

--- a/Tests/WaxIntegrationTests/HybridSearchTests.swift
+++ b/Tests/WaxIntegrationTests/HybridSearchTests.swift
@@ -2,118 +2,6 @@ import Foundation
 import Testing
 import Wax
 
-@Test func rrfWithDisjointResults() {
-    let textResults: [(UInt64, Float)] = [(0, 0.9), (1, 0.8), (2, 0.7)]
-    let vectorResults: [(UInt64, Float)] = [(3, 0.95), (4, 0.85), (5, 0.75)]
-
-    let merged = HybridSearch.rrfFusion(
-        textResults: textResults,
-        vectorResults: vectorResults,
-        k: 60,
-        alpha: 0.5
-    )
-
-    #expect(merged.count == 6)
-    let frameIds = Set(merged.map { $0.0 })
-    #expect(frameIds == Set([0, 1, 2, 3, 4, 5]))
-}
-
-@Test func rrfWithOverlappingResults() {
-    let textResults: [(UInt64, Float)] = [(0, 0.9), (1, 0.8)]
-    let vectorResults: [(UInt64, Float)] = [(1, 0.95), (2, 0.85)]
-
-    let merged = HybridSearch.rrfFusion(
-        textResults: textResults,
-        vectorResults: vectorResults,
-        k: 60,
-        alpha: 0.5
-    )
-
-    #expect(merged.count == 3)
-    #expect(merged[0].0 == 1)
-}
-
-@Test func rrfAlphaWeighting() {
-    let textResults: [(UInt64, Float)] = [(0, 0.9)]
-    let vectorResults: [(UInt64, Float)] = [(1, 0.95)]
-
-    let textOnly = HybridSearch.rrfFusion(
-        textResults: textResults,
-        vectorResults: vectorResults,
-        k: 60,
-        alpha: 1.0
-    )
-    #expect(textOnly[0].0 == 0)
-
-    let vectorOnly = HybridSearch.rrfFusion(
-        textResults: textResults,
-        vectorResults: vectorResults,
-        k: 60,
-        alpha: 0.0
-    )
-    #expect(vectorOnly[0].0 == 1)
-}
-
-@Test func rrfWithEmptyTextResults() {
-    let textResults: [(UInt64, Float)] = []
-    let vectorResults: [(UInt64, Float)] = [(0, 0.9), (1, 0.8)]
-
-    let merged = HybridSearch.rrfFusion(
-        textResults: textResults,
-        vectorResults: vectorResults,
-        k: 60,
-        alpha: 0.5
-    )
-
-    #expect(merged.count == 2)
-}
-
-@Test func rrfWithEmptyVectorResults() {
-    let textResults: [(UInt64, Float)] = [(0, 0.9), (1, 0.8)]
-    let vectorResults: [(UInt64, Float)] = []
-
-    let merged = HybridSearch.rrfFusion(
-        textResults: textResults,
-        vectorResults: vectorResults,
-        k: 60,
-        alpha: 0.5
-    )
-
-    #expect(merged.count == 2)
-}
-
-@Test func rrfExclusiveTextRank1BeatsExclusiveVectorNeighborAtDefaultAlpha() {
-    // Vector neighbor gets a lower frame id so the old frame-id tie-break would
-    // bury the exclusive lexical canary when RRF scores are equal or vector-leaning.
-    let textCanary: UInt64 = 1706
-    let vectorNeighbor: UInt64 = 1
-    let merged = HybridSearch.rrfFusion(
-        textResults: [(textCanary, 0.9)],
-        vectorResults: [(vectorNeighbor, 0.95)],
-        k: 60,
-        alpha: 0.5,
-        applyFloor: true
-    )
-
-    #expect(merged.first?.0 == textCanary)
-}
-
-@Test func rrfSemanticExclusiveVectorRank1StaysAheadOfExclusiveTextAtDefaultAlpha() {
-    // Semantic path must not run the exclusive-text floor. Equal-weight RRF at
-    // alpha 0.5 then keeps the lower-id exclusive vector neighbor ahead.
-    let textCanary: UInt64 = 1706
-    let vectorNeighbor: UInt64 = 1
-    let merged = HybridSearch.rrfFusion(
-        textResults: [(textCanary, 0.9)],
-        vectorResults: [(vectorNeighbor, 0.95)],
-        k: 60,
-        alpha: 0.5,
-        applyFloor: false
-    )
-
-    #expect(merged.first?.0 == vectorNeighbor)
-}
-
 @Test func rrfFactualExclusiveListsPromoteTextRank1() {
     // Exclusive lists: text top absent from vector, vector top absent from text.
     var merged: [(UInt64, Float)] = [(1, 0.02), (1706, 0.019), (2, 0.01)]
@@ -149,27 +37,17 @@ import Wax
     #expect(merged.map(\.0) == [1, 1706])
 }
 
-@Test func rrfPublishedScoresDescendAndAreThresholdable() {
-    let textCanary: UInt64 = 1706
-    let vectorNeighbor: UInt64 = 1
-    let merged = HybridSearch.rrfFusion(
-        textResults: [(textCanary, 0.9), (2, 0.4)],
-        vectorResults: [(vectorNeighbor, 0.95), (3, 0.8)],
-        k: 60,
-        alpha: 0.5,
-        applyFloor: true
-    )
-
-    #expect(merged.first?.0 == textCanary)
-    #expect(merged.count == 4)
-    for (previous, next) in zip(merged, merged.dropFirst()) {
-        #expect(previous.1 >= next.1)
-    }
-    // Independent of raw RRF (≈ weight/(k+1) ≈ 0.008): rank-1 must be
-    // usable as a 0–1 threshold the way text scores already are.
-    #expect(merged[0].1 >= 0.5)
-    #expect(merged[0].1 <= 1.0)
-    #expect(merged.allSatisfy { (0...1).contains($0.1) })
+@Test func publishedRRFScoresStayInUnitIntervalAndKeepOrder() {
+    var ranked: [(UInt64, Float)] = [
+        (1706, 1.0 / 61.0),
+        (1, 0.5 / 61.0),
+        (2, 0.25 / 61.0),
+    ]
+    HybridSearch.publishNormalizedRRFScores(&ranked, k: 60, totalWeight: 1)
+    #expect(ranked.map(\.0) == [1706, 1, 2])
+    #expect(ranked[0].1 == 1.0)
+    #expect(abs(ranked[1].1 - 0.5) < 1e-6)
+    #expect(abs(ranked[2].1 - 0.25) < 1e-6)
 }
 
 @Test func hybridSearchRanksUniqueLexicalCanaryAboveVectorNeighbors() async throws {
@@ -195,6 +73,10 @@ import Wax
             top.previewText?.contains("7f3a91") == true,
             "hybrid rank-1 was \(top.previewText ?? "<nil>")"
         )
+        #expect(top.sources.contains(.text))
+        for (previous, next) in zip(hits, hits.dropFirst()) {
+            #expect(previous.score >= next.score)
+        }
 
         try await orchestrator.close()
     }
@@ -218,4 +100,3 @@ private struct CanaryConfusionEmbedder: EmbeddingProvider {
         return VectorMath.normalizeL2([1, 0])
     }
 }
-

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -1433,3 +1433,137 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await wax.close()
     }
 }
+
+/// Unpunctuated `OR` is a Ranking token, not an FTS boolean. AND of both
+/// terms misses disjoint frames; OR fallback then publishes a 1-of-2 score.
+@Test func unpunctuatedBooleanWordsAreLiteralsNotFTSOperators() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let text = try await wax.enableTextSearch()
+
+        let catsOnly = try await wax.put(Data("only cats live here".utf8))
+        try await text.index(frameId: catsOnly, text: "only cats live here")
+        let dogsOnly = try await wax.put(Data("only dogs live here".utf8))
+        try await text.index(frameId: dogsOnly, text: "only dogs live here")
+        try await text.commit()
+
+        let response = try await wax.search(
+            SearchRequest(query: "cats OR dogs", mode: .textOnly, topK: 10)
+        )
+        let catsHit = try #require(response.results.first { $0.frameId == catsOnly })
+        let dogsHit = try #require(response.results.first { $0.frameId == dogsOnly })
+        #expect(catsHit.score <= 0.5)
+        #expect(dogsHit.score <= 0.5)
+
+        try await wax.close()
+    }
+}
+
+/// Temporal hybrid ranking publishes fused hits from text, vector, timeline,
+/// and structured lanes on the live `wax.search` path.
+@Test func hybridSearchFusesTextVectorTimelineAndStructuredLanes() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        var config = WaxSession.Config()
+        config.enableVectorSearch = false
+        let session = try await wax.openSession(.readWrite(.fail), config: config)
+
+        let timelineOnly = try await session.put(
+            Data("unrelated old filler note".utf8),
+            options: FrameMetaSubset(searchText: "unrelated old filler note"),
+            timestampMs: 1_000
+        )
+        try await session.indexText(frameId: timelineOnly, text: "unrelated old filler note")
+
+        let evidence = try await session.put(
+            Data("Structured evidence payload without the alias.".utf8),
+            options: FrameMetaSubset(searchText: "Structured evidence payload"),
+            timestampMs: 2_000
+        )
+        try await session.indexText(frameId: evidence, text: "Structured evidence payload")
+
+        let vectorOnly = try await session.put(
+            Data("unrelated vector neighbor filler".utf8),
+            options: FrameMetaSubset(searchText: "unrelated vector neighbor filler"),
+            timestampMs: 3_000
+        )
+        try await session.indexText(frameId: vectorOnly, text: "unrelated vector neighbor filler")
+
+        let textHit = try await session.put(
+            Data("F027Alice last seen at the dock".utf8),
+            options: FrameMetaSubset(searchText: "F027Alice last seen at the dock"),
+            timestampMs: 4_000
+        )
+        try await session.indexText(frameId: textHit, text: "F027Alice last seen at the dock")
+
+        _ = try await session.upsertEntity(
+            key: EntityKey("person:f027-alice"),
+            kind: "person",
+            aliases: ["F027Alice"],
+            nowMs: 5_000
+        )
+        _ = try await session.assertFact(
+            subject: EntityKey("person:f027-alice"),
+            predicate: PredicateKey("status"),
+            object: .string("active"),
+            valid: StructuredTimeRange(fromMs: 0),
+            system: StructuredTimeRange(fromMs: 5_000),
+            evidence: [
+                StructuredEvidence(
+                    sourceFrameId: evidence,
+                    extractorId: "test",
+                    extractorVersion: "1",
+                    confidence: 1,
+                    assertedAtMs: 5_000
+                ),
+            ]
+        )
+        try await session.commit()
+
+        let response = try await wax.search(
+            SearchRequest(
+                query: "when was F027Alice last seen",
+                embedding: [1.0, 0.0, 0.0, 0.0],
+                vectorEnginePreference: .cpuOnly,
+                mode: .hybrid(alpha: 0.5),
+                topK: 10,
+                enableRankingDiagnostics: true,
+                rankingDiagnosticsTopK: 10
+            ),
+            engineOverrides: UnifiedSearchEngineOverrides(
+                textEngine: nil,
+                vectorEngine: DeterministicVectorResultsEngine(
+                    dimensions: 4,
+                    results: [(frameId: vectorOnly, score: 0.99)]
+                ),
+                structuredEngine: nil
+            )
+        )
+
+        let byID = Dictionary(uniqueKeysWithValues: response.results.map { ($0.frameId, $0) })
+        let textResult = try #require(byID[textHit])
+        let vectorResult = try #require(byID[vectorOnly])
+        let evidenceResult = try #require(byID[evidence])
+        let timelineResult = try #require(byID[timelineOnly])
+        #expect(textResult.sources.contains(.text))
+        #expect(vectorResult.sources.contains(.vector))
+        #expect(evidenceResult.sources.contains(.structuredMemory))
+        #expect(timelineResult.sources.contains(.timeline))
+        #expect(timelineResult.sources.contains(.text) == false)
+
+        let laneSources = Set(
+            response.results.compactMap(\.rankingDiagnostics).flatMap(\.laneContributions).map(\.source)
+        )
+        #expect(laneSources.contains(.text))
+        #expect(laneSources.contains(.vector))
+        #expect(laneSources.contains(.timeline))
+        #expect(laneSources.contains(.structuredMemory))
+
+        for (previous, next) in zip(response.results, response.results.dropFirst()) {
+            #expect(previous.score >= next.score)
+        }
+
+        await session.close()
+        try await wax.close()
+    }
+}

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -1459,8 +1459,29 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
     }
 }
 
-/// Temporal hybrid ranking publishes fused hits from text, vector, timeline,
-/// and structured lanes on the live `wax.search` path.
+@Test func textOnlySearchSkipsMatchWhenPlanIsEmpty() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let text = try await wax.enableTextSearch()
+
+        let indexed = try await wax.put(Data("the and or not near filler".utf8))
+        try await text.index(frameId: indexed, text: "the and or not near filler")
+        try await text.commit()
+
+        let stopwordOnly = try await wax.search(
+            SearchRequest(query: "the and or", mode: .textOnly, topK: 10)
+        )
+        #expect(stopwordOnly.results.isEmpty)
+
+        let operatorOnly = try await wax.search(
+            SearchRequest(query: "NOT NEAR", mode: .textOnly, topK: 10)
+        )
+        #expect(operatorOnly.results.isEmpty)
+
+        try await wax.close()
+    }
+}
+
 @Test func hybridSearchFusesTextVectorTimelineAndStructuredLanes() async throws {
     try await TempFiles.withTempFile { url in
         let wax = try await Wax.create(at: url)


### PR DESCRIPTION
## Summary

Ranking now owns the text-lane MATCH plan. UnifiedSearch always emits a quoted AND query, then OR fallback, and only calls `FTS5.search(matchQuery:)`. Unpunctuated `OR` / `AND` / `NOT` are literals, not FTS operators.

Live fusion stays `UnifiedSearch.rrfFusionResults`. Unused `HybridSearch.rrfFusion` overloads and helper-only tests are gone. Exclusive-text floor and 0–1 score publish stay as Ranking internals.

`CONTEXT.md` names Ranking, Match execute, and Recall assembly so those seams stay distinct.

Out of this PR: `TextSearchSession` / leftover `search(query:)`, FastRAG answer rerank, Broker horizon boosts, `SearchMode` collapse, identifier `+5` / `minScore` retune.

## Test plan

- [x] `swift test --filter HybridSearchTests` (5)
- [x] `swift test --filter UnifiedSearchTests` (37)
- [x] `swift test --filter DeterminismPropertyTests` (2)
- [x] Live four-lane fusion: `hybridSearchFusesTextVectorTimelineAndStructuredLanes`
- [x] Unpunctuated `OR` is fallback-scaled: `unpunctuatedBooleanWordsAreLiteralsNotFTSOperators`
- [x] Existing exclusive-text canary still ranks `7f3a91` first