### PR TITLE
Model broker responses as exclusive success/failure outcomes

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerProtocol.swift
+++ b/Sources/Wax/Broker/AgentBrokerProtocol.swift
@@ -158,25 +158,116 @@ package struct AgentBrokerRequest: Sendable, Codable, Equatable {
     }
 }
 
-package struct AgentBrokerResponse: Sendable, Codable, Equatable {
+package struct AgentBrokerResponse: Sendable, Equatable, Codable {
+    package enum Outcome: Sendable, Equatable {
+        case success(payload: AgentBrokerValue)
+        case failure(payload: AgentBrokerValue?, message: String)
+    }
+
     package var id: String?
-    package var ok: Bool
-    package var payload: AgentBrokerValue?
-    package var error: String?
+    package var outcome: Outcome
     package var shouldExit: Bool
 
     package init(
         id: String? = nil,
-        ok: Bool,
-        payload: AgentBrokerValue? = nil,
-        error: String? = nil,
+        outcome: Outcome,
         shouldExit: Bool = false
     ) {
         self.id = id
-        self.ok = ok
-        self.payload = payload
-        self.error = error
+        self.outcome = outcome
         self.shouldExit = shouldExit
+    }
+
+    package static func success(
+        id: String? = nil,
+        payload: AgentBrokerValue,
+        shouldExit: Bool = false
+    ) -> AgentBrokerResponse {
+        AgentBrokerResponse(
+            id: id,
+            outcome: .success(payload: payload),
+            shouldExit: shouldExit
+        )
+    }
+
+    package static func failure(
+        id: String? = nil,
+        payload: AgentBrokerValue? = nil,
+        message: String,
+        shouldExit: Bool = false
+    ) -> AgentBrokerResponse {
+        AgentBrokerResponse(
+            id: id,
+            outcome: .failure(payload: payload, message: message),
+            shouldExit: shouldExit
+        )
+    }
+
+    package var ok: Bool {
+        if case .success = outcome {
+            return true
+        }
+        return false
+    }
+
+    /// Success payload (nil when it is `.null` or the response failed with no payload).
+    package var payload: AgentBrokerValue? {
+        switch outcome {
+        case .success(let payload):
+            return payload == .null ? nil : payload
+        case .failure(let payload, _):
+            return payload
+        }
+    }
+
+    package var error: String? {
+        if case .failure(_, let message) = outcome {
+            return message
+        }
+        return nil
+    }
+
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = try container.decodeIfPresent(String.self, forKey: .id)
+        let ok = try container.decode(Bool.self, forKey: .ok)
+        let payload = try container.decodeIfPresent(AgentBrokerValue.self, forKey: .payload)
+        let error = try container.decodeIfPresent(String.self, forKey: .error)
+        let shouldExit = try container.decodeIfPresent(Bool.self, forKey: .shouldExit) ?? false
+        self.id = id
+        self.shouldExit = shouldExit
+        if ok {
+            self.outcome = .success(payload: payload ?? .null)
+        } else {
+            self.outcome = .failure(payload: payload, message: error ?? "Broker execution failed")
+        }
+    }
+
+    package func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        switch outcome {
+        case .success(let payload):
+            try container.encode(true, forKey: .ok)
+            if payload == .null {
+                try container.encodeNil(forKey: .payload)
+            } else {
+                try container.encode(payload, forKey: .payload)
+            }
+        case .failure(let payload, let message):
+            try container.encode(false, forKey: .ok)
+            try container.encodeIfPresent(payload, forKey: .payload)
+            try container.encodeIfPresent(message, forKey: .error)
+        }
+        try container.encode(shouldExit, forKey: .shouldExit)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case ok
+        case payload
+        case error
+        case shouldExit
     }
 }
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -232,28 +232,21 @@ package actor AgentBrokerService {
                 shouldExit = false
             }
 
-            return AgentBrokerResponse(
+            return AgentBrokerResponse.success(
                 id: request.id,
-                ok: true,
                 payload: payload,
-                error: nil,
                 shouldExit: shouldExit
             )
         } catch let error as BrokerSessionInactiveError {
-            return AgentBrokerResponse(
+            return AgentBrokerResponse.failure(
                 id: request.id,
-                ok: false,
                 payload: error.brokerPayload(),
-                error: error.localizedDescription,
-                shouldExit: false
+                message: error.localizedDescription
             )
         } catch {
-            return AgentBrokerResponse(
+            return AgentBrokerResponse.failure(
                 id: request.id,
-                ok: false,
-                payload: nil,
-                error: error.localizedDescription,
-                shouldExit: false
+                message: error.localizedDescription
             )
         }
     }

--- a/Sources/WaxCLI/DaemonCommand.swift
+++ b/Sources/WaxCLI/DaemonCommand.swift
@@ -265,13 +265,12 @@ private extension DaemonCommand {
                 let request = try JSONDecoder().decode(AgentBrokerRequest.self, from: Data(line.utf8))
                 response = await service.handle(request)
             } catch {
-                response = AgentBrokerResponse(
-                    ok: false,
-                    error: "Invalid request: \(error.localizedDescription)"
+                response = AgentBrokerResponse.failure(
+                    message: "Invalid request: \(error.localizedDescription)"
                 )
             }
         } else {
-            response = AgentBrokerResponse(ok: false, error: "Invalid request: empty payload")
+            response = AgentBrokerResponse.failure(message: "Invalid request: empty payload")
         }
 
         try writeJSONLine(response, to: fileHandle)
@@ -291,9 +290,8 @@ private extension DaemonCommand {
         do {
             request = try JSONDecoder().decode(AgentBrokerRequest.self, from: Data(trimmed.utf8))
         } catch {
-            let response = AgentBrokerResponse(
-                ok: false,
-                error: "Invalid request: \(error.localizedDescription)"
+            let response = AgentBrokerResponse.failure(
+                message: "Invalid request: \(error.localizedDescription)"
             )
             try writeJSONLine(response, to: output)
             return

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -98,17 +98,13 @@ enum WaxMCPTools {
             case .failure(let payload, let message):
                 if let fields = payload?.objectValue,
                    let code = fields["code"]?.stringValue {
-                    let failureMessage = message
-                        ?? fields["reason"]?.stringValue
-                        ?? "Broker execution failed"
                     return structuredErrorResult(
-                        message: failureMessage,
+                        message: message,
                         code: code,
                         fields: fields
                     )
                 }
-                let failureMessage = message ?? "Broker execution failed"
-                return errorResult(message: failureMessage, code: errorCode(for: failureMessage))
+                return errorResult(message: message, code: errorCode(for: message))
             case .success:
                 guard let payload = response.payload else {
                     return errorResult(message: "Broker returned an empty payload", code: "execution_failed")

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -94,27 +94,28 @@ enum WaxMCPTools {
                 )
             )
 
-            guard response.ok else {
-                if let payload = response.payload?.objectValue,
-                   let code = payload["code"]?.stringValue {
-                    let message = response.error
-                        ?? payload["reason"]?.stringValue
+            switch response.outcome {
+            case .failure(let payload, let message):
+                if let fields = payload?.objectValue,
+                   let code = fields["code"]?.stringValue {
+                    let failureMessage = message
+                        ?? fields["reason"]?.stringValue
                         ?? "Broker execution failed"
                     return structuredErrorResult(
-                        message: message,
+                        message: failureMessage,
                         code: code,
-                        fields: payload
+                        fields: fields
                     )
                 }
-                let message = response.error ?? "Broker execution failed"
-                return errorResult(message: message, code: errorCode(for: message))
+                let failureMessage = message ?? "Broker execution failed"
+                return errorResult(message: failureMessage, code: errorCode(for: failureMessage))
+            case .success:
+                guard let payload = response.payload else {
+                    return errorResult(message: "Broker returned an empty payload", code: "execution_failed")
+                }
+                sessionHint?.remember(name: params.name, payload: payload)
+                return renderResult(name: params.name, payload: payload, verbosity: verbosity)
             }
-
-            guard let payload = response.payload else {
-                return errorResult(message: "Broker returned an empty payload", code: "execution_failed")
-            }
-            sessionHint?.remember(name: params.name, payload: payload)
-            return renderResult(name: params.name, payload: payload, verbosity: verbosity)
         } catch let error as ToolValidationError {
             return errorResult(message: error.localizedDescription, code: "invalid_arguments")
         } catch {

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -84,12 +84,26 @@ func agentBrokerResponseWireFormatMatchesLegacyShape() throws {
     )
     #expect(decodedSuccess == success)
 
+    let successNullPayload = AgentBrokerResponse.success(payload: .null)
+    #expect(
+        String(data: try encoder.encode(successNullPayload), encoding: .utf8)
+            == #"{"ok":true,"payload":null,"shouldExit":false}"#
+    )
+
     let decodedLegacyEmptyPayload = try decoder.decode(
         AgentBrokerResponse.self,
         from: Data(#"{"id":"req-4","ok":true,"shouldExit":false}"#.utf8)
     )
     #expect(decodedLegacyEmptyPayload.ok)
     #expect(decodedLegacyEmptyPayload.payload == nil)
+
+    let decodedLegacyFailureWithoutError = try decoder.decode(
+        AgentBrokerResponse.self,
+        from: Data(#"{"id":"req-5","ok":false,"shouldExit":false}"#.utf8)
+    )
+    #expect(!decodedLegacyFailureWithoutError.ok)
+    #expect(decodedLegacyFailureWithoutError.error == "Broker execution failed")
+    #expect(decodedLegacyFailureWithoutError.payload == nil)
 
     let decodedFailure = try decoder.decode(
         AgentBrokerResponse.self,

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -42,6 +42,65 @@ private func withAgentBrokerService<T>(
 }
 
 @Test
+func agentBrokerResponseWireFormatMatchesLegacyShape() throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+
+    let success = AgentBrokerResponse.success(
+        id: "req-1",
+        payload: .object(["status": .string("ok")])
+    )
+    #expect(
+        String(data: try encoder.encode(success), encoding: .utf8)
+            == #"{"id":"req-1","ok":true,"payload":{"status":"ok"},"shouldExit":false}"#
+    )
+
+    let successNoID = AgentBrokerResponse.success(payload: .object([:]), shouldExit: true)
+    #expect(
+        String(data: try encoder.encode(successNoID), encoding: .utf8)
+            == #"{"ok":true,"payload":{},"shouldExit":true}"#
+    )
+
+    let failure = AgentBrokerResponse.failure(
+        id: "req-2",
+        payload: .object(["code": .string("bad_request")]),
+        message: "unsupported argument"
+    )
+    #expect(
+        String(data: try encoder.encode(failure), encoding: .utf8)
+            == #"{"error":"unsupported argument","id":"req-2","ok":false,"payload":{"code":"bad_request"},"shouldExit":false}"#
+    )
+
+    let failureNoPayload = AgentBrokerResponse.failure(id: "req-3", message: "boom")
+    #expect(
+        String(data: try encoder.encode(failureNoPayload), encoding: .utf8)
+            == #"{"error":"boom","id":"req-3","ok":false,"shouldExit":false}"#
+    )
+
+    let decoder = JSONDecoder()
+    let decodedSuccess = try decoder.decode(
+        AgentBrokerResponse.self,
+        from: Data(#"{"id":"req-1","ok":true,"payload":{"status":"ok"},"shouldExit":false}"#.utf8)
+    )
+    #expect(decodedSuccess == success)
+
+    let decodedLegacyEmptyPayload = try decoder.decode(
+        AgentBrokerResponse.self,
+        from: Data(#"{"id":"req-4","ok":true,"shouldExit":false}"#.utf8)
+    )
+    #expect(decodedLegacyEmptyPayload.ok)
+    #expect(decodedLegacyEmptyPayload.payload == nil)
+
+    let decodedFailure = try decoder.decode(
+        AgentBrokerResponse.self,
+        from: Data(
+            #"{"id":"req-2","ok":false,"payload":{"code":"bad_request"},"error":"unsupported argument","shouldExit":false}"#.utf8
+        )
+    )
+    #expect(decodedFailure == failure)
+}
+
+@Test
 func brokerRejectsInvalidEmbedderChoice() async throws {
     let rootURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("wax-broker-invalid-embedder-\(UUID().uuidString)", isDirectory: true)
@@ -314,7 +373,7 @@ private final class UnixStatsResponder: @unchecked Sendable {
             return
         }
 
-        let response = AgentBrokerResponse(id: "__ping__", ok: true, payload: .object([:]))
+        let response = AgentBrokerResponse.success(id: "__ping__", payload: .object([:]))
         guard let payload = try? JSONEncoder().encode(response) else {
             close(client)
             return


### PR DESCRIPTION
## Summary
Refactors the package-internal `AgentBrokerResponse` from a weak field set
`{id, ok: Bool, payload: AgentBrokerValue?, error: String?, shouldExit: Bool}` — where
`ok: true` + `error` and other invalid combinations were representable — to a struct
carrying an exclusive `enum Outcome { case success(payload:); case failure(payload:, message:) }`.

- Custom `Codable` preserves the legacy JSON wire shape exactly (`id`/`ok`/`payload`/`error`/`shouldExit`, nil fields omitted), so the broker socket protocol consumed by wax-cli, wax-mcp, and Hermes is unchanged. A golden test (`agentBrokerResponseWireFormatMatchesLegacyShape`) pins the wire contract, including `.null` payload encoding and legacy `{"ok":false}` decoding.
- Consumers (`AgentBrokerService.handle`, `WaxCLI/DaemonCommand`, `WaxMCPServer/WaxMCPTools`) now construct via `.success`/`.failure` factories; MCP failure handling switches on the outcome, which removed dead nil-coalescing fallbacks.
- Computed `ok`/`payload`/`error` accessors keep remaining read sites unchanged, preserving the empty-payload error path semantics in `WaxMCPTools`.

No public API change (`package` access only); no behavior change.

## Spec
Candidate 01 (result-shaped broker responses) of the Swift type-system architecture review; ticket T1 in `/tmp/spec-architecture-broker-response-outcome.md`.

## Validation
- `swift build --traits MCPServer` — clean, zero warnings
- `swift test --traits MCPServer --filter WaxMCPServerTests` — 166/168 pass; the 2 failures (`brokerSessionStartAppendsStartedEventBeforeSavingManifest`, `brokerSessionEndKeepsActiveSessionUntilPersistenceSucceeds`) are pre-existing on main (verified via baseline run)
- `swift test --filter WaxCLITests` — 51/52 pass; 1 pre-existing baseline failure (WaxCLIDemoTests ANSI-coloring demo test)

## Review
Fresh-context reviewers (implementer separate): `swift-pr-review` method, fix-allowed pass (commit 0f6e09767 fixes) + final verification pass (verdict: CLEAN).