### PR TITLE
release: waxmcp v0.1.30

### DIFF
--- a/.pi/extensions/wax-agents/package.json
+++ b/.pi/extensions/wax-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-agents",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Wax-specific multi-agent orchestration for pi",
   "dependencies": {
     "typebox": "^1.0.0"

--- a/Resources/hermes/README.md
+++ b/Resources/hermes/README.md
@@ -98,7 +98,7 @@ Add to your Hermes `$HERMES_HOME/config.yaml`:
 mcp_servers:
   wax-memory:
     command: "npx"
-    args: ["-y", "waxmcp@0.1.29", "mcp", "serve"]
+    args: ["-y", "waxmcp@0.1.30", "mcp", "serve"]
     env:
       WAX_MCP_FEATURE_LICENSE: "0"
       WAX_MCP_FEATURE_STRUCTURED_MEMORY: "1"
@@ -115,7 +115,7 @@ mcp_servers:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `command` | `npx` | Launcher for waxmcp |
-| `args` | `["-y", "waxmcp@0.1.29", "mcp", "serve"]` | Arguments passed to waxmcp |
+| `args` | `["-y", "waxmcp@0.1.30", "mcp", "serve"]` | Arguments passed to waxmcp |
 | `env.WAX_MCP_FEATURE_LICENSE` | `"0"` | Disable license checks |
 | `env.WAX_MCP_FEATURE_STRUCTURED_MEMORY` | `"1"` | Enable structured memory tools |
 | `timeout` | `120` | MCP call timeout in seconds |

--- a/Resources/hermes/wax-memory-plugin/plugin.yaml
+++ b/Resources/hermes/wax-memory-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.29
+version: 0.1.30
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -1,8 +1,8 @@
 class Wax < Formula
   desc "On-device memory and RAG framework with MCP server for Claude Code"
   homepage "https://github.com/christopherkarani/Wax"
-  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.29.tar.gz"
-  sha256 "e936ba19c46dd29605d1f1b2183a09f3bdcb6015297adcad0ceeae5505b1fb3e"
+  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.30.tar.gz"
+  sha256 "19bbdbb7f31fbf1f53e1f6df4f515ba60a6469996a1040f3f53e6e1bebe32cc2"
   license "MIT"
 
   depends_on xcode: ["16.3", :build]

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxmcp",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "npx launcher for the Wax MCP server",
   "repository": {
     "type": "git",

--- a/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
+++ b/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.29
+version: 0.1.30
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/openclaw/wax-memory-plugin/package.json
+++ b/Resources/openclaw/wax-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wax/openclaw-wax-memory",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "description": "OpenClaw memory plugin for Wax-backed agent memory.",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "openclaw": ">=2026.3.24-beta.2"
   },
   "dependencies": {
-    "waxmcp": "0.1.29"
+    "waxmcp": "0.1.30"
   },
   "devDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -23,7 +23,7 @@ import WaxVectorSearchArctic
 #endif
 
 enum WaxMCPServerMetadata {
-    static let version = "0.1.29"
+    static let version = "0.1.30"
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
## Summary

Cut **waxmcp / Wax 0.1.30** from current `main` (everything merged since `waxmcp-v0.1.29`).

### Version surfaces
- `waxmcp` npm → 0.1.30
- `WaxMCPServerMetadata.version` → 0.1.30
- OpenClaw plugin + `waxmcp` dep → 0.1.30
- Homebrew formula URL → `waxmcp-v0.1.30`
- OpenCode extension → 0.1.30
- Hermes plugin (canonical + npm ship copy) → 0.1.30

### Since 0.1.29
- Harden recall scoping, session rebind, and close path (#125)
- Apply project hard-filter before recall merge (#127)
- Extract Layered recall from AgentBrokerService (#128)
- Drop dead `pendingRememberWrites` after await-ready remember (#129)
- Plan MATCH in UnifiedSearch ranking (#123); deepen MatchPlan / MCP handle path (#124)
- Extract internal virtual session store (#122)
- Rank hyphenated identifiers first and shrink session WAL (#121)

### Follow-ups after tag
- Tag `waxmcp-v0.1.30` (+ SwiftPM `0.1.30`) triggers release workflow → npm publish
- Recompute Homebrew `sha256` from the live GitHub tarball (local git-archive SHA is provisional)

## Test plan
- [x] `scripts/validate-congruency.sh` → all surfaces 0.1.30
- [x] `bash Resources/scripts/quality/hermes_plugin_tests.sh`
- [x] `bash Resources/scripts/quality/release_workflow_tests.sh`
- [ ] Tag `waxmcp-v0.1.30` → `npm view waxmcp version` is `0.1.30`
- [ ] After tag, set Homebrew sha256 from the live GitHub tarball

Made with [Cursor](https://cursor.com)