### PR TITLE
fix: crash-inject gate, MCP isolation, and Memory.search overloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ Package.resolved
 .qwen/
 .skynex/production-gate.json
 .skynex/audit.log
+Resources/npm/waxmcp/dist/
+.grok/

--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -14,7 +14,8 @@ Source: `Sources/Wax/Memory.swift`
 - `public func save<each S: StringProtocol>(_ texts: repeat each S) async throws`
 - `public func search(_ query: String, options: Memory.SearchOptions = .default) async throws -> Memory.Results`
 - `public func search(_ query: String, configure: (inout Memory.SearchOptions) -> Void) async throws -> Memory.Results`
-- `public func search(_:strategy:options:)` / `search(_:strategy:options:reranker:)` with `SearchStrategy` / `ResultReranker`
+- `public func search(_ query: String, strategy: (any SearchStrategy)?, reranker: (any ResultReranker)? = nil, options: Memory.SearchOptions = .default) async throws -> Memory.Results`
+- Deprecated aliases: `search(_:strategy:options:)` and `search(_:strategy:options:reranker:)` (generic shims; use the existential form)
 - `public func delete(frameID: UInt64) async throws` — soft-deletes the frame and removes it from enabled text and vector indexes (committed).
 - `public func flush() async throws` — commits pending writes (WAL, FTS, vector index) to durable storage.
 - `public func close() async throws` — flushes, then closes.
@@ -119,6 +120,12 @@ try await photos.close()
 ```
 
 Video does not transcribe and does not store media bytes. The host supplies transcripts.
+
+## Migration
+
+- `OrchestratorConfig.useMetalVectorSearch` is a deprecated `package` shim. Use `vectorEnginePreference` (`true` → `.auto`, `false` → `.cpuOnly`).
+- Hybrid search may run as text-only; compare `RAGContext.diagnostics.requestedMode` with `effectiveMode` (and `queryEmbeddingState`).
+- `Memory.search(_:strategy:options:)` and `Memory.search(_:strategy:options:reranker:)` are deprecated shims. Use `search(_:strategy:reranker:options:)` with `any SearchStrategy` / `any ResultReranker`.
 
 ## Package-only (NOT public API)
 

--- a/Sources/Wax/Memory+Deprecated.swift
+++ b/Sources/Wax/Memory+Deprecated.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension Memory {
+    @available(*, deprecated, message: "Use search(_:strategy:reranker:options:)")
+    @_disfavoredOverload
+    public func search<S: SearchStrategy>(
+        _ query: String,
+        strategy: S,
+        options: SearchOptions = .default
+    ) async throws -> Results {
+        try await search(query, strategy: strategy as any SearchStrategy, options: options)
+    }
+
+    @available(*, deprecated, message: "Use search(_:strategy:reranker:options:)")
+    @_disfavoredOverload
+    public func search<S: SearchStrategy, R: ResultReranker>(
+        _ query: String,
+        strategy: S,
+        options: SearchOptions = .default,
+        reranker: R
+    ) async throws -> Results {
+        try await search(
+            query,
+            strategy: strategy as any SearchStrategy,
+            reranker: reranker as any ResultReranker,
+            options: options
+        )
+    }
+}

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -176,23 +176,20 @@ public actor Memory {
         return try await search(query, options: options)
     }
 
-    public func search<S: SearchStrategy>(
+    /// Search with an optional strategy and reranker.
+    ///
+    /// `strategy` is required at the call site (pass `nil` to skip) so this overload
+    /// does not collide with ``search(_:options:)``.
+    public func search(
         _ query: String,
-        strategy: S,
+        strategy: (any SearchStrategy)?,
+        reranker: (any ResultReranker)? = nil,
         options: SearchOptions = .default
     ) async throws -> Results {
         var resolved = options
-        strategy.configure(&resolved)
-        return try await search(query, options: resolved)
-    }
-
-    public func search<S: SearchStrategy, R: ResultReranker>(
-        _ query: String,
-        strategy: S,
-        options: SearchOptions = .default,
-        reranker: R
-    ) async throws -> Results {
-        let results = try await search(query, strategy: strategy, options: options)
+        strategy?.configure(&resolved)
+        let results = try await search(query, options: resolved)
+        guard let reranker else { return results }
         return try await reranker.rerank(query: query, results: results)
     }
 

--- a/Sources/WaxCore/Wax.swift
+++ b/Sources/WaxCore/Wax.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if DEBUG
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -22,6 +23,7 @@ private func posixKill(_ pid: Int32, _ signal: Int32) -> Int32 {
     Glibc.kill(pid, signal)
     #endif
 }
+#endif
 
 package struct WaxStats: Equatable, Sendable {
     package var frameCount: UInt64
@@ -1821,17 +1823,23 @@ package actor Wax {
         try await io.run {
             try file.writeAll(tocBytes, at: tocOffset)
         }
+        #if DEBUG
         Self.maybeCrashAfterCheckpoint(.afterTocWriteBeforeFooter)
+        #endif
 
         try await io.run {
             try file.writeAll(try footer.encode(), at: footerOffset)
         }
+        #if DEBUG
         Self.maybeCrashAfterCheckpoint(.afterFooterWriteBeforeFsync)
+        #endif
 
         try await io.run {
             try file.fsync()
         }
+        #if DEBUG
         Self.maybeCrashAfterCheckpoint(.afterFooterFsyncBeforeHeader)
+        #endif
 
         header.footerOffset = footerOffset
         header.fileGeneration = footer.generation
@@ -1843,7 +1851,9 @@ package actor Wax {
         header.headerPageGeneration &+= 1
 
         try await writeHeaderPage(header)
+        #if DEBUG
         Self.maybeCrashAfterCheckpoint(.afterHeaderWriteBeforeFinalFsync)
+        #endif
         try await io.run {
             try file.fsync()
             wal.recordCheckpoint()
@@ -3005,6 +3015,7 @@ package actor Wax {
 
     // MARK: - Internal helpers
 
+#if DEBUG
     private static func maybeCrashAfterCheckpoint(_ checkpoint: CrashInjectionCheckpoint) {
         let env = ProcessInfo.processInfo.environment
         guard env[CrashInjectionCheckpoint.envKey] == checkpoint.rawValue else { return }
@@ -3015,6 +3026,12 @@ package actor Wax {
         _ = posixKill(posixGetPID(), SIGKILL)
         fatalError("crash injection did not terminate process at \(checkpoint.rawValue)")
     }
+#else
+    @inline(__always)
+    private static func maybeCrashAfterCheckpoint(_ checkpoint: CrashInjectionCheckpoint) {
+        _ = checkpoint
+    }
+#endif
 
     private func persistReplaySnapshotOnSelectedHeaderPage(_ snapshot: WaxHeaderPage.WALReplaySnapshot) async throws {
         var snapshotPage = header

--- a/Sources/WaxMCPServer/HTTPApp.swift
+++ b/Sources/WaxMCPServer/HTTPApp.swift
@@ -312,9 +312,20 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private var requestState: RequestState?
+    private var channelContext: ChannelHandlerContext?
 
     init(app: MCPHTTPApplication) {
         self.app = app
+    }
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        channelContext = context
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        if channelContext === context {
+            channelContext = nil
+        }
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -353,9 +364,18 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         case .end:
             guard let state = requestState else { return }
             requestState = nil
-            nonisolated(unsafe) let ctx = context
-            Task { @MainActor in
-                await self.handleRequest(state: state, context: ctx)
+            let version = state.head.version
+            let path = state.head.uri.split(separator: "?").first.map(String.init) ?? state.head.uri
+            let exceededBodyLimit = state.exceededBodyLimit
+            let request = makeHTTPRequest(from: state)
+            let eventLoop = context.eventLoop
+            Task {
+                let response = await self.completeRequest(
+                    path: path,
+                    exceededBodyLimit: exceededBodyLimit,
+                    request: request
+                )
+                await self.writeResponse(response, version: version, eventLoop: eventLoop)
             }
         }
     }
@@ -375,24 +395,22 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
     }
 
-    private func handleRequest(state: RequestState, context: ChannelHandlerContext) async {
-        let head = state.head
-        let path = head.uri.split(separator: "?").first.map(String.init) ?? head.uri
+    private func completeRequest(
+        path: String,
+        exceededBodyLimit: Bool,
+        request: HTTPRequest
+    ) async -> HTTPResponse {
         let endpoint = await app.endpoint
 
-        guard !state.exceededBodyLimit else {
-            await writeResponse(.error(statusCode: 413, .invalidRequest("Payload Too Large")), version: head.version, context: context)
-            return
+        if exceededBodyLimit {
+            return .error(statusCode: 413, .invalidRequest("Payload Too Large"))
         }
 
         guard path == endpoint else {
-            await writeResponse(.error(statusCode: 404, .invalidRequest("Not Found")), version: head.version, context: context)
-            return
+            return .error(statusCode: 404, .invalidRequest("Not Found"))
         }
 
-        let request = makeHTTPRequest(from: state)
-        let response = await app.handleHTTPRequest(request)
-        await writeResponse(response, version: head.version, context: context)
+        return await app.handleHTTPRequest(request)
     }
 
     private func makeHTTPRequest(from state: RequestState) -> HTTPRequest {
@@ -420,56 +438,93 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     private func writeResponse(
         _ response: HTTPResponse,
         version: HTTPVersion,
-        context: ChannelHandlerContext
+        eventLoop: EventLoop
     ) async {
-        nonisolated(unsafe) let ctx = context
-        let eventLoop = ctx.eventLoop
         let statusCode = response.statusCode
         let headers = response.headers
 
         switch response {
         case .stream(let stream, _):
-            eventLoop.execute {
-                var head = HTTPResponseHead(version: version, status: HTTPResponseStatus(statusCode: statusCode))
-                for (name, value) in headers {
-                    head.headers.add(name: name, value: value)
-                }
-                ctx.write(self.wrapOutboundOut(.head(head)), promise: nil)
-                ctx.flush()
+            await hop(eventLoop) {
+                self.writeHeadAndFlush(statusCode: statusCode, headers: headers, version: version)
             }
 
             do {
                 for try await chunk in stream {
-                    eventLoop.execute {
-                        var buffer = ctx.channel.allocator.buffer(capacity: chunk.count)
-                        buffer.writeBytes(chunk)
-                        ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+                    await hop(eventLoop) {
+                        self.writeBodyChunk(chunk)
                     }
                 }
             } catch {
                 // Let the connection drain naturally.
             }
 
-            eventLoop.execute {
-                ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+            await hop(eventLoop) {
+                self.writeEnd()
             }
 
         default:
             let bodyData = response.bodyData
-            eventLoop.execute {
-                var head = HTTPResponseHead(version: version, status: HTTPResponseStatus(statusCode: statusCode))
-                for (name, value) in headers {
-                    head.headers.add(name: name, value: value)
-                }
-                ctx.write(self.wrapOutboundOut(.head(head)), promise: nil)
-                if let body = bodyData {
-                    var buffer = ctx.channel.allocator.buffer(capacity: body.count)
-                    buffer.writeBytes(body)
-                    ctx.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
-                }
-                ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+            await hop(eventLoop) {
+                self.writeCompleteResponse(
+                    statusCode: statusCode,
+                    headers: headers,
+                    version: version,
+                    bodyData: bodyData
+                )
             }
         }
+    }
+
+    private func hop(_ eventLoop: EventLoop, _ body: @escaping @Sendable () -> Void) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            eventLoop.execute {
+                body()
+                continuation.resume()
+            }
+        }
+    }
+
+    private func writeHeadAndFlush(statusCode: Int, headers: [String: String], version: HTTPVersion) {
+        guard let context = channelContext else { return }
+        var head = HTTPResponseHead(version: version, status: HTTPResponseStatus(statusCode: statusCode))
+        for (name, value) in headers {
+            head.headers.add(name: name, value: value)
+        }
+        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        context.flush()
+    }
+
+    private func writeBodyChunk(_ chunk: Data) {
+        guard let context = channelContext else { return }
+        var buffer = context.channel.allocator.buffer(capacity: chunk.count)
+        buffer.writeBytes(chunk)
+        context.writeAndFlush(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+    }
+
+    private func writeEnd() {
+        guard let context = channelContext else { return }
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+    }
+
+    private func writeCompleteResponse(
+        statusCode: Int,
+        headers: [String: String],
+        version: HTTPVersion,
+        bodyData: Data?
+    ) {
+        guard let context = channelContext else { return }
+        var head = HTTPResponseHead(version: version, status: HTTPResponseStatus(statusCode: statusCode))
+        for (name, value) in headers {
+            head.headers.add(name: name, value: value)
+        }
+        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        if let body = bodyData {
+            var buffer = context.channel.allocator.buffer(capacity: body.count)
+            buffer.writeBytes(body)
+            context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+        }
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
     }
 }
 #endif

--- a/Sources/WaxMCPServer/LicenseValidator.swift
+++ b/Sources/WaxMCPServer/LicenseValidator.swift
@@ -5,29 +5,34 @@ import Foundation
 import Security
 #endif
 
-// LicenseValidator is nonisolated — all access to mutable statics goes through `lock`.
-// Do NOT add @MainActor here; the MCP server runs on a non-main executor and calling
-// MainActor.run { } from a dispatchMain() context risks deadlocks.
+// LicenseValidator is nonisolated — mutable statics are serialized via NSLock.
+// Synchronization.Mutex is macOS 15+/iOS 18+; this package's floor is macOS 14
+// (`Package.swift` platforms). UserDefaults is not Sendable; it is only touched
+// inside the lock. Do NOT add @MainActor here; the MCP server runs on a non-main
+// executor and calling MainActor.run { } from a dispatchMain() context risks deadlocks.
 enum LicenseValidator {
-    private static let lock = NSLock()
+    private final class LockedState: @unchecked Sendable {
+        let lock = NSLock()
+        var trialDefaults: UserDefaults = .standard
+        var firstLaunchKey = "wax_first_launch"
+        var keychainEnabled = true
+    }
+
+    private static let locked = LockedState()
 
     // These are mutated only from tests; production code treats them as constants.
     static var trialDefaults: UserDefaults {
-        get { lock.withLock { _trialDefaults } }
-        set { lock.withLock { _trialDefaults = newValue } }
+        get { locked.lock.withLock { locked.trialDefaults } }
+        set { locked.lock.withLock { locked.trialDefaults = newValue } }
     }
     static var firstLaunchKey: String {
-        get { lock.withLock { _firstLaunchKey } }
-        set { lock.withLock { _firstLaunchKey = newValue } }
+        get { locked.lock.withLock { locked.firstLaunchKey } }
+        set { locked.lock.withLock { locked.firstLaunchKey = newValue } }
     }
     static var keychainEnabled: Bool {
-        get { lock.withLock { _keychainEnabled } }
-        set { lock.withLock { _keychainEnabled = newValue } }
+        get { locked.lock.withLock { locked.keychainEnabled } }
+        set { locked.lock.withLock { locked.keychainEnabled = newValue } }
     }
-
-    nonisolated(unsafe) private static var _trialDefaults: UserDefaults = .standard
-    nonisolated(unsafe) private static var _firstLaunchKey = "wax_first_launch"
-    nonisolated(unsafe) private static var _keychainEnabled = true
 
     private static let keyPattern = #"^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$"#
     private static let keyRegex = try? NSRegularExpression(pattern: keyPattern)

--- a/Tests/WaxCoreTests/CrashInjectionReleaseGuardTests.swift
+++ b/Tests/WaxCoreTests/CrashInjectionReleaseGuardTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import WaxCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Release builds must ignore `WAX_CRASH_INJECT_CHECKPOINT` and complete commit.
+/// DEBUG keeps the kill path; that is covered by `WaxCrashHarness`.
+@Test
+func commitCompletesWithCrashInjectionEnvSetWhenNotDebug() async throws {
+#if DEBUG
+    return
+#else
+    let url = TempFiles.uniqueURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    setenv("WAX_CRASH_INJECT_CHECKPOINT", "after_toc_write_before_footer", 1)
+    defer { unsetenv("WAX_CRASH_INJECT_CHECKPOINT") }
+
+    let wax = try await Wax.create(at: url)
+    _ = try await wax.put(Data("crash-inject-release-guard".utf8))
+    try await wax.commit()
+    let stats = await wax.stats()
+    #expect(stats.frameCount == 1)
+    try await wax.close()
+#endif
+}

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -1400,6 +1400,30 @@ func httpHandlerRejectsOversizedContentLengthBeforeReadingBody() async throws {
 }
 
 @Test
+func httpHandlerReturns404AfterRequestEndForUnknownPath() async throws {
+    let app = MCPHTTPApplication(
+        configuration: .init(maxRequestBodyBytes: 1_048),
+        serverFactory: { _, _ in
+            Issue.record("unknown path should not reach MCP server creation")
+            throw MCP.MCPError.invalidRequest("unexpected server creation")
+        }
+    )
+    let channel = await NIOAsyncTestingChannel(handler: HTTPHandler(app: app))
+    let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/not-mcp")
+
+    try await channel.writeInbound(HTTPServerRequestPart.head(head))
+    try await channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let responseHeadPart = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+    guard case .head(let response) = responseHeadPart else {
+        Issue.record("expected response head, got \(responseHeadPart)")
+        return
+    }
+    #expect(response.status == HTTPResponseStatus(statusCode: 404))
+    _ = try await channel.finish()
+}
+
+@Test
 func httpHandlerRejectsStreamingOverflowBeforeRequestEnd() async throws {
     let app = MCPHTTPApplication(
         configuration: .init(maxRequestBodyBytes: 10),


### PR DESCRIPTION
## Summary
- Gate `WAX_CRASH_INJECT_CHECKPOINT` / `posixKill` behind `#if DEBUG` so release `wax-cli` has no SIGKILL commit path.
- Replace `nonisolated(unsafe)` in `LicenseValidator` with an `NSLock` box (package floor is macOS 14; `Mutex` is 15+). Hop HTTP writes with `eventLoop.execute` instead of capturing `ChannelHandlerContext` in a `Task`.
- Collapse public `Memory.search` to three forms, move generic shims to `Memory+Deprecated.swift`, and add `## Migration` plus `.gitignore` entries for `waxmcp/dist` and `.grok/`.

## Test plan
- [ ] `swift build --traits default,MCPServer`
- [ ] `swift test --filter waxTests`
- [ ] `swift test --traits default,MCPServer --filter httpHandlerReturns404AfterRequestEndForUnknownPath --filter httpHandlerRejectsOversizedContentLengthBeforeReadingBody --filter licenseValidatorTrialPassAndExpiration`
- [ ] `swift build -c release --product wax-cli --traits default,MCPServer` then `strings`/`nm` show no `posixKill`/`SIGKILL`
- [ ] `git ls-files | rg '(waxmcp/dist|\.grok/)'` is empty
