### PR TITLE
Bound entity_resolve.limit to the published MCP schema

### DIFF
--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -515,9 +515,15 @@ extension BrokerCommand.EntityUpsert {
 
 extension BrokerCommand.EntityResolve {
     package static func decode(_ args: BrokerArguments) throws -> Self {
-        Self(
+        let limit = try args.optionalInt("limit") ?? 10
+        guard (1...BrokerLimits.maxEntityResolveLimit).contains(limit) else {
+            throw BrokerValidationError.invalid(
+                "limit must be between 1 and \(BrokerLimits.maxEntityResolveLimit)"
+            )
+        }
+        return Self(
             alias: try args.requiredString("alias", maxBytes: BrokerLimits.maxGraphIdentifierBytes),
-            limit: try args.optionalInt("limit") ?? 10
+            limit: limit
         )
     }
 }

--- a/Sources/Wax/Broker/BrokerLimits.swift
+++ b/Sources/Wax/Broker/BrokerLimits.swift
@@ -9,6 +9,7 @@ package enum BrokerLimits {
     package static let maxTopK = 200
     package static let maxRecallLimit = 100
     package static let maxGraphLimit = 500
+    package static let maxEntityResolveLimit = 100
     package static let maxGraphIdentifierBytes = 256
     package static let maxGraphKindBytes = 64
     package static let maxMemoryIDBytes = 512

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -924,7 +924,7 @@ enum ToolSchemas {
                 "type": "integer",
                 "description": "Maximum matches to return. Default: 10.",
                 "minimum": 1,
-                "maximum": 100,
+                "maximum": .int(BrokerLimits.maxEntityResolveLimit),
             ],
         ],
         required: ["alias"]

--- a/Tests/WaxTests/BrokerCommandDecodeTests.swift
+++ b/Tests/WaxTests/BrokerCommandDecodeTests.swift
@@ -480,4 +480,23 @@ struct BrokerCommandDecodeTests {
             )
         }
     }
+
+    @Test
+    func entityResolveRejectsOutOfRangeLimit() {
+        #expect(throws: BrokerValidationError.self) {
+            _ = try BrokerCommand.decode(
+                command: "entity_resolve",
+                arguments: ["alias": .string("Wax"), "limit": .int(0)]
+            )
+        }
+        #expect(throws: BrokerValidationError.self) {
+            _ = try BrokerCommand.decode(
+                command: "entity_resolve",
+                arguments: [
+                    "alias": .string("Wax"),
+                    "limit": .int(Int64(BrokerLimits.maxEntityResolveLimit) + 1),
+                ]
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Follow-up from the PR 135 review: typed `entity_resolve` decode now rejects `limit` outside `1...100`, matching the published MCP schema.
- MCP `entity_resolve` schema maximum now reads from `BrokerLimits.maxEntityResolveLimit` so the wire contract and decode cannot drift.

## Test plan
- [x] `swift test --filter entityResolveRejectsOutOfRangeLimit`


Made with [Cursor](https://cursor.com)