### PR TITLE
release: waxmcp v0.1.31

### DIFF
--- a/.pi/extensions/wax-agents/package.json
+++ b/.pi/extensions/wax-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-agents",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Wax-specific multi-agent orchestration for pi",
   "dependencies": {
     "typebox": "^1.0.0"

--- a/Resources/hermes/README.md
+++ b/Resources/hermes/README.md
@@ -98,7 +98,7 @@ Add to your Hermes `$HERMES_HOME/config.yaml`:
 mcp_servers:
   wax-memory:
     command: "npx"
-    args: ["-y", "waxmcp@0.1.30", "mcp", "serve"]
+    args: ["-y", "waxmcp@0.1.31", "mcp", "serve"]
     env:
       WAX_MCP_FEATURE_LICENSE: "0"
       WAX_MCP_FEATURE_STRUCTURED_MEMORY: "1"
@@ -115,7 +115,7 @@ mcp_servers:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `command` | `npx` | Launcher for waxmcp |
-| `args` | `["-y", "waxmcp@0.1.30", "mcp", "serve"]` | Arguments passed to waxmcp |
+| `args` | `["-y", "waxmcp@0.1.31", "mcp", "serve"]` | Arguments passed to waxmcp |
 | `env.WAX_MCP_FEATURE_LICENSE` | `"0"` | Disable license checks |
 | `env.WAX_MCP_FEATURE_STRUCTURED_MEMORY` | `"1"` | Enable structured memory tools |
 | `timeout` | `120` | MCP call timeout in seconds |

--- a/Resources/hermes/wax-memory-plugin/plugin.yaml
+++ b/Resources/hermes/wax-memory-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.30
+version: 0.1.31
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -1,8 +1,8 @@
 class Wax < Formula
   desc "On-device memory and RAG framework with MCP server for Claude Code"
   homepage "https://github.com/christopherkarani/Wax"
-  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.30.tar.gz"
-  sha256 "ea1cc5b44dce9be547ffae144c79e30cde26b35b7c3db4279d68c39236098192"
+  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.31.tar.gz"
+  sha256 "ceaaa1231dea39168a6dbfffc73851e2b6f5fad95f43bc4870419b72a04c9157"
   license "MIT"
 
   depends_on xcode: ["16.3", :build]

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxmcp",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "npx launcher for the Wax MCP server",
   "repository": {
     "type": "git",

--- a/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
+++ b/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.30
+version: 0.1.31
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/openclaw/wax-memory-plugin/package.json
+++ b/Resources/openclaw/wax-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wax/openclaw-wax-memory",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "description": "OpenClaw memory plugin for Wax-backed agent memory.",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "openclaw": ">=2026.3.24-beta.2"
   },
   "dependencies": {
-    "waxmcp": "0.1.30"
+    "waxmcp": "0.1.31"
   },
   "devDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/Resources/scripts/sync-waxmcp-version.sh
+++ b/Resources/scripts/sync-waxmcp-version.sh
@@ -10,6 +10,7 @@ REQUESTED_VERSION="$1"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_DIR="$ROOT/Resources/npm/waxmcp"
 SERVER_SWIFT="$ROOT/Sources/WaxMCPServer/main.swift"
+CLI_SWIFT="$ROOT/Sources/WaxCLI/WaxCLICommand.swift"
 
 if [[ ! -f "$PKG_DIR/package.json" ]]; then
   echo "error: missing $PKG_DIR/package.json" >&2
@@ -18,6 +19,11 @@ fi
 
 if [[ ! -f "$SERVER_SWIFT" ]]; then
   echo "error: missing $SERVER_SWIFT" >&2
+  exit 2
+fi
+
+if [[ ! -f "$CLI_SWIFT" ]]; then
+  echo "error: missing $CLI_SWIFT" >&2
   exit 2
 fi
 
@@ -34,5 +40,6 @@ npm --prefix "$PKG_DIR" version "$REQUESTED_VERSION" --no-git-tag-version --allo
 RELEASE_VERSION="$(node -p "require('$PKG_DIR/package.json').version")"
 
 perl -0pi -e 's/static let version\s*=\s*"[^"]+"/static let version = "'"$RELEASE_VERSION"'"/' "$SERVER_SWIFT"
+perl -0pi -e 's/(CommandConfiguration\(\s*commandName:\s*"wax-cli",\s*abstract:\s*"[^"]*",\s*version:\s*)"[^"]+"/${1}"'"$RELEASE_VERSION"'"/s' "$CLI_SWIFT"
 
 echo "$RELEASE_VERSION"

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -8,7 +8,7 @@ struct WaxCLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wax-cli",
         abstract: "Wax developer CLI",
-        version: "0.1.30",
+        version: "0.1.31",
         subcommands: [
             RememberCommand.self,
             RecallCommand.self,

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -8,7 +8,7 @@ struct WaxCLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wax-cli",
         abstract: "Wax developer CLI",
-        version: "0.1.28",
+        version: "0.1.30",
         subcommands: [
             RememberCommand.self,
             RecallCommand.self,

--- a/Sources/WaxMCPServer/HTTPApp.swift
+++ b/Sources/WaxMCPServer/HTTPApp.swift
@@ -45,6 +45,9 @@ actor MCPHTTPApplication {
     private let validationPipeline: (any HTTPRequestValidationPipeline)?
     private var channel: Channel?
     private var sessions: [String: SessionContext] = [:]
+    /// In-flight recoveries keyed by client `Mcp-Session-Id` so concurrent stale
+    /// tool calls wait for one recreate instead of racing.
+    private var sessionRecoveryTasks: [String: Task<Bool, Never>] = [:]
     private var cleanupTask: Task<Void, Never>?
 
     nonisolated let logger: Logger
@@ -166,10 +169,18 @@ actor MCPHTTPApplication {
             return response
         }
 
-        if request.method.uppercased() == "POST",
-           let body = request.body,
-           isInitializeRequest(body) {
-            return await createSessionAndHandle(request)
+        // Unknown or missing session map entry.
+        if request.method.uppercased() == "POST", let body = request.body {
+            if isInitializeRequest(body) {
+                // Reuse the client's id when present so Cursor can keep its cached header
+                // after wax-mcp restarts (otherwise a fresh UUID leaves the client stuck).
+                return await createSessionAndHandle(request, preferredSessionID: sessionID)
+            }
+            if let sessionID {
+                // Cursor keeps calling tools with a stale Mcp-Session-Id after process
+                // restart and does not re-initialize. Recreate under the same id.
+                return await recoverSessionAndHandle(request, sessionID: sessionID)
+            }
         }
 
         if sessionID != nil {
@@ -186,8 +197,22 @@ actor MCPHTTPApplication {
         func generateSessionID() -> String { sessionID }
     }
 
-    private func createSessionAndHandle(_ request: HTTPRequest) async -> HTTPResponse {
-        let sessionID = UUID().uuidString
+    private func isValidClientSessionID(_ sessionID: String) -> Bool {
+        !sessionID.isEmpty && sessionID.utf8.allSatisfy { $0 >= 0x21 && $0 <= 0x7E }
+    }
+
+    private func resolveSessionID(preferred: String?) -> String {
+        if let preferred, isValidClientSessionID(preferred) {
+            return preferred
+        }
+        return UUID().uuidString
+    }
+
+    private func createSessionAndHandle(
+        _ request: HTTPRequest,
+        preferredSessionID: String? = nil
+    ) async -> HTTPResponse {
+        let sessionID = resolveSessionID(preferred: preferredSessionID)
         let transport = StatefulHTTPServerTransport(
             sessionIDGenerator: FixedSessionIDGenerator(sessionID: sessionID),
             validationPipeline: validationPipeline,
@@ -217,13 +242,164 @@ actor MCPHTTPApplication {
         }
     }
 
+    /// Recreate an HTTP MCP session under the client's existing `Mcp-Session-Id`.
+    ///
+    /// Used when the in-memory map was wiped (process restart) but the client still
+    /// holds the old id. Synthetic `initialize` binds the transport session so
+    /// subsequent `tools/call` passes `SessionValidator`.
+    private func recoverSessionAndHandle(
+        _ request: HTTPRequest,
+        sessionID: String
+    ) async -> HTTPResponse {
+        guard isValidClientSessionID(sessionID) else {
+            return .error(
+                statusCode: 400,
+                .invalidRequest("Bad Request: Invalid \(HTTPHeaderName.sessionID) header")
+            )
+        }
+
+        guard await ensureRecoveredSession(sessionID: sessionID) else {
+            return .error(
+                statusCode: 500,
+                .internalError("Failed to recover MCP HTTP session")
+            )
+        }
+
+        guard var session = sessions[sessionID] else {
+            return .error(statusCode: 404, .invalidRequest("Not Found: Session not found or expired"))
+        }
+        session.lastAccessedAt = Date()
+        sessions[sessionID] = session
+        return await session.transport.handleRequest(request)
+    }
+
+    private func ensureRecoveredSession(sessionID: String) async -> Bool {
+        if sessions[sessionID] != nil {
+            return true
+        }
+        if let existing = sessionRecoveryTasks[sessionID] {
+            return await existing.value
+        }
+        let task = Task<Bool, Never> {
+            await self.createRecoveredSession(sessionID: sessionID)
+        }
+        sessionRecoveryTasks[sessionID] = task
+        let recovered = await task.value
+        sessionRecoveryTasks[sessionID] = nil
+        return recovered
+    }
+
+    private func createRecoveredSession(sessionID: String) async -> Bool {
+        if sessions[sessionID] != nil {
+            return true
+        }
+
+        let transport = StatefulHTTPServerTransport(
+            sessionIDGenerator: FixedSessionIDGenerator(sessionID: sessionID),
+            validationPipeline: validationPipeline,
+            retryInterval: configuration.retryInterval,
+            logger: logger
+        )
+
+        do {
+            let server = try await serverFactory(sessionID, transport)
+            try await server.start(transport: transport)
+
+            let initRequest = HTTPRequest(
+                method: "POST",
+                headers: [
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                ],
+                body: Self.syntheticInitializeBody,
+                path: configuration.endpoint
+            )
+            let initResponse = await transport.handleRequest(initRequest)
+            guard await Self.consumeSuccessfulInitializeResponse(initResponse) else {
+                await transport.disconnect()
+                logger.error(
+                    "HTTP session recovery initialize failed",
+                    metadata: ["sessionID": "\(sessionID)"]
+                )
+                return false
+            }
+
+            // Optional hygiene notification; ignore failures.
+            let initializedNotification = HTTPRequest(
+                method: "POST",
+                headers: [
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                    HTTPHeaderName.sessionID: sessionID,
+                ],
+                body: Data(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.utf8),
+                path: configuration.endpoint
+            )
+            _ = await transport.handleRequest(initializedNotification)
+
+            sessions[sessionID] = SessionContext(
+                server: server,
+                transport: transport,
+                createdAt: Date(),
+                lastAccessedAt: Date()
+            )
+            logger.info(
+                "Recovered HTTP session after map miss",
+                metadata: ["sessionID": "\(sessionID)"]
+            )
+            return true
+        } catch {
+            await transport.disconnect()
+            logger.error(
+                "HTTP session recovery failed",
+                metadata: [
+                    "sessionID": "\(sessionID)",
+                    "error": "\(error.localizedDescription)",
+                ]
+            )
+            return false
+        }
+    }
+
+    private static let syntheticInitializeBody = Data(
+        #"{"jsonrpc":"2.0","id":"wax-session-recover","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"wax-mcp-session-recover","version":"0.0.0"}}}"#
+            .utf8
+    )
+
+    private static func consumeSuccessfulInitializeResponse(_ response: HTTPResponse) async -> Bool {
+        switch response {
+        case .error:
+            return false
+        case .accepted, .ok, .data:
+            return true
+        case .stream(let stream, _):
+            do {
+                for try await chunk in stream {
+                    if let text = String(data: chunk, encoding: .utf8),
+                       text.contains("\"result\"") {
+                        return true
+                    }
+                }
+                return true
+            } catch {
+                return false
+            }
+        }
+    }
+
     private func closeSession(_ sessionID: String) async {
+        sessionRecoveryTasks[sessionID]?.cancel()
+        sessionRecoveryTasks[sessionID] = nil
         guard let session = sessions.removeValue(forKey: sessionID) else { return }
         await session.transport.disconnect()
         logger.info("Closed HTTP session", metadata: ["sessionID": "\(sessionID)"])
     }
 
     private func closeAllSessions() async {
+        for task in sessionRecoveryTasks.values {
+            task.cancel()
+        }
+        sessionRecoveryTasks.removeAll()
         for sessionID in sessions.keys {
             await closeSession(sessionID)
         }

--- a/Sources/WaxMCPServer/HTTPApp.swift
+++ b/Sources/WaxMCPServer/HTTPApp.swift
@@ -370,17 +370,24 @@ actor MCPHTTPApplication {
         switch response {
         case .error:
             return false
-        case .accepted, .ok, .data:
-            return true
+        case .accepted, .ok:
+            // Initialize should return a JSON-RPC result body/stream; bare
+            // accepted/ok without payload is not enough to bind the session.
+            return false
+        case .data(let data, _):
+            guard let text = String(data: data, encoding: .utf8) else { return false }
+            return text.contains("\"result\"")
         case .stream(let stream, _):
             do {
                 for try await chunk in stream {
-                    if let text = String(data: chunk, encoding: .utf8),
-                       text.contains("\"result\"") {
+                    guard let text = String(data: chunk, encoding: .utf8) else { continue }
+                    if text.contains("\"result\"") {
                         return true
                     }
                 }
-                return true
+                // Stream finished without a JSON-RPC result — treat as failure so
+                // we do not register a half-initialized transport session.
+                return false
             } catch {
                 return false
             }

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -23,7 +23,7 @@ import WaxVectorSearchArctic
 #endif
 
 enum WaxMCPServerMetadata {
-    static let version = "0.1.30"
+    static let version = "0.1.31"
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -1497,6 +1497,117 @@ func httpApplicationRejectsUnauthorizedOffLoopbackRequests() async throws {
 }
 
 @Test
+func httpInitializeReusesClientSessionIDWhenUnknown() async throws {
+    let preferredID = "cursor-stale-session-reuse-001"
+    let app = MCPHTTPApplication(
+        serverFactory: { _, _ in
+            Server(
+                name: "wax-mcp-test",
+                version: "0.0.0",
+                capabilities: .init(tools: .init(listChanged: false))
+            )
+        }
+    )
+    let body = try JSONSerialization.data(withJSONObject: [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "protocolVersion": "2024-11-05",
+            "capabilities": [:] as [String: Any],
+            "clientInfo": ["name": "cursor-probe", "version": "0"],
+        ],
+    ])
+
+    let response = await app.handleHTTPRequest(HTTPRequest(
+        method: "POST",
+        headers: [
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            HTTPHeaderName.sessionID: preferredID,
+        ],
+        body: body,
+        path: "/mcp"
+    ))
+
+    #expect(response.statusCode == 200)
+    #expect(response.headers[HTTPHeaderName.sessionID] == preferredID)
+}
+
+@Test
+func httpRecoversUnknownSessionForToolsListWithoutClientReinit() async throws {
+    let staleID = "cursor-stale-session-tools-002"
+    let app = MCPHTTPApplication(
+        serverFactory: { _, _ in
+            Server(
+                name: "wax-mcp-test",
+                version: "0.0.0",
+                capabilities: .init(tools: .init(listChanged: false))
+            )
+        }
+    )
+    let body = try JSONSerialization.data(withJSONObject: [
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": [:] as [String: Any],
+    ])
+
+    let response = await app.handleHTTPRequest(HTTPRequest(
+        method: "POST",
+        headers: [
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            HTTPHeaderName.sessionID: staleID,
+        ],
+        body: body,
+        path: "/mcp"
+    ))
+
+    #expect(response.statusCode == 200)
+    #expect(response.headers[HTTPHeaderName.sessionID] == staleID)
+    // Second call should hit the live map, not recover again.
+    let again = await app.handleHTTPRequest(HTTPRequest(
+        method: "POST",
+        headers: [
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            HTTPHeaderName.sessionID: staleID,
+        ],
+        body: body,
+        path: "/mcp"
+    ))
+    #expect(again.statusCode == 200)
+    #expect(again.headers[HTTPHeaderName.sessionID] == staleID)
+}
+
+@Test
+func httpMissingSessionHeaderOnNonInitializeStillFails() async throws {
+    let app = MCPHTTPApplication(
+        serverFactory: { _, _ in
+            Issue.record("missing session header should not create a server")
+            throw MCP.MCPError.invalidRequest("unexpected server creation")
+        }
+    )
+    let body = try JSONSerialization.data(withJSONObject: [
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/list",
+        "params": [:] as [String: Any],
+    ])
+    let response = await app.handleHTTPRequest(HTTPRequest(
+        method: "POST",
+        headers: [
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        ],
+        body: body,
+        path: "/mcp"
+    ))
+    #expect(response.statusCode == 400)
+}
+
+@Test
 func httpSessionCleanupTaskStopsWithApplicationStop() async throws {
     let app = MCPHTTPApplication(
         configuration: .init(port: 0, sessionCleanupInterval: .milliseconds(10)),
@@ -7401,8 +7512,14 @@ struct WaxMCPProcessTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
+        let packageJSON = packageRoot
+            .appendingPathComponent("Resources/npm/waxmcp/package.json")
+        let packageData = try Data(contentsOf: packageJSON)
+        let packageObject = try JSONSerialization.jsonObject(with: packageData) as? [String: Any]
+        let expectedVersion = try #require(packageObject?["version"] as? String)
+
         let mcp = try MCPServerProcessHarness.waxMCPBinaryURLForTests(packageRoot: packageRoot)
-        try expectVersion(executable: mcp, expectedSubstring: "0.1.28")
+        try expectVersion(executable: mcp, expectedSubstring: expectedVersion)
 
         let cliCandidates = [
             mcp.deletingLastPathComponent().appendingPathComponent("wax-cli"),
@@ -7410,7 +7527,7 @@ struct WaxMCPProcessTests {
             packageRoot.appendingPathComponent(".build/arm64-apple-macosx/debug/wax-cli"),
         ]
         let cli = try #require(cliCandidates.first { FileManager.default.isExecutableFile(atPath: $0.path) })
-        try expectVersion(executable: cli, expectedSubstring: "0.1.")
+        try expectVersion(executable: cli, expectedSubstring: expectedVersion)
     }
 }
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -9,12 +9,13 @@ set -euo pipefail
 # Surfaces managed:
 #   1. Resources/npm/waxmcp/package.json (npm package)
 #   2. Sources/WaxMCPServer/main.swift (Swift server)
-#   3. Resources/openclaw/wax-memory-plugin/package.json (OpenClaw plugin version)
-#   4. Resources/openclaw/wax-memory-plugin/package.json (OpenClaw waxmcp dependency)
-#   5. Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb (Homebrew URL)
-#   6. Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb (Homebrew SHA256)
-#   7. .pi/extensions/wax-agents/package.json (OpenCode/pi extension)
-#   8. Resources/hermes/README.md (Hermes MCP config reference)
+#   3. Sources/WaxCLI/WaxCLICommand.swift (wax-cli --version)
+#   4. Resources/openclaw/wax-memory-plugin/package.json (OpenClaw plugin version)
+#   5. Resources/openclaw/wax-memory-plugin/package.json (OpenClaw waxmcp dependency)
+#   6. Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb (Homebrew URL)
+#   7. Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb (Homebrew SHA256)
+#   8. .pi/extensions/wax-agents/package.json (OpenCode/pi extension)
+#   9. Resources/hermes/README.md (Hermes MCP config reference)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -22,6 +23,7 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # ── Configuration ───────────────────────────────────────────────────────────
 NPM_PKG="$ROOT/Resources/npm/waxmcp"
 SERVER_SWIFT="$ROOT/Sources/WaxMCPServer/main.swift"
+CLI_SWIFT="$ROOT/Sources/WaxCLI/WaxCLICommand.swift"
 OPENCLAW_PKG="$ROOT/Resources/openclaw/wax-memory-plugin"
 OPENCODE_PKG="$ROOT/.pi/extensions/wax-agents"
 HOMEBREW_FORMULA="$ROOT/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb"
@@ -77,6 +79,11 @@ read_pkg_version() {
 # Read current version from main.swift
 read_swift_version() {
   grep -oE 'static let version = "[0-9]+\.[0-9]+\.[0-9]+"' "$SERVER_SWIFT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "NOT_FOUND"
+}
+
+# Read version from wax-cli ArgumentParser configuration
+read_cli_version() {
+  perl -0ne 'if (/CommandConfiguration\(\s*commandName:\s*"wax-cli".*?version:\s*"([0-9]+\.[0-9]+\.[0-9]+)"/s) { print "$1\n" }' "$CLI_SWIFT" || echo "NOT_FOUND"
 }
 
 # Read current version from Homebrew formula URL
@@ -144,6 +151,7 @@ echo ""
 
 CURRENT_NPM=$(read_pkg_version "$NPM_PKG")
 CURRENT_SWIFT=$(read_swift_version)
+CURRENT_CLI=$(read_cli_version)
 CURRENT_OPENCLAW=$(read_pkg_version "$OPENCLAW_PKG")
 CURRENT_OPENCLAW_DEP=$(node -p "require('$OPENCLAW_PKG/package.json').dependencies.waxmcp" 2>/dev/null || echo "NOT_FOUND")
 CURRENT_HOMEBREW=$(read_homebrew_version)
@@ -184,6 +192,7 @@ echo ""
 # ── Idempotency check ───────────────────────────────────────────────────────
 if [[ "$CURRENT_NPM" == "$TARGET_VERSION" ]] && \
    [[ "$CURRENT_SWIFT" == "$TARGET_VERSION" ]] && \
+   [[ "$CURRENT_CLI" == "$TARGET_VERSION" ]] && \
    [[ "$CURRENT_OPENCLAW" == "$TARGET_VERSION" ]] && \
    [[ "$CURRENT_OPENCLAW_DEP" == "$TARGET_VERSION" ]] && \
    [[ "$CURRENT_HOMEBREW" == "$TARGET_VERSION" ]] && \
@@ -201,6 +210,7 @@ printf "  %-50s ├ %-10s ┼ %-10s\n" "$(printf '%*s' 50 '' | tr ' ' '-')" "$(p
 
 [[ "$CURRENT_NPM" != "$TARGET_VERSION" ]] && print_row "npm/waxmcp/package.json" "$CURRENT_NPM" "$TARGET_VERSION"
 [[ "$CURRENT_SWIFT" != "$TARGET_VERSION" ]] && print_row "Sources/WaxMCPServer/main.swift" "$CURRENT_SWIFT" "$TARGET_VERSION"
+[[ "$CURRENT_CLI" != "$TARGET_VERSION" ]] && print_row "Sources/WaxCLI/WaxCLICommand.swift" "$CURRENT_CLI" "$TARGET_VERSION"
 [[ "$CURRENT_OPENCLAW" != "$TARGET_VERSION" ]] && print_row "openclaw plugin (version)" "$CURRENT_OPENCLAW" "$TARGET_VERSION"
 [[ "$CURRENT_OPENCLAW_DEP" != "$TARGET_VERSION" ]] && print_row "openclaw plugin (waxmcp dep)" "$CURRENT_OPENCLAW_DEP" "$TARGET_VERSION"
 [[ "$CURRENT_HOMEBREW" != "$TARGET_VERSION" ]] && print_row "homebrew formula (url)" "$CURRENT_HOMEBREW" "$TARGET_VERSION"
@@ -221,14 +231,15 @@ fi
 echo "📝 Applying version bumps..."
 echo ""
 
-# Surface 1+2: Already done by sync-waxmcp-version.sh (called above)
+# Surface 1+2+CLI: Already done by sync-waxmcp-version.sh (called above)
 # We just verify it worked
 NEW_NPM=$(read_pkg_version "$NPM_PKG")
 NEW_SWIFT=$(read_swift_version)
-if [[ "$NEW_NPM" != "$TARGET_VERSION" ]] || [[ "$NEW_SWIFT" != "$TARGET_VERSION" ]]; then
-  fail "sync-waxmcp-version.sh did not bump correctly (npm=$NEW_NPM, swift=$NEW_SWIFT)"
+NEW_CLI=$(read_cli_version)
+if [[ "$NEW_NPM" != "$TARGET_VERSION" ]] || [[ "$NEW_SWIFT" != "$TARGET_VERSION" ]] || [[ "$NEW_CLI" != "$TARGET_VERSION" ]]; then
+  fail "sync-waxmcp-version.sh did not bump correctly (npm=$NEW_NPM, swift=$NEW_SWIFT, cli=$NEW_CLI)"
 fi
-info "npm/waxmcp + Swift server → $TARGET_VERSION"
+info "npm/waxmcp + Swift server + wax-cli → $TARGET_VERSION"
 
 # Surface 3+4: OpenClaw plugin
 if [[ "$CURRENT_OPENCLAW" != "$TARGET_VERSION" ]] || [[ "$CURRENT_OPENCLAW_DEP" != "$TARGET_VERSION" ]]; then

--- a/scripts/validate-congruency.sh
+++ b/scripts/validate-congruency.sh
@@ -16,6 +16,7 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # ── Configuration ───────────────────────────────────────────────────────────
 NPM_PKG="$ROOT/Resources/npm/waxmcp"
 SERVER_SWIFT="$ROOT/Sources/WaxMCPServer/main.swift"
+CLI_SWIFT="$ROOT/Sources/WaxCLI/WaxCLICommand.swift"
 OPENCLAW_PKG="$ROOT/Resources/openclaw/wax-memory-plugin"
 OPENCODE_PKG="$ROOT/.pi/extensions/wax-agents"
 HOMEBREW_FORMULA="$ROOT/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb"
@@ -43,6 +44,11 @@ read_swift_version() {
   grep -oE 'static let version = "[0-9]+\.[0-9]+\.[0-9]+"' "$SERVER_SWIFT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "NOT_FOUND"
 }
 
+# Read version from wax-cli ArgumentParser configuration
+read_cli_version() {
+  perl -0ne 'if (/CommandConfiguration\(\s*commandName:\s*"wax-cli".*?version:\s*"([0-9]+\.[0-9]+\.[0-9]+)"/s) { print "$1\n" }' "$CLI_SWIFT" || echo "NOT_FOUND"
+}
+
 # Read waxmcp dependency from OpenClaw plugin
 read_openclaw_dep() {
   node -p "require('$OPENCLAW_PKG/package.json').dependencies.waxmcp" 2>/dev/null || echo "NOT_FOUND"
@@ -66,6 +72,7 @@ done
 # ── Read all versions ───────────────────────────────────────────────────────
 NPM_VERSION=$(read_pkg_version "$NPM_PKG")
 SWIFT_VERSION=$(read_swift_version)
+CLI_VERSION=$(read_cli_version)
 OPENCLAW_VERSION=$(read_pkg_version "$OPENCLAW_PKG")
 OPENCLAW_DEP=$(read_openclaw_dep)
 HOMEBREW_VERSION=$(read_homebrew_version)
@@ -82,6 +89,11 @@ MISMATCHES=()
 if [[ "$SWIFT_VERSION" != "$CANONICAL" ]]; then
   CONGRUENT=false
   MISMATCHES+=("swift:$SWIFT_VERSION")
+fi
+
+if [[ "$CLI_VERSION" != "$CANONICAL" ]]; then
+  CONGRUENT=false
+  MISMATCHES+=("cli:$CLI_VERSION")
 fi
 
 if [[ "$OPENCLAW_VERSION" != "$CANONICAL" ]]; then
@@ -131,6 +143,7 @@ if [[ "$JSON" == true ]]; then
   echo "  \"versions\": {"
   echo "    \"npm\": \"$NPM_VERSION\","
   echo "    \"swift\": \"$SWIFT_VERSION\","
+  echo "    \"cli\": \"$CLI_VERSION\","
   echo "    \"openclaw\": \"$OPENCLAW_VERSION\","
   echo "    \"openclaw-dep\": \"$OPENCLAW_DEP\","
   echo "    \"homebrew\": \"$HOMEBREW_VERSION\","
@@ -166,7 +179,7 @@ else
       printf "  %-20s │ %-10s │ %s\n" "Surface" "Version" "Status"
       printf "  %-20s ├ %-10s ┼ %s\n" "$(printf '%*s' 20 '' | tr ' ' '-')" "$(printf '%*s' 10 '' | tr ' ' '-')" "$(printf '%*s' 8 '' | tr ' ' '-')"
 
-      for surface in "npm:$NPM_VERSION" "swift:$SWIFT_VERSION" "openclaw:$OPENCLAW_VERSION" "openclaw-dep:$OPENCLAW_DEP" "homebrew:$HOMEBREW_VERSION" "opencode:$OPENCODE_VERSION" "hermes-readme:${HERMES_VERSION:-NOT_FOUND}" "hermes-plugin:${HERMES_PLUGIN_VERSION:-NOT_FOUND}"; do
+      for surface in "npm:$NPM_VERSION" "swift:$SWIFT_VERSION" "cli:$CLI_VERSION" "openclaw:$OPENCLAW_VERSION" "openclaw-dep:$OPENCLAW_DEP" "homebrew:$HOMEBREW_VERSION" "opencode:$OPENCODE_VERSION" "hermes-readme:${HERMES_VERSION:-NOT_FOUND}" "hermes-plugin:${HERMES_PLUGIN_VERSION:-NOT_FOUND}"; do
         name="${surface%%:*}"
         version="${surface#*:}"
         if [[ "$version" == "$CANONICAL" ]]; then


### PR DESCRIPTION
## Summary

Cut **waxmcp / Wax 0.1.31** from `main` after [#132](https://github.com/christopherkarani/Wax/pull/132) (stale MCP HTTP session recovery).

This branch already includes the #132 merge of `origin/main` plus the session-recovery fix and release tooling that bumps `wax-cli --version`.

### Version surfaces
- `waxmcp` npm → 0.1.31
- `WaxMCPServerMetadata.version` → 0.1.31
- `wax-cli` ArgumentParser version → 0.1.31
- OpenClaw plugin + `waxmcp` dep → 0.1.31
- Homebrew formula URL → `waxmcp-v0.1.31`
- OpenCode extension → 0.1.31
- Hermes plugin (canonical + npm ship copy) → 0.1.31

### Since 0.1.30
- Recover stale MCP HTTP sessions after `wax-mcp` restart (#132)
- Gate crash injection, isolate MCP HTTP concurrency, collapse search overloads (#126)
- wax-cli version included in sync/bump/congruency scripts

### Follow-ups after tag
- Tag `waxmcp-v0.1.31` (+ SwiftPM `0.1.31`) triggers release workflow → npm publish
- Recompute Homebrew `sha256` from the live GitHub tarball (local git-archive SHA is provisional)
- Close #132 if this PR lands the same commits

## Test plan
- [x] `scripts/validate-congruency.sh` → all surfaces 0.1.31
- [x] `bash Resources/scripts/quality/hermes_plugin_tests.sh`
- [x] `bash Resources/scripts/quality/release_workflow_tests.sh`
- [x] `swift test --traits MCPServer --filter 'httpInitializeReusesClientSessionIDWhenUnknown|httpRecoversUnknownSessionForToolsListWithoutClientReinit|httpMissingSessionHeaderOnNonInitializeStillFails'`
- [ ] Merge #132 first (or merge this PR which includes it), then tag `waxmcp-v0.1.31`
- [ ] `npm view waxmcp version` is `0.1.31`
- [ ] After tag, set Homebrew sha256 from the live GitHub tarball


Made with [Cursor](https://cursor.com)