### PR TITLE
fix(release): Homebrew sha256 for waxmcp-v0.1.30

### DIFF
--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -2,7 +2,7 @@ class Wax < Formula
   desc "On-device memory and RAG framework with MCP server for Claude Code"
   homepage "https://github.com/christopherkarani/Wax"
   url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.30.tar.gz"
-  sha256 "19bbdbb7f31fbf1f53e1f6df4f515ba60a6469996a1040f3f53e6e1bebe32cc2"
+  sha256 "ea1cc5b44dce9be547ffae144c79e30cde26b35b7c3db4279d68c39236098192"
   license "MIT"
 
   depends_on xcode: ["16.3", :build]


### PR DESCRIPTION
## Summary
- Replace provisional local `git archive` Homebrew `sha256` with the live GitHub `waxmcp-v0.1.30` source tarball digest.

## Test plan
- [x] `curl -sL https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.30.tar.gz | shasum -a 256` matches formula

Made with [Cursor](https://cursor.com)