### PR TITLE
Unify vector watermark/ghost bookkeeping in a single owner

### DIFF
--- a/Sources/Wax/VectorSearchSession.swift
+++ b/Sources/Wax/VectorSearchSession.swift
@@ -136,26 +136,45 @@ package actor WaxVectorSearchSession {
     }
 
     package func stageForCommit() async throws {
-        let snapshot = await wax.pendingEmbeddingMutations(since: lastPendingEmbeddingSequence)
+        lastPendingEmbeddingSequence = try await Self.syncPendingEmbeddings(
+            wax: wax,
+            into: concreteEngine,
+            watermark: lastPendingEmbeddingSequence,
+            removedFrameIds: pendingRemovedFrameIds
+        )
+        try await stageEngineForCommit()
+        pendingRemovedFrameIds.removeAll(keepingCapacity: true)
+    }
+
+    /// Single owner of vector-index watermark advance + ghost-frame removal bookkeeping,
+    /// shared by ``WaxVectorSearchSession`` and ``WaxSession``.
+    ///
+    /// Syncs pending embeddings into `engine` since `watermark` (replaying the full log when
+    /// the store rolled back), then re-applies `removedFrameIds` so pending putEmbedding cannot
+    /// resurrect deleted frames. Returns the advanced watermark; on throw no caller state moves.
+    /// Callers re-stage the engine themselves and clear their ghost set only after success.
+    static func syncPendingEmbeddings(
+        wax: Wax,
+        into engine: LoadedVectorSearchEngine,
+        watermark: UInt64?,
+        removedFrameIds: Set<UInt64> = []
+    ) async throws -> UInt64? {
+        var snapshot = await wax.pendingEmbeddingMutations(since: watermark)
         if let latest = snapshot.latestSequence,
-           let last = lastPendingEmbeddingSequence,
+           let last = watermark,
            latest < last {
-            lastPendingEmbeddingSequence = nil
+            snapshot = await wax.pendingEmbeddingMutations(since: nil)
         }
         if !snapshot.embeddings.isEmpty {
-            try await addBatchToEngine(
+            try await engine.addBatch(
                 frameIds: snapshot.embeddings.map(\.frameId),
                 vectors: snapshot.embeddings.map(\.vector)
             )
         }
-        if !pendingRemovedFrameIds.isEmpty {
-            for frameId in pendingRemovedFrameIds {
-                try await removeFromEngine(frameId: frameId)
-            }
+        for frameId in removedFrameIds {
+            try await engine.remove(frameId: frameId)
         }
-        lastPendingEmbeddingSequence = snapshot.latestSequence
-        try await stageEngineForCommit()
-        pendingRemovedFrameIds.removeAll(keepingCapacity: true)
+        return snapshot.latestSequence
     }
 
     private func addToEngine(frameId: UInt64, vector: [Float]) async throws {

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -53,7 +53,6 @@ package actor WaxSession {
     private var concreteVectorEngine: ConcreteVectorEngine?
     private var lastPendingEmbeddingSequence: UInt64?
     /// Frame IDs removed from the vector index that must be re-applied after syncing pending embeddings.
-    /// Mirrors ``WaxVectorSearchSession`` so pending putEmbedding + remove does not re-stage ghosts.
     private var pendingRemovedFrameIds: Set<UInt64> = []
     private var writerLeaseId: UUID?
     private var isClosed = false
@@ -511,15 +510,12 @@ package actor WaxSession {
     }
 
     private func stageVectorForCommit(using engine: ConcreteVectorEngine) async throws {
-        try await syncPendingEmbeddings(into: engine)
-        // Re-apply removes after sync so pending embeddings cannot resurrect deleted frameIds.
-        // Clear only after a successful stage so a failed stage can re-apply on the next attempt
-        // (mirrors ``WaxVectorSearchSession.stageForCommit``).
-        if !pendingRemovedFrameIds.isEmpty {
-            for frameId in pendingRemovedFrameIds {
-                try await engine.remove(frameId: frameId)
-            }
-        }
+        lastPendingEmbeddingSequence = try await WaxVectorSearchSession.syncPendingEmbeddings(
+            wax: wax,
+            into: engine,
+            watermark: lastPendingEmbeddingSequence,
+            removedFrameIds: pendingRemovedFrameIds
+        )
         try await engine.stageForCommit(into: wax)
         pendingRemovedFrameIds.removeAll(keepingCapacity: true)
     }
@@ -540,31 +536,12 @@ package actor WaxSession {
             return vectorEngine
         }
 
-        try await syncPendingEmbeddings(into: concreteVectorEngine)
+        lastPendingEmbeddingSequence = try await WaxVectorSearchSession.syncPendingEmbeddings(
+            wax: wax,
+            into: concreteVectorEngine,
+            watermark: lastPendingEmbeddingSequence
+        )
         return concreteVectorEngine.erased
-    }
-
-    private func syncPendingEmbeddings(into engine: ConcreteVectorEngine) async throws {
-        var sinceSequence = lastPendingEmbeddingSequence
-        var snapshot = await wax.pendingEmbeddingMutations(since: sinceSequence)
-        if let latest = snapshot.latestSequence,
-           let last = sinceSequence,
-           latest < last {
-            sinceSequence = nil
-            snapshot = await wax.pendingEmbeddingMutations(since: nil)
-        }
-        if !snapshot.embeddings.isEmpty {
-            var frameIds: [UInt64] = []
-            var vectors: [[Float]] = []
-            frameIds.reserveCapacity(snapshot.embeddings.count)
-            vectors.reserveCapacity(snapshot.embeddings.count)
-            for embedding in snapshot.embeddings {
-                frameIds.append(embedding.frameId)
-                vectors.append(embedding.vector)
-            }
-            try await engine.addBatch(frameIds: frameIds, vectors: vectors)
-        }
-        lastPendingEmbeddingSequence = snapshot.latestSequence
     }
 
     private static func resolveVectorDimensions(for wax: Wax, config: Config) async throws -> Int? {


### PR DESCRIPTION
Ticket **T3b** of spec `swift-arch-waxfe01` (functional-core hardening).

## What
Exactly one implementation of vector-index watermark advance + ghost-frame re-application, owned by `WaxVectorSearchSession.syncPendingEmbeddings(...)` (internal static). All three call shapes route through it (VSS stageForCommit w/ ghosts; WaxSession stage path w/ ghosts; search-freshness sync-only). Mirror comment + duplicate in `WaxSession` deleted (+41/−45).

Resolves pre-existing drift between the two copies by adopting the immediate-refetch-on-rollback variant; replay proven idempotent (addBatch upserts by frameId; remove tolerates missing ids — Accelerate + MetalANNS both verified).

## Verification
swift build clean · WaxSessionTests 7/7 · VideoRAGDeleteVectorDurability 3/3 · VectorSearchEngineTests 27/27 · MemoryDeleteVectorDurability = exact pre-existing base failure set (5 ids confirmed identical on pristine base worktree).

Review chain: implement → fresh `swift-pr-review` (4 findings dismissed-with-reason after tree verification) → fresh final pass spot-checking every dismissal. Verdicts READY.