### PR TITLE
refactor(broker): centralize command catalog

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,3 +35,7 @@ _Avoid_: default store, global Memory, durable store (as the store name; durable
 **Virtual session store**:
 A per-session memory store, distinct from long-term Memory, identified by `session_id`. It is its own store, not a metadata slice of long-term Memory. An omitted `session_id` means no virtual session: lookup does not infer one and does not create one. The same `agent_id` and `run_id` pair reuses the active store; one id is not enough; an ended store is not reused.
 _Avoid_: Compat session, MCP session registry, `metadata.session_id` (as the store)
+
+**Command catalog**:
+The canonical vocabulary of executable broker commands, their broker-valid aliases, and their accepted argument surfaces, independent of MCP presentation.
+_Avoid_: tool schema, transport schema, command handler

--- a/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
+++ b/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
@@ -1,71 +1,181 @@
 import Foundation
 
 package enum AgentBrokerCommandSurface {
+    package enum Exposure: Sendable, Equatable {
+        case publicCommand
+        case control
+    }
+
+    package struct Entry: Sendable, Equatable {
+        package let canonicalName: String
+        package let aliases: Set<String>
+        package let acceptedArgumentKeys: Set<String>
+        package let exposure: Exposure
+        package let requiresStructuredMemory: Bool
+
+        package var acceptedNames: Set<String> {
+            aliases.union([canonicalName])
+        }
+
+        package init(
+            canonicalName: String,
+            aliases: Set<String> = [],
+            acceptedArgumentKeys: Set<String>,
+            exposure: Exposure = .publicCommand,
+            requiresStructuredMemory: Bool = false
+        ) {
+            self.canonicalName = canonicalName
+            self.aliases = aliases
+            self.acceptedArgumentKeys = acceptedArgumentKeys
+            self.exposure = exposure
+            self.requiresStructuredMemory = requiresStructuredMemory
+        }
+    }
+
     package static let corpusSearchDefaultRebuild = false
 
-    package static let publicCommandArguments: [String: Set<String>] = [
-        "memory_append": ["content", "session_id", "metadata", "memory_type", "durability", "project", "repo", "confidence", "expires_in_days", "reviewed", "locked", "cwd", "scope", "verbosity"],
-        "memory_search": ["query", "topK", "session_id", "mode", "alpha", "include_working", "include_episodic", "include_durable"],
-        "memory_get": ["memory_id"],
-        "remember": ["content", "session_id", "metadata", "memory_type", "durability", "project", "repo", "confidence", "expires_in_days", "reviewed", "locked", "cwd", "scope", "verbosity"],
-        "recall": ["query", "limit", "session_id", "mode", "alpha", "search_top_k", "topK", "filters", "project", "repo", "scope", "cwd", "verbosity"],
-        "search": ["query", "mode", "topK", "session_id", "alpha", "filters"],
-        "session_synthesize": ["session_id", "minimum_confidence", "minimum_recall_count", "max_candidates"],
-        "memory_promote": ["session_id", "frame_id", "content", "metadata", "memory_type", "durability", "project", "repo", "confidence", "expires_in_days", "reviewed", "locked", "approve", "minimum_confidence", "minimum_recall_count", "max_candidates"],
-        "promote": ["session_id", "frame_id", "content", "metadata", "memory_type", "durability", "project", "repo", "confidence", "expires_in_days", "reviewed", "locked", "approve", "minimum_confidence", "minimum_recall_count", "max_candidates"],
-        "memory_health": [],
-        "knowledge_capture": ["content", "metadata", "memory_type", "durability", "project", "repo", "confidence", "reviewed", "locked", "subject", "kind", "aliases", "predicate", "object", "cwd"],
-        "corpus_search": ["query", "rebuild", "recursive", "mode", "alpha", "topK"],
-        "stats": ["session_id"],
-        "session_start": ["session_id", "agent_id", "run_id", "cwd", "project", "repo"],
-        "session_resume": ["session_id", "agent_id", "run_id"],
-        "session_end": ["session_id"],
-        "session_close": ["session_id", "content", "project", "pending_tasks"],
-        "session_open": ["project", "repo", "agent_id", "run_id", "recall_query", "cwd"],
-        "handoff": ["content", "session_id", "project", "pending_tasks"],
-        "handoff_latest": ["project"],
-        "compact_context": ["query", "session_id", "token_budget", "max_items", "mode", "alpha"],
-        "markdown_export": ["output_dir", "session_id", "project", "all_projects", "cwd"],
-        "markdown_sync": ["root_dir", "dry_run"],
-        "entity_upsert": ["key", "kind", "aliases"],
-        "fact_assert": ["subject", "predicate", "object", "relation", "valid_from", "valid_to", "evidence"],
-        "fact_retract": ["fact_id", "at_ms"],
-        "facts_query": ["subject", "predicate", "as_of", "system_as_of", "valid_as_of", "limit"],
-        "entity_resolve": ["alias", "limit"],
+    private static let catalog: [Entry] = [
+        Entry(
+            canonicalName: "remember",
+            aliases: ["memory_append"],
+            acceptedArgumentKeys: [
+                "content", "session_id", "metadata", "memory_type", "durability", "project", "repo",
+                "confidence", "expires_in_days", "reviewed", "locked", "cwd", "scope", "verbosity",
+            ]
+        ),
+        Entry(
+            canonicalName: "memory_search",
+            acceptedArgumentKeys: [
+                "query", "topK", "session_id", "mode", "alpha", "include_working", "include_episodic",
+                "include_durable",
+            ]
+        ),
+        Entry(canonicalName: "memory_get", acceptedArgumentKeys: ["memory_id"]),
+        Entry(
+            canonicalName: "recall",
+            acceptedArgumentKeys: [
+                "query", "limit", "session_id", "mode", "alpha", "search_top_k", "topK", "filters",
+                "project", "repo", "scope", "cwd", "verbosity",
+            ]
+        ),
+        Entry(canonicalName: "search", acceptedArgumentKeys: ["query", "mode", "topK", "session_id", "alpha", "filters"]),
+        Entry(canonicalName: "session_synthesize", acceptedArgumentKeys: ["session_id", "minimum_confidence", "minimum_recall_count", "max_candidates"]),
+        Entry(canonicalName: "memory_promote", acceptedArgumentKeys: [
+            "session_id", "frame_id", "content", "metadata", "memory_type", "durability", "project", "repo",
+            "confidence", "expires_in_days", "reviewed", "locked", "approve", "minimum_confidence",
+            "minimum_recall_count", "max_candidates",
+        ]),
+        Entry(canonicalName: "promote", acceptedArgumentKeys: [
+            "session_id", "frame_id", "content", "metadata", "memory_type", "durability", "project", "repo",
+            "confidence", "expires_in_days", "reviewed", "locked", "approve", "minimum_confidence",
+            "minimum_recall_count", "max_candidates",
+        ]),
+        Entry(canonicalName: "memory_health", acceptedArgumentKeys: []),
+        Entry(canonicalName: "knowledge_capture", acceptedArgumentKeys: [
+            "content", "metadata", "memory_type", "durability", "project", "repo", "confidence", "reviewed",
+            "locked", "subject", "kind", "aliases", "predicate", "object", "cwd",
+        ], requiresStructuredMemory: true),
+        Entry(canonicalName: "corpus_search", acceptedArgumentKeys: ["query", "rebuild", "recursive", "mode", "alpha", "topK"]),
+        Entry(canonicalName: "stats", acceptedArgumentKeys: ["session_id"]),
+        Entry(canonicalName: "session_start", acceptedArgumentKeys: ["session_id", "agent_id", "run_id", "cwd", "project", "repo"]),
+        Entry(canonicalName: "session_resume", acceptedArgumentKeys: ["session_id", "agent_id", "run_id"]),
+        Entry(canonicalName: "session_end", acceptedArgumentKeys: ["session_id"]),
+        Entry(canonicalName: "session_close", acceptedArgumentKeys: ["session_id", "content", "project", "pending_tasks"]),
+        Entry(canonicalName: "session_open", acceptedArgumentKeys: ["project", "repo", "agent_id", "run_id", "recall_query", "cwd"]),
+        Entry(canonicalName: "handoff", acceptedArgumentKeys: ["content", "session_id", "project", "pending_tasks"]),
+        Entry(canonicalName: "handoff_latest", acceptedArgumentKeys: ["project"]),
+        Entry(canonicalName: "compact_context", acceptedArgumentKeys: ["query", "session_id", "token_budget", "max_items", "mode", "alpha"]),
+        Entry(canonicalName: "markdown_export", acceptedArgumentKeys: ["output_dir", "session_id", "project", "all_projects", "cwd"]),
+        Entry(canonicalName: "markdown_sync", acceptedArgumentKeys: ["root_dir", "dry_run"]),
+        Entry(canonicalName: "entity_upsert", acceptedArgumentKeys: ["key", "kind", "aliases"], requiresStructuredMemory: true),
+        Entry(canonicalName: "fact_assert", acceptedArgumentKeys: ["subject", "predicate", "object", "relation", "valid_from", "valid_to", "evidence"], requiresStructuredMemory: true),
+        Entry(canonicalName: "fact_retract", acceptedArgumentKeys: ["fact_id", "at_ms"], requiresStructuredMemory: true),
+        Entry(canonicalName: "facts_query", acceptedArgumentKeys: ["subject", "predicate", "as_of", "system_as_of", "valid_as_of", "limit"], requiresStructuredMemory: true),
+        Entry(canonicalName: "entity_resolve", acceptedArgumentKeys: ["alias", "limit"], requiresStructuredMemory: true),
+        Entry(canonicalName: "flush", acceptedArgumentKeys: [], exposure: .control),
+        Entry(canonicalName: "shutdown", aliases: ["exit", "quit"], acceptedArgumentKeys: [], exposure: .control),
     ]
 
-    private static let controlCommandArguments: [String: Set<String>] = [
-        "flush": [],
-        "shutdown": [],
-        "exit": [],
-        "quit": [],
-    ]
-
-    package static let commandArguments: [String: Set<String>] = {
-        publicCommandArguments.merging(controlCommandArguments) { publicArguments, _ in
-            publicArguments
+    private static let lookup: [String: Entry] = {
+        var result: [String: Entry] = [:]
+        for entry in catalog {
+            for name in entry.acceptedNames {
+                precondition(result.updateValue(entry, forKey: name) == nil, "Duplicate broker command '\(name)'")
+            }
         }
+        return result
     }()
 
+    package static var allEntries: [Entry] {
+        catalog
+    }
+
+    package static var publicEntries: [Entry] {
+        catalog.filter { $0.exposure == .publicCommand }
+    }
+
+    package static var publicCommandNames: Set<String> {
+        Set(publicEntries.flatMap(\.acceptedNames))
+    }
+
+    package static let publicCommandArguments: [String: Set<String>] = commandArguments(for: .publicCommand)
+
+    package static let commandArguments: [String: Set<String>] = {
+        commandArguments(for: nil)
+    }()
+
+    private static func commandArguments(for exposure: Exposure?) -> [String: Set<String>] {
+        catalog
+            .filter { exposure == nil || $0.exposure == exposure }
+            .reduce(into: [String: Set<String>]()) { result, entry in
+                for name in entry.acceptedNames {
+                    result[name] = entry.acceptedArgumentKeys
+                }
+            }
+    }
+
+    package static func entry(for command: String) -> Entry? {
+        lookup[normalize(command)]
+    }
+
+    package static func canonicalCommand(for command: String) -> String? {
+        entry(for: command)?.canonicalName
+    }
+
+    package static func isPublicCommand(_ command: String) -> Bool {
+        entry(for: command)?.exposure == .publicCommand
+    }
+
+    package static func requiresStructuredMemory(_ command: String) -> Bool {
+        entry(for: command)?.requiresStructuredMemory == true
+    }
+
     package static func allowedPublicArguments(for command: String) -> Set<String>? {
-        publicCommandArguments[command.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()]
+        guard let entry = entry(for: command), entry.exposure == .publicCommand else { return nil }
+        return entry.acceptedArgumentKeys
     }
 
     package static func allowedArguments(for command: String) -> Set<String>? {
-        commandArguments[command.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()]
+        entry(for: command)?.acceptedArgumentKeys
     }
 
+    @discardableResult
     package static func validateArgumentSurface(
         command: String,
         providedKeys: Set<String>
-    ) throws {
-        guard let allowed = allowedArguments(for: command) else {
+    ) throws -> Entry {
+        guard let entry = entry(for: command) else {
             throw BrokerValidationError.invalid("Unknown broker command '\(command)'.")
         }
 
-        let unknown = providedKeys.subtracting(allowed)
+        let unknown = providedKeys.subtracting(entry.acceptedArgumentKeys)
         guard unknown.isEmpty else {
             throw BrokerValidationError.invalid("unsupported argument(s): \(unknown.sorted().joined(separator: ", "))")
         }
+        return entry
+    }
+
+    private static func normalize(_ command: String) -> String {
+        command.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -146,9 +146,6 @@ package actor AgentBrokerService {
             case .remember(let command):
                 payload = try await remember(command)
                 shouldExit = false
-            case .memoryAppend(let command):
-                payload = try await remember(command)
-                shouldExit = false
             case .recall(let command):
                 payload = try await recall(command)
                 shouldExit = false

--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -6,7 +6,6 @@ import Foundation
 /// payloads and do not re-parse argument bags.
 package enum BrokerCommand: Sendable, Equatable {
     case remember(Remember)
-    case memoryAppend(Remember)
     case recall(Recall)
     case search(Search)
     case memorySearch(MemorySearch)
@@ -243,17 +242,15 @@ package enum BrokerCommand: Sendable, Equatable {
         command rawCommand: String,
         arguments: [String: AgentBrokerValue]
     ) throws -> BrokerCommand {
-        let command = rawCommand.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        try AgentBrokerCommandSurface.validateArgumentSurface(
-            command: command,
+        let entry = try AgentBrokerCommandSurface.validateArgumentSurface(
+            command: rawCommand,
             providedKeys: Set(arguments.keys)
         )
+        let command = entry.canonicalName
         let args = BrokerArguments(arguments)
         switch command {
         case "remember":
             return .remember(try Remember.decode(args))
-        case "memory_append":
-            return .memoryAppend(try Remember.decode(args))
         case "recall":
             return .recall(try Recall.decode(args))
         case "search":
@@ -286,7 +283,7 @@ package enum BrokerCommand: Sendable, Equatable {
             return .entityResolve(try EntityResolve.decode(args))
         case "fact_retract":
             return .factRetract(try FactRetract.decode(args))
-        case "shutdown", "exit", "quit":
+        case "shutdown":
             return .shutdown
         case "session_synthesize":
             return .sessionSynthesize(try SessionSynthesize.decode(args))

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -121,40 +121,41 @@ enum ToolSchemas {
         ),
         ]
 
-        if structuredMemoryEnabled {
-            tools.append(contentsOf: [
-                Tool(
-                    name: "knowledge_capture",
-                    description: "Capture durable knowledge from a natural statement and optionally upsert related entity/fact records.",
-                    inputSchema: waxKnowledgeCapture
-                ),
-                Tool(
-                    name: "entity_upsert",
-                    description: "Upsert a stable structured-memory entity by key. Use for durable graph nodes, not transient debug notes.",
-                    inputSchema: waxEntityUpsert
-                ),
-                Tool(
-                    name: "fact_assert",
-                    description: "Assert a structured-memory fact that can later be retracted. Prefer over free-text remember for stable true/false relations.",
-                    inputSchema: waxFactAssert
-                ),
-                Tool(
-                    name: "fact_retract",
-                    description: "Retract (soft-delete) a structured-memory fact by id when corrected or obsolete.",
-                    inputSchema: waxFactRetract
-                ),
-                Tool(
-                    name: "facts_query",
-                    description: "Query structured-memory facts for stable knowledge-graph answers.",
-                    inputSchema: waxFactsQuery
-                ),
-                Tool(
-                    name: "entity_resolve",
-                    description: "Resolve structured-memory entities by alias before asserting related facts.",
-                    inputSchema: waxEntityResolve
-                ),
-            ])
-        }
+        let structuredTools: [Tool] = [
+            Tool(
+                name: "knowledge_capture",
+                description: "Capture durable knowledge from a natural statement and optionally upsert related entity/fact records.",
+                inputSchema: waxKnowledgeCapture
+            ),
+            Tool(
+                name: "entity_upsert",
+                description: "Upsert a stable structured-memory entity by key. Use for durable graph nodes, not transient debug notes.",
+                inputSchema: waxEntityUpsert
+            ),
+            Tool(
+                name: "fact_assert",
+                description: "Assert a structured-memory fact that can later be retracted. Prefer over free-text remember for stable true/false relations.",
+                inputSchema: waxFactAssert
+            ),
+            Tool(
+                name: "fact_retract",
+                description: "Retract (soft-delete) a structured-memory fact by id when corrected or obsolete.",
+                inputSchema: waxFactRetract
+            ),
+            Tool(
+                name: "facts_query",
+                description: "Query structured-memory facts for stable knowledge-graph answers.",
+                inputSchema: waxFactsQuery
+            ),
+            Tool(
+                name: "entity_resolve",
+                description: "Resolve structured-memory entities by alias before asserting related facts.",
+                inputSchema: waxEntityResolve
+            ),
+        ]
+        tools.append(contentsOf: structuredTools.filter { tool in
+            structuredMemoryEnabled || !AgentBrokerCommandSurface.requiresStructuredMemory(tool.name)
+        })
 
         return tools
     }

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -155,7 +155,6 @@ final class MCPClientSessionHint: @unchecked Sendable {
 
 private extension WaxMCPTools {
     static let readOnlyTextCommands: Set<String> = ["recall", "search", "memory_search", "memory_get", "compact_context", "corpus_search", "session_synthesize", "memory_health"]
-    static let structuredCommands: Set<String> = ["knowledge_capture", "entity_upsert", "fact_assert", "fact_retract", "facts_query", "entity_resolve"]
     static let clientCWDCommands: Set<String> = [
         "session_start", "session_open", "remember", "memory_append", "knowledge_capture",
         "markdown_export", "recall",
@@ -194,11 +193,11 @@ private extension WaxMCPTools {
     }
 
     static func validateToolAvailability(name: String, structuredMemoryEnabled: Bool) throws {
-        if structuredCommands.contains(name), !structuredMemoryEnabled {
-            throw ToolValidationError.invalid("tool '\(name)' requires structured memory to be enabled")
-        }
-        guard AgentBrokerCommandSurface.allowedPublicArguments(for: name) != nil else {
+        guard let entry = AgentBrokerCommandSurface.entry(for: name), entry.exposure == .publicCommand else {
             throw ToolValidationError.invalid("Unknown tool '\(name)'.")
+        }
+        if entry.requiresStructuredMemory, !structuredMemoryEnabled {
+            throw ToolValidationError.invalid("tool '\(name)' requires structured memory to be enabled")
         }
     }
 

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -476,6 +476,22 @@ func toolsListHonorsStructuredMemoryFlag() {
 }
 
 @Test
+func toolSchemasStayWithinCommandCatalogSurface() {
+    let tools = ToolSchemas.allTools
+    let toolNames = Set(tools.map(\.name))
+    #expect(toolNames == AgentBrokerCommandSurface.publicCommandNames)
+
+    for tool in tools {
+        guard let entry = AgentBrokerCommandSurface.entry(for: tool.name) else {
+            Issue.record("Tool '\(tool.name)' is missing from the command catalog")
+            continue
+        }
+        #expect(entry.exposure == .publicCommand)
+        #expect(schemaPropertyNames(tool.inputSchema).isSubset(of: entry.acceptedArgumentKeys))
+    }
+}
+
+@Test
 func toolSchemaRegression() {
     let tools = ToolSchemas.allTools
 
@@ -5401,6 +5417,15 @@ private func schemaMaximum(_ schema: Value, property: String) -> Double? {
     default:
         return nil
     }
+}
+
+private func schemaPropertyNames(_ schema: Value) -> Set<String> {
+    guard case .object(let root) = schema,
+          case .object(let properties)? = root["properties"]
+    else {
+        return []
+    }
+    return Set(properties.keys)
 }
 
 private func schemaEnum(_ schema: Value, property: String) -> [String]? {

--- a/Tests/WaxTests/BrokerCommandDecodeTests.swift
+++ b/Tests/WaxTests/BrokerCommandDecodeTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct BrokerCommandDecodeTests {
     @Test
-    func rememberAliasSharesPayloadShape() throws {
+    func rememberAliasCanonicalizesToOneTypedCommand() throws {
         let args: [String: AgentBrokerValue] = [
             "content": .string("  keep spaces  "),
             "session_id": .string("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"),
@@ -14,7 +14,7 @@ struct BrokerCommandDecodeTests {
         ]
         let remember = try BrokerCommand.decode(command: "remember", arguments: args)
         let append = try BrokerCommand.decode(command: "memory_append", arguments: args)
-        guard case .remember(let a) = remember, case .memoryAppend(let b) = append else {
+        guard case .remember(let a) = remember, case .remember(let b) = append else {
             Issue.record("alias mismatch")
             return
         }
@@ -23,6 +23,21 @@ struct BrokerCommandDecodeTests {
         #expect(a.sessionID == UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
         #expect(a.writeScope == .session)
         #expect(a.writeSemantics.type == .decision)
+    }
+
+    @Test
+    func commandCatalogNormalizesAliasesAndStaticFacts() throws {
+        #expect(AgentBrokerCommandSurface.canonicalCommand(for: "  MEMORY_APPEND ") == "remember")
+        #expect(AgentBrokerCommandSurface.canonicalCommand(for: "QUIT") == "shutdown")
+        #expect(AgentBrokerCommandSurface.canonicalCommand(for: "wax_recall") == nil)
+        #expect(AgentBrokerCommandSurface.isPublicCommand("memory_append"))
+        #expect(!AgentBrokerCommandSurface.isPublicCommand("flush"))
+        #expect(AgentBrokerCommandSurface.requiresStructuredMemory("facts_query"))
+        #expect(!AgentBrokerCommandSurface.requiresStructuredMemory("recall"))
+
+        let rememberKeys = try #require(AgentBrokerCommandSurface.allowedArguments(for: "remember"))
+        let appendKeys = try #require(AgentBrokerCommandSurface.allowedArguments(for: "memory_append"))
+        #expect(rememberKeys == appendKeys)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Centralize broker command names, aliases, accepted argument keys, exposure, and structured-memory requirements in the existing command-surface module.
- Canonicalize behavior-preserving aliases into the existing typed BrokerCommand cases.
- Reuse the catalog for MCP availability and argument validation while keeping MCP descriptions, schema types, and curated ordering in ToolSchemas.
- Add command-catalog and MCP schema-parity tests.

## Verification

- PASS: `swift test --scratch-path /tmp/wax-command-catalog-test-20260822 --filter BrokerCommandDecodeTests` — 22 tests.
- PASS: `swift test --scratch-path /tmp/wax-command-catalog-test-20260822 --traits MCPServer --filter toolSchemasStayWithinCommandCatalogSurface` — 1 test.
- PASS: `git diff --check` and public-repository hygiene scan.
- The full MCP target ran 169 tests with two failures in existing VirtualSessionStore source-contract tests; VirtualSessionStore.swift is untouched by this PR.
- The full production gate ran 1306 tests with 11 failures outside this diff across the CLI demo, embedding readiness, vector deletion, surrogate sources, PDF ingest, and Video RAG. These are recorded as repository baseline residuals, not claimed as green.

Existing untracked `.ryk/` and `.skynex/` artifacts were preserved and are not part of this PR.