### PR TITLE
fix(mcp): cut response bloat and harden memory lifecycle

### DIFF
--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -30,6 +30,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - Never put `session_id` inside `metadata`.
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
+   - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
    - Call `session_end` (pass `session_id` when multiple sessions may be active).
    - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
@@ -46,6 +47,11 @@ Search mode guidance:
 
 - Prefer `mode: "hybrid"` when semantic recall helps.
 - Use `mode: "text"` for fast or deterministic lexical lookup.
+
+Response guidance:
+
+- Responses default to one compact JSON content block.
+- Pass `verbosity: "verbose"` only when narrative text plus standard MCP `structuredContent` is useful.
 
 ## Write Path
 

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -30,6 +30,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - Never put `session_id` inside `metadata`.
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
+   - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
    - Call `session_end` (pass `session_id` when multiple sessions may be active).
    - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
@@ -46,6 +47,11 @@ Search mode guidance:
 
 - Prefer `mode: "hybrid"` when semantic recall helps.
 - Use `mode: "text"` for fast or deterministic lexical lookup.
+
+Response guidance:
+
+- Responses default to one compact JSON content block.
+- Pass `verbosity: "verbose"` only when narrative text plus standard MCP `structuredContent` is useful.
 
 ## Write Path
 

--- a/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
+++ b/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
@@ -26,7 +26,9 @@ package enum AgentBrokerCommandSurface {
         ) {
             self.canonicalName = canonicalName
             self.aliases = aliases
-            self.acceptedArgumentKeys = acceptedArgumentKeys
+            self.acceptedArgumentKeys = exposure == .publicCommand
+                ? acceptedArgumentKeys.union(["verbosity"])
+                : acceptedArgumentKeys
             self.exposure = exposure
             self.requiresStructuredMemory = requiresStructuredMemory
         }
@@ -76,14 +78,14 @@ package enum AgentBrokerCommandSurface {
             "locked", "subject", "kind", "aliases", "predicate", "object", "cwd",
         ], requiresStructuredMemory: true),
         Entry(canonicalName: "corpus_search", acceptedArgumentKeys: ["query", "rebuild", "recursive", "mode", "alpha", "topK"]),
-        Entry(canonicalName: "stats", acceptedArgumentKeys: ["session_id"]),
-        Entry(canonicalName: "session_start", acceptedArgumentKeys: ["session_id", "agent_id", "run_id", "cwd", "project", "repo"]),
-        Entry(canonicalName: "session_resume", acceptedArgumentKeys: ["session_id", "agent_id", "run_id"]),
-        Entry(canonicalName: "session_end", acceptedArgumentKeys: ["session_id"]),
-        Entry(canonicalName: "session_close", acceptedArgumentKeys: ["session_id", "content", "project", "pending_tasks"]),
-        Entry(canonicalName: "session_open", acceptedArgumentKeys: ["project", "repo", "agent_id", "run_id", "recall_query", "cwd"]),
-        Entry(canonicalName: "handoff", acceptedArgumentKeys: ["content", "session_id", "project", "pending_tasks"]),
-        Entry(canonicalName: "handoff_latest", acceptedArgumentKeys: ["project"]),
+        Entry(canonicalName: "stats", acceptedArgumentKeys: ["session_id", "verbosity"]),
+        Entry(canonicalName: "session_start", acceptedArgumentKeys: ["session_id", "agent_id", "run_id", "cwd", "project", "repo", "verbosity"]),
+        Entry(canonicalName: "session_resume", acceptedArgumentKeys: ["session_id", "agent_id", "run_id", "verbosity"]),
+        Entry(canonicalName: "session_end", acceptedArgumentKeys: ["session_id", "verbosity"]),
+        Entry(canonicalName: "session_close", acceptedArgumentKeys: ["session_id", "content", "project", "pending_tasks", "verbosity"]),
+        Entry(canonicalName: "session_open", acceptedArgumentKeys: ["project", "repo", "agent_id", "run_id", "recall_query", "cwd", "verbosity"]),
+        Entry(canonicalName: "handoff", acceptedArgumentKeys: ["content", "session_id", "project", "pending_tasks", "verbosity"]),
+        Entry(canonicalName: "handoff_latest", acceptedArgumentKeys: ["project", "verbosity"]),
         Entry(canonicalName: "compact_context", acceptedArgumentKeys: ["query", "session_id", "token_budget", "max_items", "mode", "alpha"]),
         Entry(canonicalName: "markdown_export", acceptedArgumentKeys: ["output_dir", "session_id", "project", "all_projects", "cwd"]),
         Entry(canonicalName: "markdown_sync", acceptedArgumentKeys: ["root_dir", "dry_run"]),
@@ -170,7 +172,10 @@ package enum AgentBrokerCommandSurface {
 
         let unknown = providedKeys.subtracting(entry.acceptedArgumentKeys)
         guard unknown.isEmpty else {
-            throw BrokerValidationError.invalid("unsupported argument(s): \(unknown.sorted().joined(separator: ", "))")
+            let valid = entry.acceptedArgumentKeys.sorted().joined(separator: ", ")
+            throw BrokerValidationError.invalid(
+                "unsupported argument(s): \(unknown.sorted().joined(separator: ", ")); valid argument(s): \(valid)"
+            )
         }
         return entry
     }

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -20,6 +20,7 @@ package actor AgentBrokerService {
     let factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)?
     let brokerInstanceID = UUID().uuidString
     let virtualSessions: VirtualSessionStore
+    private let commandMutex = AsyncMutex()
     var activeSessions: [UUID: SessionState] {
         virtualSessions.live
     }
@@ -128,12 +129,20 @@ package actor AgentBrokerService {
     }
 
     package func close() async throws {
-        await virtualSessions.closeAll()
-        try await longTermMemory.flush()
-        try await longTermMemory.close()
+        try await commandMutex.withLock { [self] in
+            await virtualSessions.closeAll()
+            try await longTermMemory.flush()
+            try await longTermMemory.close()
+        }
     }
 
     package func handle(_ request: AgentBrokerRequest) async -> AgentBrokerResponse {
+        await commandMutex.withLock { [self] in
+            await handleSerialized(request)
+        }
+    }
+
+    private func handleSerialized(_ request: AgentBrokerRequest) async -> AgentBrokerResponse {
         do {
             let decoded = try BrokerCommand.decode(
                 command: request.command,
@@ -307,8 +316,7 @@ extension AgentBrokerService {
             memory: memory,
             content: command.content,
             metadata: metadata,
-            sessionID: sessionID,
-            before: before
+            sessionID: sessionID
         )
     }
 
@@ -338,16 +346,9 @@ extension AgentBrokerService {
         memory: MemoryOrchestrator,
         content: String,
         metadata: [String: String],
-        sessionID: UUID?,
-        before: MemoryOrchestrator.RuntimeStats? = nil
+        sessionID: UUID?
     ) async throws -> AgentBrokerValue {
-        let beforeStats: MemoryOrchestrator.RuntimeStats
-        if let before {
-            beforeStats = before
-        } else {
-            beforeStats = await memory.runtimeStats()
-        }
-        try await memory.remember(content, metadata: metadata)
+        let rememberResult = try await memory.remember(content, metadata: metadata)
         if let sessionID {
             try await refreshSessionManifest(sessionID)
             try await appendSessionEvent(
@@ -362,16 +363,25 @@ extension AgentBrokerService {
         }
         try await memory.flush()
         let after = await memory.runtimeStats()
-        let totalBefore = beforeStats.frameCount + beforeStats.pendingFrames
-        let totalAfter = after.frameCount + after.pendingFrames
-        let added = totalAfter >= totalBefore ? (totalAfter - totalBefore) : 0
 
+        let scope = sessionID == nil ? "durable" : "session"
+        let memoryID = sessionID.map {
+            "working:\($0.uuidString):\(rememberResult.frameId)"
+        } ?? "durable:\(rememberResult.frameId)"
         return .object([
             "status": .string("ok"),
-            "framesAdded": .from(added),
+            "frame_id": .from(rememberResult.frameId),
+            "memory_id": .string(memoryID),
+            "framesAdded": .from(rememberResult.framesAdded),
             "frameCount": .from(after.frameCount),
             "pendingFrames": .from(after.pendingFrames),
-            "display_text": .string("Remembered. \(added) frame(s) added (\(after.frameCount) total, \(after.pendingFrames) pending)."),
+            "scope": .string(scope),
+            "session_id": .from(sessionID?.uuidString),
+            "memory_type": .string(metadata[MemoryMetadataKeys.type] ?? MemoryType.note.rawValue),
+            "durability": .string(metadata[MemoryMetadataKeys.durability] ?? MemoryDurability.working.rawValue),
+            "deduplicated": .bool(rememberResult.deduplicated),
+            "searchable": .bool(rememberResult.searchable),
+            "display_text": .string("Remembered. \(rememberResult.framesAdded) frame(s) added (\(after.frameCount) total, \(after.pendingFrames) pending)."),
         ])
     }
 

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -563,12 +563,6 @@ package enum LayeredRecall {
             inferred: inferred
         )
 
-        var mode = request.mode
-        let durableStats = await stores.longTermMemory.runtimeStats()
-        if mode == nil, case .degraded = durableStats.embeddingStatus {
-            mode = .textOnly
-        }
-
         let retrievalTopK = Self.retrievalTopK(requested: request.searchTopK, scope: request.scope)
         let scopedFrameFilter = Self.frameFilterForScopedRetrieval(
             base: request.frameFilter,
@@ -581,7 +575,7 @@ package enum LayeredRecall {
         if let working {
             let execution = try await working.memory.recallExecution(
                 query: request.query,
-                mode: mode,
+                mode: request.mode,
                 frameFilter: scopedFrameFilter,
                 timeRange: request.timeRange,
                 topK: retrievalTopK
@@ -634,7 +628,7 @@ package enum LayeredRecall {
         if request.scope != .session {
             let execution = try await stores.longTermMemory.recallExecution(
                 query: request.query,
-                mode: mode,
+                mode: request.mode,
                 frameFilter: scopedFrameFilter,
                 timeRange: request.timeRange,
                 topK: retrievalTopK

--- a/Sources/Wax/Broker/VirtualSessionStore.swift
+++ b/Sources/Wax/Broker/VirtualSessionStore.swift
@@ -112,13 +112,30 @@ package final class VirtualSessionStore: @unchecked Sendable {
     private let nowMs: @Sendable () -> Int64
     private let waxOptions: WaxOptions
     private let openExisting: @Sendable (URL) async throws -> MemoryOrchestrator
+    private let endMutex = AsyncMutex()
     private let lock = NSLock()
     private var _live: [UUID: SessionState] = [:]
+    private var endingSessions: Set<UUID> = []
+    private var endHoldForTesting: Duration?
+    private var endCloseFailuresForTesting = 0
+    private var endEventFailuresForTesting = 0
     private var creatingPairs: Set<SessionPairKey> = []
     private var pairWaiters: [SessionPairKey: [CheckedContinuation<LifecycleResult?, Error>]] = [:]
 
     package var live: [UUID: SessionState] {
-        locked { _live }
+        locked { _live.filter { !endingSessions.contains($0.key) } }
+    }
+
+    package func setEndHoldForTesting(_ duration: Duration?) {
+        locked { endHoldForTesting = duration }
+    }
+
+    package func setEndCloseFailuresForTesting(_ count: Int) {
+        locked { endCloseFailuresForTesting = max(0, count) }
+    }
+
+    package func setEndEventFailuresForTesting(_ count: Int) {
+        locked { endEventFailuresForTesting = max(0, count) }
     }
 
     package init(
@@ -167,6 +184,9 @@ package final class VirtualSessionStore: @unchecked Sendable {
         runID: String?,
         inferredScope: MemoryScopeContext
     ) async throws -> LifecycleResult {
+        if let agentID, let runID, locked({ endingSessionMatchesLocked(agentID: agentID, runID: runID) }) {
+            throw BrokerValidationError.invalid("agent_id and run_id session is ending; start a new run after it closes")
+        }
         if let agentID, let runID, let existing = try findActive(agentID: agentID, runID: runID) {
             if let explicitSessionID, explicitSessionID != existing.sessionID {
                 throw BrokerValidationError.invalid(
@@ -226,17 +246,28 @@ package final class VirtualSessionStore: @unchecked Sendable {
             throw BrokerValidationError.invalid("session_id has already been ended and cannot be resumed")
         }
 
-        if let existing = locked({ _live[manifest.sessionID] }) {
+        if let existing = locked({
+            endingSessions.contains(manifest.sessionID) ? nil : _live[manifest.sessionID]
+        }) {
             return .resumed(existing, recoveredLease: false)
+        }
+        if locked({ endingSessions.contains(manifest.sessionID) }) {
+            throw Self.notActiveError(for: manifest.sessionID)
         }
 
         let timestamp = nowMs()
         let recoveredLease = manifest.brokerLeaseOwnerID != nil && manifest.brokerLeaseOwnerID != brokerInstanceID
         let memory = try await openExistingSessionMemory(at: URL(fileURLWithPath: manifest.storePath))
         do {
-            if let existing = locked({ _live[manifest.sessionID] }) {
+            if let existing = locked({
+                endingSessions.contains(manifest.sessionID) ? nil : _live[manifest.sessionID]
+            }) {
                 try? await memory.close()
                 return .resumed(existing, recoveredLease: false)
+            }
+            if locked({ endingSessions.contains(manifest.sessionID) }) {
+                try? await memory.close()
+                throw Self.notActiveError(for: manifest.sessionID)
             }
 
             var refreshed = manifest
@@ -293,7 +324,13 @@ package final class VirtualSessionStore: @unchecked Sendable {
     }
 
     package func end(sessionID: UUID?) async throws -> EndResult {
-        let evicted: (id: UUID, state: SessionState, remaining: Int)? = try locked {
+        try await endMutex.withLock { [self] in
+            try await endSerialized(sessionID: sessionID)
+        }
+    }
+
+    private func endSerialized(sessionID: UUID?) async throws -> EndResult {
+        let target: (id: UUID, state: SessionState)? = try locked {
             switch endTarget(sessionID) {
             case .idle:
                 return nil
@@ -301,41 +338,91 @@ package final class VirtualSessionStore: @unchecked Sendable {
                 throw Self.notActiveError(for: missingID)
             case .requireSessionID:
                 throw Self.requireSessionIDError
-            case .session(let id, var state):
-                let timestamp = nowMs()
-                state.manifest.status = .ended
-                state.manifest.updatedAtMs = timestamp
-                state.manifest.brokerLeaseOwnerID = nil
-                state.manifest.leaseExpiresAtMs = nil
-                try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-                try BrokerSessionPersistence.appendEvent(
-                    BrokerSessionEvent(
-                        sessionID: state.id,
-                        agentID: state.manifest.agentID,
-                        runID: state.manifest.runID,
-                        timestampMs: timestamp,
-                        kind: .ended
-                    ),
-                    to: state.eventLogURL
-                )
-                _live.removeValue(forKey: id)
-                return (id, state, _live.count)
+            case .session(let id, let state):
+                endingSessions.insert(id)
+                return (id, state)
             }
         }
 
-        guard let evicted else {
+        guard let target else {
             return .idle
         }
-        try await evicted.state.memory.flush()
-        try await evicted.state.memory.close()
-        return .ended(sessionID: evicted.id, remainingActive: evicted.remaining)
+
+        if let hold = locked({ endHoldForTesting }) {
+            do {
+                try await Task.sleep(for: hold)
+            } catch {
+                if target.state.manifest.status != .ended {
+                    _ = locked { endingSessions.remove(target.id) }
+                }
+                throw error
+            }
+        }
+
+        // `_live` retains the state for retry, while `endingSessions` removes it
+        // from every routable view before the first suspension point.
+        if target.state.manifest.status != .ended {
+            do {
+                try await target.state.memory.flush()
+                _ = try locked {
+                    guard var state = _live[target.id] else {
+                        throw Self.notActiveError(for: target.id)
+                    }
+                    let timestamp = nowMs()
+                    state.manifest.status = .ended
+                    state.manifest.updatedAtMs = timestamp
+                    state.manifest.brokerLeaseOwnerID = nil
+                    state.manifest.leaseExpiresAtMs = nil
+                    if endEventFailuresForTesting > 0 {
+                        endEventFailuresForTesting -= 1
+                        throw BrokerValidationError.invalid("injected session end event failure")
+                    }
+                    try BrokerSessionPersistence.appendEvent(
+                        BrokerSessionEvent(
+                            sessionID: state.id,
+                            agentID: state.manifest.agentID,
+                            runID: state.manifest.runID,
+                            timestampMs: timestamp,
+                            kind: .ended
+                        ),
+                        to: state.eventLogURL
+                    )
+                    try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
+                    _live[target.id] = state
+                    return state
+                }
+            } catch {
+                _ = locked { endingSessions.remove(target.id) }
+                throw error
+            }
+        }
+
+        // A close failure deliberately leaves the session reserved (not routable)
+        // so a later explicit end can retry without admitting new writes.
+        let injectCloseFailure = locked { () -> Bool in
+            guard endCloseFailuresForTesting > 0 else { return false }
+            endCloseFailuresForTesting -= 1
+            return true
+        }
+        if injectCloseFailure {
+            throw BrokerValidationError.invalid("injected session close failure")
+        }
+        try await target.state.memory.close()
+        let remaining = locked {
+            _live.removeValue(forKey: target.id)
+            endingSessions.remove(target.id)
+            return _live.count - endingSessions.count
+        }
+        return .ended(sessionID: target.id, remainingActive: remaining)
     }
 
     /// Lookup never infers or mints. Omitted `session_id` is no virtual session.
     /// Unknown or not live here fails closed (no auto-rebind).
     package func lookup(_ sessionID: UUID?) throws -> Lookup {
         guard let sessionID else { return .none }
-        guard let state = locked({ _live[sessionID] }) else {
+        guard let state = locked({
+            endingSessions.contains(sessionID) ? nil : _live[sessionID]
+        }) else {
             throw Self.notActiveError(for: sessionID)
         }
         return .live(state.memory)
@@ -351,8 +438,13 @@ package final class VirtualSessionStore: @unchecked Sendable {
     /// - Throws: ``BrokerSessionInactiveError`` when the UUID is unknown, ended, or unreadable.
     package func ensureLive(_ sessionID: UUID?) async throws -> Lookup {
         guard let sessionID else { return .none }
-        if let state = locked({ _live[sessionID] }) {
+        if let state = locked({
+            endingSessions.contains(sessionID) ? nil : _live[sessionID]
+        }) {
             return .live(state.memory)
+        }
+        if locked({ endingSessions.contains(sessionID) }) {
+            throw Self.notActiveError(for: sessionID)
         }
 
         let manifest: BrokerSessionManifest
@@ -445,7 +537,7 @@ package final class VirtualSessionStore: @unchecked Sendable {
 
     package func refreshManifest(_ sessionID: UUID) throws {
         try locked {
-            guard var state = _live[sessionID] else {
+            guard !endingSessions.contains(sessionID), var state = _live[sessionID] else {
                 throw Self.notActiveError(for: sessionID)
             }
             state.manifest.updatedAtMs = nowMs()
@@ -462,7 +554,7 @@ package final class VirtualSessionStore: @unchecked Sendable {
         payload: [String: String] = [:]
     ) throws {
         let snapshot = try locked { () -> (agentID: String, runID: String, eventLogURL: URL) in
-            guard let state = _live[sessionID] else {
+            guard !endingSessions.contains(sessionID), let state = _live[sessionID] else {
                 throw Self.notActiveError(for: sessionID)
             }
             return (state.manifest.agentID, state.manifest.runID, state.eventLogURL)
@@ -482,7 +574,7 @@ package final class VirtualSessionStore: @unchecked Sendable {
 
     package func updateLive(_ sessionID: UUID, _ body: (inout SessionState) throws -> Void) throws {
         try locked {
-            guard var state = _live[sessionID] else {
+            guard !endingSessions.contains(sessionID), var state = _live[sessionID] else {
                 throw Self.notActiveError(for: sessionID)
             }
             try body(&state)
@@ -495,6 +587,7 @@ package final class VirtualSessionStore: @unchecked Sendable {
         let sessions = locked { () -> [SessionState] in
             let values = Array(_live.values)
             _live.removeAll()
+            endingSessions.removeAll()
             return values
         }
         for session in sessions {
@@ -510,8 +603,13 @@ package final class VirtualSessionStore: @unchecked Sendable {
         inferredScope: MemoryScopeContext
     ) async throws -> LifecycleResult {
         let sessionID = explicitSessionID ?? UUID()
-        if let active = locked({ _live[sessionID] }) {
+        if let active = locked({
+            endingSessions.contains(sessionID) ? nil : _live[sessionID]
+        }) {
             return .resumed(active, recoveredLease: false)
+        }
+        if locked({ endingSessions.contains(sessionID) }) {
+            throw Self.notActiveError(for: sessionID)
         }
 
         let manifestURL = BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
@@ -536,9 +634,15 @@ package final class VirtualSessionStore: @unchecked Sendable {
                     runID: nil
                 )
             }
-            if let active = locked({ _live[sessionID] }) {
+            if let active = locked({
+                endingSessions.contains(sessionID) ? nil : _live[sessionID]
+            }) {
                 try? await memory.close()
                 return .resumed(active, recoveredLease: false)
+            }
+            if locked({ endingSessions.contains(sessionID) }) {
+                try? await memory.close()
+                throw Self.notActiveError(for: sessionID)
             }
 
             let timestamp = nowMs()
@@ -662,9 +766,19 @@ package final class VirtualSessionStore: @unchecked Sendable {
     }
 
     private func liveMatchLocked(agentID: String, runID: String) -> SessionState? {
-        _live.values.first(where: {
-            $0.manifest.agentID == agentID && $0.manifest.runID == runID
-        })
+        _live.first(where: {
+            !endingSessions.contains($0.key)
+                && $0.value.manifest.agentID == agentID
+                && $0.value.manifest.runID == runID
+        })?.value
+    }
+
+    private func endingSessionMatchesLocked(agentID: String, runID: String) -> Bool {
+        _live.contains { entry in
+            endingSessions.contains(entry.key)
+                && entry.value.manifest.agentID == agentID
+                && entry.value.manifest.runID == runID
+        }
     }
 
     private func abandonUnusedSessionFile(

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -141,12 +141,12 @@ public actor Memory {
 
     /// Persist text into memory.
     public func save(_ text: String, metadata: [String: String] = [:]) async throws {
-        try await orchestrator.remember(text, metadata: metadata)
+        _ = try await orchestrator.remember(text, metadata: metadata)
     }
 
     /// Persist multiple texts in a single call.
     public func save<each S: StringProtocol>(_ texts: repeat each S) async throws {
-        repeat try await orchestrator.remember(String(each texts))
+        repeat _ = try await orchestrator.remember(String(each texts))
     }
 
     /// Search memory and return ranked context.

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -278,8 +278,22 @@ package enum MemorySemantics {
             adjustment += 0.45
             reasons.append("constraint memory")
         case .handoff:
-            adjustment += 0.20
-            reasons.append("handoff")
+            if let createdAtMs = info.createdAtMs {
+                let ageDays = max(0, nowMs - createdAtMs) / (1000 * 60 * 60 * 24)
+                if ageDays <= 3 {
+                    adjustment += 0.80
+                    reasons.append("recent handoff")
+                } else if ageDays <= 14 {
+                    adjustment += 0.20
+                    reasons.append("handoff")
+                } else {
+                    adjustment -= 0.40
+                    reasons.append("stale handoff")
+                }
+            } else {
+                adjustment += 0.10
+                reasons.append("handoff without timestamp")
+            }
         case .taskState:
             if let createdAtMs = info.createdAtMs {
                 let ageHours = max(0, nowMs - createdAtMs) / (1000 * 60 * 60)

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -4,6 +4,25 @@ import WaxVectorSearch
 
 /// High-level orchestrator for text memory RAG, managing ingest, recall, and lifecycle on a Wax store.
 package actor MemoryOrchestrator {
+    package struct RememberResult: Sendable, Equatable {
+        package var frameId: UInt64
+        package var framesAdded: UInt64
+        package var deduplicated: Bool
+        package var searchable: Bool
+
+        package init(
+            frameId: UInt64,
+            framesAdded: UInt64,
+            deduplicated: Bool,
+            searchable: Bool
+        ) {
+            self.frameId = frameId
+            self.framesAdded = framesAdded
+            self.deduplicated = deduplicated
+            self.searchable = searchable
+        }
+    }
+
     /// Policy controlling when to compute query embeddings for vector search.
     private enum QueryEmbeddingPolicy: Sendable, Equatable {
         case never
@@ -188,6 +207,7 @@ package actor MemoryOrchestrator {
     let wax: Wax
     let config: OrchestratorConfig
     private let ragBuilder: FastRAGContextBuilder
+    private let handoffWriteMutex = AsyncMutex()
 
     let session: WaxSession
     private var embedder: (any EmbeddingProvider)?
@@ -401,7 +421,8 @@ package actor MemoryOrchestrator {
     ///   (WAL guarantees crash safety), but the ingested content may be incomplete.
     ///   Callers requiring all-or-nothing semantics should validate post-ingest or
     ///   implement their own rollback by superseding the document frame on failure.
-    package func remember(_ content: String, metadata: [String: String] = [:]) async throws {
+    @discardableResult
+    package func remember(_ content: String, metadata: [String: String] = [:]) async throws -> RememberResult {
         lastWriteActivityAt = .now
         let contentData = Data(content.utf8)
         let contentHash = ContentHasher.hash(contentData).hexString
@@ -421,7 +442,14 @@ package actor MemoryOrchestrator {
             embeddingIdentity: Self.rememberDedupEmbeddingIdentity(from: localEmbedder?.identity)
         ) {
             if existingProbe.isComplete {
-                return
+                return RememberResult(
+                    frameId: existingProbe.documentId,
+                    framesAdded: 0,
+                    deduplicated: true,
+                    searchable: !chunks.isEmpty && (
+                        config.enableTextSearch || (config.enableVectorSearch && localEmbedder != nil)
+                    )
+                )
             }
             // Single-chunk remember writes only the document. A matching
             // document is not complete unless it is actually searchable.
@@ -430,7 +458,12 @@ package actor MemoryOrchestrator {
                     documentId: existingProbe.documentId,
                     text: chunks[0]
                 )
-                return
+                return RememberResult(
+                    frameId: existingProbe.documentId,
+                    framesAdded: 0,
+                    deduplicated: true,
+                    searchable: true
+                )
             }
         }
 
@@ -447,14 +480,19 @@ package actor MemoryOrchestrator {
         }
 
         guard !chunks.isEmpty else {
-            _ = try await localSession.put(
+            let frameId = try await localSession.put(
                 contentData,
                 options: FrameMetaSubset(
                     role: .document,
                     metadata: docMeta
                 )
             )
-            return
+            return RememberResult(
+                frameId: frameId,
+                framesAdded: 1,
+                deduplicated: false,
+                searchable: false
+            )
         }
 
         if useVectorSearch, localEmbedder == nil {
@@ -501,7 +539,12 @@ package actor MemoryOrchestrator {
                     EnrichmentTask(frameId: frameId, text: chunk)
                 )
             }
-            return
+            return RememberResult(
+                frameId: frameId,
+                framesAdded: 1,
+                deduplicated: false,
+                searchable: config.enableTextSearch || chunkEmbedding != nil
+            )
         }
 
         struct IngestBatchResult {
@@ -651,6 +694,12 @@ package actor MemoryOrchestrator {
                 }
             }
         }
+        return RememberResult(
+            frameId: docId,
+            framesAdded: UInt64(chunkCount + 1),
+            deduplicated: false,
+            searchable: config.enableTextSearch || writeVectors
+        )
     }
 
     private static func rememberDedupEmbeddingIdentity(
@@ -1349,51 +1398,72 @@ package actor MemoryOrchestrator {
         sessionId: UUID? = nil,
         commit: Bool = true
     ) async throws -> UInt64 {
+        try await handoffWriteMutex.withLock { [self] in
+            try await rememberHandoffSerialized(
+                content: content,
+                project: project,
+                pendingTasks: pendingTasks,
+                sessionId: sessionId,
+                commit: commit
+            )
+        }
+    }
+
+    private func rememberHandoffSerialized(
+        content: String,
+        project: String?,
+        pendingTasks: [String],
+        sessionId: UUID?,
+        commit: Bool
+    ) async throws -> UInt64 {
         let pending = pendingTasks
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-
-        let text: String
-        if pending.isEmpty {
-            text = content
+        let normalizedProject = project?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveSessionId = sessionId ?? currentSessionId
+        let previous: FrameMeta? = if let normalizedProject,
+                                      !normalizedProject.isEmpty,
+                                      let effectiveSessionId {
+            await wax.latestActiveHandoffMeta(
+                project: normalizedProject,
+                matchingSessionId: effectiveSessionId.uuidString
+            )
         } else {
-            let items = pending.map { "- \($0)" }.joined(separator: "\n")
-            text = """
-            \(content)
-
-            Pending tasks:
-            \(items)
-            """
+            nil
         }
+        let searchText = ([content] + pending).joined(separator: "\n")
 
         var metadata = Metadata()
         metadata.entries["kind"] = "handoff"
         metadata.entries[MemoryMetadataKeys.type] = MemoryType.handoff.rawValue
         metadata.entries[MemoryMetadataKeys.durability] = MemoryDurability.ephemeral.rawValue
         metadata.entries[MemoryMetadataKeys.createdAtMs] = String(Int64(Date().timeIntervalSince1970 * 1000))
-        if let project, !project.isEmpty {
-            metadata.entries["project"] = project
-            metadata.entries[MemoryMetadataKeys.project] = project
+        if let normalizedProject, !normalizedProject.isEmpty {
+            metadata.entries["project"] = normalizedProject
+            metadata.entries[MemoryMetadataKeys.project] = normalizedProject
         }
         if !pending.isEmpty {
             metadata.entries["pending_tasks"] = pending.joined(separator: "\n")
         }
-        if let effectiveSessionId = sessionId ?? currentSessionId {
+        if let effectiveSessionId {
             metadata.entries["session_id"] = effectiveSessionId.uuidString
         }
 
         let frameId = try await session.put(
-            Data(text.utf8),
+            Data(content.utf8),
             options: FrameMetaSubset(
                 kind: "handoff",
                 labels: ["handoff"],
                 role: .document,
-                searchText: text,
+                searchText: searchText,
                 metadata: metadata
             )
         )
         if config.enableTextSearch {
-            try await session.indexText(frameId: frameId, text: text)
+            try await session.indexText(frameId: frameId, text: searchText)
+        }
+        if let previous, previous.id != frameId {
+            try await wax.supersede(supersededId: previous.id, supersedingId: frameId)
         }
         // Ensure latestHandoff() can observe this frame immediately when commit=true.
         if commit {

--- a/Sources/WaxCore/Wax.swift
+++ b/Sources/WaxCore/Wax.swift
@@ -2010,6 +2010,59 @@ package actor Wax {
         }
     }
 
+    package func latestActiveHandoffMeta(
+        project: String,
+        matchingSessionId sessionId: String
+    ) async -> FrameMeta? {
+        await withReadLock {
+            var visibleFrames = toc.frames
+            for mutation in orderedPendingMutationsLocked() {
+                switch mutation.entry {
+                case .putFrame(let put):
+                    if let meta = try? FrameMeta.fromPut(put) {
+                        visibleFrames.append(meta)
+                    }
+                case .deleteFrame(let delete):
+                    if delete.frameId < UInt64(visibleFrames.count) {
+                        visibleFrames[Int(delete.frameId)].status = .deleted
+                    }
+                case .supersedeFrame(let supersede):
+                    if supersede.supersededId < UInt64(visibleFrames.count) {
+                        visibleFrames[Int(supersede.supersededId)].supersededBy = supersede.supersedingId
+                    }
+                    if supersede.supersedingId < UInt64(visibleFrames.count) {
+                        visibleFrames[Int(supersede.supersedingId)].supersedes = supersede.supersededId
+                    }
+                case .putEmbedding:
+                    continue
+                }
+            }
+
+            var latest: FrameMeta?
+
+            for frame in visibleFrames {
+                guard frame.status == .active, frame.supersededBy == nil else { continue }
+
+                let hasHandoffKind = frame.kind == "handoff" || frame.metadata?.entries["kind"] == "handoff"
+                let hasHandoffLabel = frame.labels.contains("handoff")
+                guard hasHandoffKind || hasHandoffLabel else { continue }
+                guard frame.metadata?.entries["project"] == project else { continue }
+                guard frame.metadata?.entries["session_id"] == sessionId else { continue }
+
+                guard let current = latest else {
+                    latest = frame
+                    continue
+                }
+                if frame.timestamp > current.timestamp
+                    || (frame.timestamp == current.timestamp && frame.id > current.id) {
+                    latest = frame
+                }
+            }
+
+            return latest
+        }
+    }
+
     package func committedPayloadLivenessBytes() async -> (
         totalPayloadBytes: UInt64,
         deadPayloadBytes: UInt64
@@ -2171,7 +2224,11 @@ package actor Wax {
                 guard meta.role == .document else { return nil }
                 guard let entries = meta.metadata?.entries else { return nil }
                 guard entries["wax.content.hash"] == contentHash else { return nil }
-                guard entries == metadata else { return nil }
+                var storedIdentity = entries
+                var requestedIdentity = metadata
+                storedIdentity.removeValue(forKey: "wax.created_at_ms")
+                requestedIdentity.removeValue(forKey: "wax.created_at_ms")
+                guard storedIdentity == requestedIdentity else { return nil }
 
                 let coverage = chunkCoverageByDocument[meta.id] ?? ChunkCoverage()
                 return RememberDedupProbe(

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -12,7 +12,7 @@ enum MCPAgentInstructions {
         1) Prefer session_open(project?, agent_id?, run_id?, recall_query?) for a one-shot open, or call handoff_latest first (optional project) then session_start once and keep the returned session_id. The same agent_id+run_id resumes the active session.
         2) Before answering from memory, call recall (default) or search (raw ranked hits). Default recall scope is project: hard-filters to resolved project (explicit project, session project, or cwd/git root). Empty project lane returns an explicit miss — never auto-widens to global. Pass scope=global only when cross-project retrieval is intentional. Passing session_id merges that session with durable long-term memory under project scope.
         3) When you learn durable facts, call remember with concise factual content. Prefer scope=session|durable; session requires top-level session_id; durable forbids session_id. Never put session_id inside metadata.
-        4) Near session end, prefer session_close(session_id, content, optional project/pending_tasks) for atomic handoff+end. Or call handoff then session_end. session_end/session_close `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
+        4) Near session end, prefer session_close(session_id, content, optional project/pending_tasks) for atomic handoff+end. Keep content to a concise state summary; put unfinished work only in pending_tasks and never store transcripts. Or call handoff then session_end. session_end/session_close `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
         5) A persisted session_id survives broker hops: remember/recall/handoff rebind that UUID when the manifest is still active. Ended/unknown UUIDs return structured inactive errors (resumable=false).
 
         Canonical verbs: session_open, remember, recall, session_close, stats.
@@ -25,6 +25,8 @@ enum MCPAgentInstructions {
         - stats: health / embedder / store check
 
         Do not manage SESSION_STORE, --store-path, or flush in normal agent flows. The broker owns long-term memory and virtual session stores.
+
+        Responses default to one compact JSON content block. Pass verbosity=verbose only when narrative text plus structuredContent is useful.
 
         Behavior: read handoffs and recall results before asking the user to restate prior context; keep memory writes concise and task-scoped; cite provenance on cross-session hits.
         """

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -178,8 +178,8 @@ enum ToolSchemas {
             ],
             "verbosity": [
                 "type": "string",
-                "description": "Optional response verbosity. compact returns a single JSON text block.",
-                "enum": ["compact"],
+                "description": "Response verbosity. compact (default) returns one JSON text block; verbose returns narrative text plus structured content.",
+                "enum": ["compact", "verbose"],
             ],
             "metadata": [
                 "type": "object",
@@ -283,8 +283,8 @@ enum ToolSchemas {
             ],
             "verbosity": [
                 "type": "string",
-                "description": "Optional response verbosity. compact returns a single JSON text block.",
-                "enum": ["compact"],
+                "description": "Response verbosity. compact (default) returns one JSON text block; verbose returns narrative text plus structured content.",
+                "enum": ["compact", "verbose"],
             ],
             "filters": searchFilters,
         ],
@@ -352,6 +352,7 @@ enum ToolSchemas {
                 "type": "string",
                 "description": "Optional session UUID. When omitted, stdio/HTTP inject the calling client session if this connection started one.",
             ],
+            "verbosity": responseVerbositySchema,
         ],
         required: []
     )
@@ -493,6 +494,7 @@ enum ToolSchemas {
             "project": ["type": "string", "description": "Optional project stamped onto the new session manifest (overrides cwd inference)."],
             "repo": ["type": "string", "description": "Optional repo stamped onto the new session manifest (overrides cwd inference)."],
             "cwd": ["type": "string", "description": "Optional client working directory used to infer project/repo when not explicit."],
+            "verbosity": responseVerbositySchema,
         ],
         required: []
     )
@@ -501,6 +503,7 @@ enum ToolSchemas {
             "session_id": ["type": "string", "description": "Session UUID to reopen."],
             "agent_id": ["type": "string", "description": "Optional agent selector when session_id is omitted."],
             "run_id": ["type": "string", "description": "Optional run selector when session_id is omitted."],
+            "verbosity": responseVerbositySchema,
         ],
         required: []
     )
@@ -510,6 +513,7 @@ enum ToolSchemas {
                 "type": "string",
                 "description": "Optional session UUID to end explicitly. Required when more than one MCP session is active.",
             ],
+            "verbosity": responseVerbositySchema,
         ],
         required: []
     )
@@ -522,7 +526,7 @@ enum ToolSchemas {
             ],
             "content": [
                 "type": "string",
-                "description": "Handoff text stored before ending the session.",
+                "description": "Concise handoff state summary stored before ending the session. Put unfinished work in pending_tasks; do not include transcripts or repeat the task list here.",
             ],
             "project": [
                 "type": "string",
@@ -533,6 +537,7 @@ enum ToolSchemas {
                 "description": "Optional list of pending tasks.",
                 "items": ["type": "string"],
             ],
+            "verbosity": responseVerbositySchema,
         ],
         required: ["session_id", "content"]
     )
@@ -563,6 +568,7 @@ enum ToolSchemas {
                 "type": "string",
                 "description": "Optional client working directory used to infer project/repo when not explicit.",
             ],
+            "verbosity": responseVerbositySchema,
         ],
         required: []
     )
@@ -571,7 +577,7 @@ enum ToolSchemas {
         properties: [
             "content": [
                 "type": "string",
-                "description": "Handoff text for the next session.",
+                "description": "Concise state summary for the next session. Put unfinished work in pending_tasks; do not include transcripts or repeat the task list here.",
             ],
             "session_id": [
                 "type": "string",
@@ -586,6 +592,7 @@ enum ToolSchemas {
                 "description": "Optional list of pending tasks.",
                 "items": ["type": "string"],
             ],
+            "verbosity": responseVerbositySchema,
         ],
         required: ["content"]
     )
@@ -683,7 +690,8 @@ enum ToolSchemas {
                 ],
             ],
         ],
-        required: []
+        required: [],
+        includeResponseVerbosity: false
     )
 
     static let waxHandoffLatest: Value = objectSchema(
@@ -692,6 +700,7 @@ enum ToolSchemas {
                 "type": "string",
                 "description": "Optional project scope for lookup.",
             ],
+            "verbosity": responseVerbositySchema,
         ],
         required: []
     )
@@ -933,8 +942,16 @@ enum ToolSchemas {
 
     private static let maxContentBytes = AgentBrokerService.maxContentBytes
 
-    private static func objectSchema(properties: [String: Value], required: [String]) -> Value {
-        [
+    private static func objectSchema(
+        properties: [String: Value],
+        required: [String],
+        includeResponseVerbosity: Bool = true
+    ) -> Value {
+        var properties = properties
+        if includeResponseVerbosity {
+            properties["verbosity"] = responseVerbositySchema
+        }
+        return [
             "type": "object",
             "properties": .object(properties),
             "required": .array(required.map(Value.string)),
@@ -949,6 +966,12 @@ enum ToolSchemas {
             ["type": "number"],
             ["type": "boolean"],
         ],
+    ]
+
+    private static let responseVerbositySchema: Value = [
+        "type": "string",
+        "description": "Response verbosity. compact (default) returns one JSON text block; verbose returns narrative text plus structured content.",
+        "enum": ["compact", "verbose"],
     ]
 
     private static func emptyObjectSchema() -> Value {

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -85,7 +85,7 @@ enum WaxMCPTools {
             }
             injectClientCWDIfNeeded(name: params.name, arguments: &forwarded)
             injectClientSessionIfNeeded(name: params.name, arguments: &forwarded, sessionHint: sessionHint)
-            let verbosity = compactVerbosity(from: forwarded)
+            let verbosity = try responseVerbosity(from: forwarded) ?? "compact"
 
             let response = try await perform(
                 AgentBrokerRequest(
@@ -154,7 +154,9 @@ final class MCPClientSessionHint: @unchecked Sendable {
 }
 
 private extension WaxMCPTools {
-    static let readOnlyTextCommands: Set<String> = ["recall", "search", "memory_search", "memory_get", "compact_context", "corpus_search", "session_synthesize", "memory_health"]
+    static let compactPresentationKeys: Set<String> = [
+        "display_text", "storePath", "store_path", "event_log_path",
+    ]
     static let clientCWDCommands: Set<String> = [
         "session_start", "session_open", "remember", "memory_append", "knowledge_capture",
         "markdown_export", "recall",
@@ -170,10 +172,16 @@ private extension WaxMCPTools {
         )
     }
 
-    static func compactVerbosity(from arguments: [String: Value]) -> String? {
-        guard case .string(let raw)? = arguments["verbosity"] else { return nil }
+    static func responseVerbosity(from arguments: [String: Value]) throws -> String? {
+        guard let value = arguments["verbosity"] else { return nil }
+        guard case .string(let raw) = value else {
+            throw ToolValidationError.invalid("verbosity must be a string: compact or verbose")
+        }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return trimmed.isEmpty ? nil : trimmed
+        guard trimmed == "compact" || trimmed == "verbose" else {
+            throw ToolValidationError.invalid("verbosity must be one of: compact, verbose")
+        }
+        return trimmed
     }
 
     static func injectClientCWDIfNeeded(name: String, arguments: inout [String: Value]) {
@@ -258,9 +266,12 @@ private extension WaxMCPTools {
         payload: AgentBrokerValue,
         verbosity: String? = nil
     ) -> CallTool.Result {
-        let mcpPayload = mcpValue(from: removingDisplayText(from: payload))
+        let compactPayload = mcpValue(from: removingPresentationFields(
+            from: payload,
+            removing: compactPresentationKeys
+        ))
         if verbosity == "compact" {
-            let json = encodeJSON(mcpPayload) ?? "{}"
+            let json = encodeJSON(compactPayload) ?? "{}"
             return CallTool.Result(
                 content: [
                     .text(text: json, annotations: nil, _meta: nil),
@@ -271,41 +282,57 @@ private extension WaxMCPTools {
 
         let text = payload.objectValue?["display_text"]?.stringValue
 
-        if readOnlyTextCommands.contains(name) {
-            let uri = switch name {
-            case "recall": "wax://tool/recall-summary"
-            case "search": "wax://tool/search-summary"
-            case "memory_search": "wax://tool/memory-search-summary"
-            case "memory_get": "wax://tool/memory-get-summary"
-            case "compact_context": "wax://tool/compact-context-summary"
-            case "corpus_search": "wax://tool/corpus-search-summary"
-            case "session_synthesize": "wax://tool/session-synthesize-summary"
-            case "memory_health": "wax://tool/memory-health-summary"
-            default: "wax://tool/result"
-            }
-            return textWithJSONResourceResult(text: text ?? "", payload: mcpPayload, uri: uri)
+        if verbosity == "verbose" {
+            let structuredPayload = mcpValue(from: removingPresentationFields(
+                from: payload,
+                removing: ["display_text"]
+            ))
+            return textWithStructuredResult(
+                text: text ?? "Wax \(name) completed.",
+                payload: structuredPayload
+            )
         }
 
-        return jsonResult(mcpPayload)
+        return jsonResult(compactPayload)
     }
 
-    static func removingDisplayText(from payload: AgentBrokerValue) -> AgentBrokerValue {
-        guard case .object(var object) = payload else { return payload }
-        object.removeValue(forKey: "display_text")
-        return .object(object)
+    static func removingPresentationFields(
+        from payload: AgentBrokerValue,
+        removing keys: Set<String>,
+        preservingUserFields: Bool = false
+    ) -> AgentBrokerValue {
+        switch payload {
+        case .object(let object):
+            return .object(object.reduce(into: [:]) { result, entry in
+                guard preservingUserFields || !keys.contains(entry.key) else { return }
+                result[entry.key] = removingPresentationFields(
+                    from: entry.value,
+                    removing: keys,
+                    preservingUserFields: preservingUserFields || entry.key == "metadata"
+                )
+            })
+        case .array(let values):
+            return .array(values.map {
+                removingPresentationFields(
+                    from: $0,
+                    removing: keys,
+                    preservingUserFields: preservingUserFields
+                )
+            })
+        case .null, .bool, .int, .double, .string:
+            return payload
+        }
     }
 
-    static func textWithJSONResourceResult(
+    static func textWithStructuredResult(
         text: String,
-        payload: Value,
-        uri: String = "wax://tool/result"
+        payload: Value
     ) -> CallTool.Result {
-        let json = encodeJSON(payload) ?? "{}"
         return CallTool.Result(
             content: [
                 .text(text: text, annotations: nil, _meta: nil),
-                .resource(resource: .text(json, uri: uri, mimeType: "application/json")),
             ],
+            structuredContent: Optional.some(payload),
             isError: false
         )
     }
@@ -315,7 +342,6 @@ private extension WaxMCPTools {
         return CallTool.Result(
             content: [
                 .text(text: json, annotations: nil, _meta: nil),
-                .resource(resource: .text(json, uri: "wax://tool/result", mimeType: "application/json")),
             ],
             isError: false
         )

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -1803,7 +1803,9 @@ func toolsRememberRecallSearchFlushStatsHappyPath() async throws {
             broker: service
         )
         #expect(recallResult.isError != true)
-        #expect(firstText(in: recallResult).contains("Query: actors"))
+        let recallJSON = try parseJSONText(in: recallResult)
+        #expect((recallJSON["query"] as? String) == "actors")
+        #expect((recallJSON["result_count"] as? Int) == 1)
 
         let searchResult = await WaxMCPTools.handleCall(
             params: .init(
@@ -3485,8 +3487,9 @@ func vectorSearchRememberFlushRecallHappyPath() async throws {
             broker: service
         )
         #expect(recall.isError != true)
-        let recallText = firstText(in: recall)
-        #expect(recallText.contains("Results:"))
+        let recallJSON = try parseJSONText(in: recall)
+        #expect((recallJSON["effective_mode"] as? String)?.hasPrefix("hybrid") == true)
+        #expect((recallJSON["result_count"] as? Int) == 1)
 
         let search = await WaxMCPTools.handleCall(
             params: .init(name: "search", arguments: [
@@ -4397,9 +4400,9 @@ func brokerSessionStartAppendsStartedEventBeforeSavingManifest() throws {
         contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/VirtualSessionStore.swift"),
         encoding: .utf8
     )
-    let start = try #require(source.range(of: "package func start("))
-    let resume = try #require(source[start.upperBound...].range(of: "package func resume("))
-    let body = source[start.lowerBound..<resume.lowerBound]
+    let start = try #require(source.range(of: "private func mintNewSession("))
+    let end = try #require(source[start.upperBound...].range(of: "private func abandonUnusedSessionFile("))
+    let body = source[start.lowerBound..<end.lowerBound]
 
     let appendEvent = try #require(body.range(of: "BrokerSessionPersistence.appendEvent("))
     let saveManifest = try #require(body.range(of: "BrokerSessionPersistence.saveManifest(manifest, to: manifestURL)"))
@@ -4437,19 +4440,19 @@ func brokerSessionEndKeepsActiveSessionUntilPersistenceSucceeds() throws {
         contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/VirtualSessionStore.swift"),
         encoding: .utf8
     )
-    let start = try #require(source.range(of: "package func end("))
+    let start = try #require(source.range(of: "private func endSerialized("))
     let end = try #require(source[start.upperBound...].range(of: "package func lookup("))
     let body = source[start.lowerBound..<end.lowerBound]
 
-    let saveManifest = try #require(body.range(of: "BrokerSessionPersistence.saveManifest(manifest, to: state.manifestURL)"))
+    let flush = try #require(body.range(of: "try await target.state.memory.flush()"))
+    let saveManifest = try #require(body.range(of: "BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)"))
     let appendEvent = try #require(body.range(of: "BrokerSessionPersistence.appendEvent("))
-    let flush = try #require(body.range(of: "try await state.memory.flush()"))
-    let close = try #require(body.range(of: "try await state.memory.close()"))
-    let remove = try #require(body.range(of: "live.removeValue(forKey: target)"))
+    let close = try #require(body.range(of: "try await target.state.memory.close()"))
+    let remove = try #require(body.range(of: "_live.removeValue(forKey: target.id)"))
 
+    #expect(flush.lowerBound < remove.lowerBound)
     #expect(saveManifest.lowerBound < remove.lowerBound)
     #expect(appendEvent.lowerBound < remove.lowerBound)
-    #expect(flush.lowerBound < remove.lowerBound)
     #expect(close.lowerBound < remove.lowerBound)
 }
 
@@ -5296,6 +5299,523 @@ func knowledgeCaptureAndMemoryHealthWork() async throws {
 }
 
 @Test
+func mcpSuccessResultsUseOneDefaultRepresentation() async throws {
+    try await withAgentBrokerService { service, _ in
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("DEFAULT_COMPACT_RECALL_MARKER")]
+        ))).ok == true)
+        for result in [
+            await WaxMCPTools.handleCall(
+                params: .init(name: "stats", arguments: [:]),
+                broker: service
+            ),
+            await WaxMCPTools.handleCall(
+                params: .init(name: "handoff_latest", arguments: [:]),
+                broker: service
+            ),
+            await WaxMCPTools.handleCall(
+                params: .init(
+                    name: "recall",
+                    arguments: [
+                        "query": .string("DEFAULT_COMPACT_RECALL_MARKER"),
+                        "scope": .string("global"),
+                    ]
+                ),
+                broker: service
+            ),
+        ] {
+            #expect(result.isError != true)
+            #expect(result.content.count == 1)
+            #expect(result.structuredContent == nil)
+            _ = try parseJSONText(in: result)
+        }
+    }
+}
+
+@Test
+func compactLifecycleResponsesOmitHostPaths() async throws {
+    try await withAgentBrokerService { service, _ in
+        for result in [
+            await WaxMCPTools.handleCall(
+                params: .init(name: "stats", arguments: [:]),
+                broker: service
+            ),
+            await WaxMCPTools.handleCall(
+                params: .init(name: "session_start", arguments: [:]),
+                broker: service
+            ),
+        ] {
+            let payload = try parseJSONText(in: result)
+            #expect(!containsKeyRecursively("storePath", in: payload))
+            #expect(!containsKeyRecursively("store_path", in: payload))
+            #expect(!containsKeyRecursively("event_log_path", in: payload))
+        }
+    }
+}
+
+@Test
+func verboseResultsUseStructuredContentWithoutResourceEcho() async throws {
+    try await withAgentBrokerService { service, _ in
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("VERBOSE_SEARCH_MARKER")]
+        ))).ok == true)
+        let verboseStats = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "stats",
+                arguments: ["verbosity": .string("verbose")]
+            ),
+            broker: service
+        )
+        for result in [
+            verboseStats,
+            await WaxMCPTools.handleCall(
+                params: .init(
+                    name: "search",
+                    arguments: [
+                        "query": .string("VERBOSE_SEARCH_MARKER"),
+                        "mode": .string("text"),
+                        "verbosity": .string("verbose"),
+                    ]
+                ),
+                broker: service
+            ),
+        ] {
+            #expect(result.isError != true)
+            #expect(result.content.count == 1)
+            #expect(result.structuredContent != nil)
+            #expect(result.content.allSatisfy { content in
+                if case .resource = content { return false }
+                return true
+            })
+        }
+        guard case .object(let statsPayload) = try #require(verboseStats.structuredContent) else {
+            Issue.record("Expected verbose stats structured content")
+            return
+        }
+        #expect(statsPayload["storePath"] != nil)
+    }
+}
+
+@Test
+func compactRecallPreservesUserDisplayTextMetadata() async throws {
+    try await withAgentBrokerService { service, _ in
+        let marker = "USER_DISPLAY_TEXT_MARKER_\(UUID().uuidString)"
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string(marker),
+                "metadata": .object(["display_text": .string("user-authored value")]),
+            ]
+        ))).ok == true)
+
+        let result = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "recall",
+                arguments: [
+                    "query": .string(marker),
+                    "scope": .string("global"),
+                ]
+            ),
+            broker: service
+        )
+        let payload = try parseJSONText(in: result)
+        let results = try #require(payload["results"] as? [[String: Any]])
+        let metadata = try #require(results.first?["metadata"] as? [String: Any])
+        #expect(metadata["display_text"] as? String == "user-authored value")
+    }
+}
+
+@Test
+func sessionOpenCompactRecursivelyRemovesDisplayText() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "compact-open-\(UUID().uuidString)"
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("COMPACT_OPEN_RECALL_MARKER"),
+                "project": .string(project),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "handoff",
+            arguments: [
+                "content": .string("Compact open handoff summary."),
+                "project": .string(project),
+                "pending_tasks": .array([.string("finish compact regression")]),
+            ]
+        ))).ok == true)
+
+        let opened = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": .string(project),
+                    "agent_id": .string("compact-open-agent"),
+                    "run_id": .string(UUID().uuidString),
+                    "recall_query": .string("COMPACT_OPEN_RECALL_MARKER"),
+                    "verbosity": .string("compact"),
+                ]
+            ),
+            broker: service
+        )
+
+        #expect(opened.isError != true)
+        #expect(opened.content.count == 1)
+        let payload = try parseJSONText(in: opened)
+        #expect(payload["handoff"] != nil)
+        #expect(payload["recall"] != nil)
+        #expect(!containsKeyRecursively("display_text", in: payload))
+    }
+}
+
+@Test
+func invalidArgumentErrorListsAcceptedArguments() async throws {
+    try await withAgentBrokerService { service, _ in
+        let result = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "handoff_latest",
+                arguments: ["filePath": .string("handoff.json")]
+            ),
+            broker: service
+        )
+
+        #expect(result.isError == true)
+        let message = firstText(in: result)
+        #expect(message.contains("unsupported argument(s): filePath"))
+        #expect(message.contains("valid argument(s): project, verbosity"))
+
+        let malformedVerbosity = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "stats",
+                arguments: ["verbosity": .int(42)]
+            ),
+            broker: service
+        )
+        #expect(malformedVerbosity.isError == true)
+        #expect(firstText(in: malformedVerbosity).contains("verbosity must be a string"))
+    }
+}
+
+@Test
+func rememberReceiptIdentifiesStoredMemoryAndDeduplication() async throws {
+    try await withAgentBrokerService { service, _ in
+        let content = "RECEIPT_MARKER-\(UUID().uuidString)"
+        let first = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "remember",
+                arguments: [
+                    "content": .string(content),
+                    "project": .string("Wax"),
+                    "memory_type": .string("decision"),
+                    "durability": .string("durable"),
+                ]
+            ),
+            broker: service
+        )
+        let firstJSON = try parseJSONText(in: first)
+        #expect((firstJSON["frame_id"] as? Int ?? -1) >= 0)
+        #expect((firstJSON["memory_id"] as? String)?.hasPrefix("durable:") == true)
+        #expect(firstJSON["scope"] as? String == "durable")
+        #expect(firstJSON["memory_type"] as? String == "decision")
+        #expect(firstJSON["durability"] as? String == "durable")
+        #expect(firstJSON["deduplicated"] as? Bool == false)
+        #expect(firstJSON["searchable"] as? Bool == true)
+
+        let repeated = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "remember",
+                arguments: [
+                    "content": .string(content),
+                    "project": .string("Wax"),
+                    "memory_type": .string("decision"),
+                    "durability": .string("durable"),
+                ]
+            ),
+            broker: service
+        )
+        let repeatedJSON = try parseJSONText(in: repeated)
+        #expect(repeatedJSON["memory_id"] as? String == firstJSON["memory_id"] as? String)
+        #expect(repeatedJSON["deduplicated"] as? Bool == true)
+        #expect(repeatedJSON["framesAdded"] as? Int == 0)
+    }
+}
+
+@Test
+func handoffStoresPendingTasksOnceAndSupersedesPriorProjectHandoff() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "handoff-supersede-\(UUID().uuidString)"
+        let sessionID = UUID()
+        let firstMarker = "OLD_HANDOFF_\(UUID().uuidString)"
+        let secondMarker = "NEW_HANDOFF_\(UUID().uuidString)"
+
+        #expect((await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "session_id": .string(sessionID.uuidString),
+                "project": .string(project),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "handoff",
+            arguments: [
+                "content": .string("\(firstMarker) old summary"),
+                "session_id": .string(sessionID.uuidString),
+                "project": .string(project),
+                "pending_tasks": .array([.string("old task")]),
+            ]
+        ))).ok == true)
+        #expect((await service.handle(.init(
+            command: "handoff",
+            arguments: [
+                "content": .string("\(secondMarker) current summary"),
+                "session_id": .string(sessionID.uuidString),
+                "project": .string("  \(project)  "),
+                "pending_tasks": .array([.string("current task")]),
+            ]
+        ))).ok == true)
+
+        let latest = await service.handle(.init(
+            command: "handoff_latest",
+            arguments: ["project": .string(project)]
+        ))
+        let latestPayload = try #require(latest.payload?.objectValue)
+        #expect(latestPayload["content"]?.stringValue == "\(secondMarker) current summary")
+        #expect(latestPayload["pending_tasks"]?.arrayValue?.compactMap(\.stringValue) == ["current task"])
+        #expect(latestPayload["content"]?.stringValue?.contains("Pending tasks:") == false)
+
+        let oldRecall = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(firstMarker),
+                "project": .string(project),
+                "mode": .string("text"),
+                "limit": .int(5),
+            ]
+        ))
+        let oldPayload = try #require(oldRecall.payload?.objectValue)
+        #expect(oldPayload["results"]?.arrayValue?.isEmpty == true)
+    }
+}
+
+@Test
+func handoffSupersessionKeepsOtherSessionLineagesVisible() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "handoff-lineage-\(UUID().uuidString)"
+        let sessionA = UUID()
+        let sessionB = UUID()
+        for sessionID in [sessionA, sessionB] {
+            #expect((await service.handle(.init(
+                command: "session_start",
+                arguments: [
+                    "session_id": .string(sessionID.uuidString),
+                    "project": .string(project),
+                ]
+            ))).ok == true)
+        }
+
+        let oldA = "OLD_A_\(UUID().uuidString)"
+        let currentA = "CURRENT_A_\(UUID().uuidString)"
+        let currentB = "CURRENT_B_\(UUID().uuidString)"
+        for (sessionID, content) in [(sessionA, oldA), (sessionB, currentB), (sessionA, currentA)] {
+            #expect((await service.handle(.init(
+                command: "handoff",
+                arguments: [
+                    "session_id": .string(sessionID.uuidString),
+                    "project": .string(project),
+                    "content": .string(content),
+                ]
+            ))).ok == true)
+        }
+
+        for marker in [currentA, currentB] {
+            let recall = try #require((await service.handle(.init(
+                command: "recall",
+                arguments: [
+                    "query": .string(marker),
+                    "project": .string(project),
+                    "mode": .string("text"),
+                ]
+            ))).payload?.objectValue)
+            #expect(recall["results"]?.arrayValue?.isEmpty == false)
+        }
+        let oldRecall = try #require((await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(oldA),
+                "project": .string(project),
+                "mode": .string("text"),
+            ]
+        ))).payload?.objectValue)
+        #expect(oldRecall["results"]?.arrayValue?.isEmpty == true)
+    }
+}
+
+@Test
+func concurrentHandoffsForOneLineageCommitWithoutConflictingSupersedes() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "handoff-concurrency-\(UUID().uuidString)"
+        let sessionID = UUID()
+        #expect((await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "session_id": .string(sessionID.uuidString),
+                "project": .string(project),
+            ]
+        ))).ok == true)
+
+        let responses = await withTaskGroup(of: AgentBrokerResponse.self, returning: [AgentBrokerResponse].self) { group in
+            for index in 0..<12 {
+                group.addTask {
+                    await service.handle(.init(
+                        command: "handoff",
+                        arguments: [
+                            "session_id": .string(sessionID.uuidString),
+                            "project": .string(project),
+                            "content": .string("CONCURRENT_HANDOFF_\(index)"),
+                        ]
+                    ))
+                }
+            }
+            var collected: [AgentBrokerResponse] = []
+            for await response in group { collected.append(response) }
+            return collected
+        }
+        #expect(responses.count == 12)
+        #expect(responses.allSatisfy { $0.ok })
+
+        let recall = try #require((await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string("CONCURRENT_HANDOFF"),
+                "project": .string(project),
+                "mode": .string("text"),
+                "limit": .int(20),
+            ]
+        ))).payload?.objectValue)
+        #expect(recall["results"]?.arrayValue?.count == 1)
+    }
+}
+
+@Test(.timeLimit(.minutes(1)))
+func sessionEndWaitsForInFlightRememberToFinish() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-mcp-end-drain-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let embedder = ControlledRememberEmbedder()
+    let service = try await AgentBrokerService(
+        storePath: rootURL.appendingPathComponent("memory.wax").path,
+        sessionRootPath: rootURL.appendingPathComponent("sessions", isDirectory: true).path,
+        noEmbedder: false,
+        embedderChoice: "auto",
+        requireVector: false,
+        embedderOverride: embedder
+    )
+
+    do {
+        let started = try #require((await service.handle(.init(
+            command: "session_start",
+            arguments: [:]
+        ))).payload?.objectValue)
+        let sessionID = try #require(started["session_id"]?.stringValue)
+
+        async let remembering = service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("IN_FLIGHT_END_DRAIN_MARKER"),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        await embedder.waitUntilEmbeddingStarts()
+        async let ending = service.handle(.init(
+            command: "session_end",
+            arguments: ["session_id": .string(sessionID)]
+        ))
+
+        await embedder.release()
+        let remembered = await remembering
+        let ended = await ending
+        #expect(remembered.ok == true)
+        #expect(ended.ok == true)
+        #expect(ended.payload?.objectValue?["ended"]?.boolValue == true)
+        try await service.close()
+    } catch {
+        await embedder.release()
+        try? await service.close()
+        throw error
+    }
+}
+
+@Test
+func defaultRecallUsesHybridWhenVectorCoverageIsPartial() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-mcp-partial-vectors-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    var textOnlyConfig = OrchestratorConfig.default
+    textOnlyConfig.enableVectorSearch = false
+    let textOnly = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false,
+        orchestratorConfig: textOnlyConfig
+    )
+    #expect((await textOnly.handle(.init(
+        command: "remember",
+        arguments: ["content": .string("LEGACY_TEXT_ONLY_PARTIAL_VECTOR_MARKER")]
+    ))).ok == true)
+    try await textOnly.close()
+
+    var hybridConfig = OrchestratorConfig.default
+    hybridConfig.enableVectorSearch = true
+    hybridConfig.rag.searchMode = .hybrid(alpha: 0.5)
+    let hybrid = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "auto",
+        requireVector: false,
+        embedderOverride: MCPTestDeterministicEmbedder(),
+        orchestratorConfig: hybridConfig
+    )
+    do {
+        #expect((await hybrid.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("HYBRID_DEFAULT_QUERY_MARKER")]
+        ))).ok == true)
+
+        let stats = try #require((await hybrid.handle(.init(command: "stats"))).payload?.objectValue)
+        #expect(stats["embeddingStatus"]?.stringValue == "degraded")
+        #expect(stats["queryEmbeddingAvailable"]?.boolValue == true)
+
+        let recalled = await hybrid.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string("HYBRID_DEFAULT_QUERY_MARKER"),
+                "scope": .string("global"),
+                "limit": .int(5),
+            ]
+        ))
+        let payload = try #require(recalled.payload?.objectValue)
+        #expect(payload["requested_mode"]?.stringValue == "hybrid(alpha=0.500)")
+        #expect(payload["effective_mode"]?.stringValue == "hybrid(alpha=0.500)")
+        #expect(payload["query_embedding_state"]?.stringValue == "available")
+        try await hybrid.close()
+    } catch {
+        try? await hybrid.close()
+        throw error
+    }
+}
+
+@Test
 func factRetractMissingIdDoesNotReportCommitted() async throws {
     try await withAgentBrokerService { service, _ in
         let retract = await WaxMCPTools.handleCall(
@@ -5374,6 +5894,17 @@ private func firstText(in result: CallTool.Result) -> String {
     return ""
 }
 
+private func containsKeyRecursively(_ key: String, in value: Any) -> Bool {
+    if let object = value as? [String: Any] {
+        if object[key] != nil { return true }
+        return object.values.contains { containsKeyRecursively(key, in: $0) }
+    }
+    if let array = value as? [Any] {
+        return array.contains { containsKeyRecursively(key, in: $0) }
+    }
+    return false
+}
+
 private func parseJSONText(in result: CallTool.Result) throws -> [String: Any] {
     let text = firstText(in: result)
     guard let data = text.data(using: .utf8) else {
@@ -5387,6 +5918,9 @@ private func parseJSONText(in result: CallTool.Result) throws -> [String: Any] {
 }
 
 private func parseJSONResource(in result: CallTool.Result, uriSuffix: String) throws -> [String: Any] {
+    if let textPayload = try? parseJSONText(in: result) {
+        return textPayload
+    }
     for content in result.content {
         if case .resource(let resource, _, _) = content,
            resource.uri.hasSuffix(uriSuffix),
@@ -5587,6 +6121,9 @@ private func parseToolTextJSON(fromResponseLine line: String) throws -> [String:
 }
 
 private func parseToolResourceJSON(fromResponseLine line: String, uriSuffix: String) throws -> [String: Any] {
+    if let textPayload = try? parseToolTextJSON(fromResponseLine: line) {
+        return textPayload
+    }
     guard let data = line.data(using: .utf8) else {
         throw NSError(domain: "WaxMCPServerTests", code: 24, userInfo: [NSLocalizedDescriptionKey: "Invalid UTF-8 response line"])
     }
@@ -5676,6 +6213,45 @@ private actor HangingCountingEmbedder: EmbeddingProvider {
         _ = text
         try await Task.sleep(for: .seconds(60))
         return [1.0, 0.0]
+    }
+}
+
+private actor ControlledRememberEmbedder: EmbeddingProvider {
+    let dimensions: Int = 2
+    let normalize: Bool = true
+    let identity: EmbeddingIdentity? = .init(
+        provider: "Test",
+        model: "ControlledRemember",
+        dimensions: 2,
+        normalized: true
+    )
+    private var started = false
+    private var released = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func embed(_ text: String) async throws -> [Float] {
+        _ = text
+        started = true
+        let waiters = startWaiters
+        startWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        if !released {
+            await withCheckedContinuation { releaseWaiters.append($0) }
+        }
+        return [1.0, 0.0]
+    }
+
+    func waitUntilEmbeddingStarts() async {
+        if started { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func release() {
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
     }
 }
 
@@ -6234,13 +6810,42 @@ struct WaxMCPProcessTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
+    func compactToolResponseUsesOneWireContentBlock() async throws {
+        let harness = try MCPServerProcessHarness()
+        try harness.start()
+        defer { harness.terminateIfNeeded() }
+
+        _ = try await harness.bootstrap(clientName: "wax-mcp-compact-wire-response")
+        let response = try await harness.callTool(
+            id: 2,
+            name: "stats",
+            arguments: [:],
+            timeout: 20
+        )
+        let data = try #require(response.data(using: .utf8))
+        let envelope = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let result = try #require(envelope["result"] as? [String: Any])
+        let content = try #require(result["content"] as? [[String: Any]])
+
+        #expect(content.count == 1)
+        #expect(content[0]["type"] as? String == "text")
+        #expect(result["structuredContent"] == nil)
+        _ = try parseToolTextJSON(fromResponseLine: response)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
     func brokerBackedSessionsUseHarnessIsolatedSessionRoot() async throws {
         let harness = try MCPServerProcessHarness()
         try harness.start()
         defer { harness.terminateIfNeeded() }
 
         _ = try await harness.bootstrap(clientName: "wax-mcp-session-root-isolation-test", includeToolsList: true)
-        let started = try await harness.callTool(id: 3, name: "session_start", arguments: [:], timeout: 20)
+        let started = try await harness.callTool(
+            id: 3,
+            name: "session_start",
+            arguments: ["verbosity": "verbose"],
+            timeout: 20
+        )
         #expect(started.contains("store_path"))
         #expect(started.contains(harness.brokerSessionRootURL.path))
     }
@@ -7558,7 +8163,12 @@ struct WaxMCPProcessTests {
         defer { harness.terminateIfNeeded() }
 
         _ = try await harness.bootstrap(clientName: "wax-mcp-session-root-flag", includeToolsList: true)
-        let started = try await harness.callTool(id: 3, name: "session_start", arguments: [:], timeout: 20)
+        let started = try await harness.callTool(
+            id: 3,
+            name: "session_start",
+            arguments: ["verbosity": "verbose"],
+            timeout: 20
+        )
         #expect(started.contains("store_path"))
         #expect(started.contains(sessionRoot.path))
 
@@ -7581,7 +8191,12 @@ struct WaxMCPProcessTests {
         defer { harness.terminateIfNeeded() }
 
         _ = try await harness.bootstrap(clientName: "wax-mcp-isolated-store-no-product-sessions")
-        let started = try await harness.callTool(id: 3, name: "session_start", arguments: [:], timeout: 20)
+        let started = try await harness.callTool(
+            id: 3,
+            name: "session_start",
+            arguments: ["verbosity": "verbose"],
+            timeout: 20
+        )
         #expect(started.contains("store_path"))
         #expect(started.contains("/.local/share/waxmcp/sessions") == false)
 

--- a/Tests/WaxTests/MemorySemanticsRankingTests.swift
+++ b/Tests/WaxTests/MemorySemanticsRankingTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import Wax
+
+@Suite("Memory semantics ranking")
+struct MemorySemanticsRankingTests {
+    @Test
+    func recentHandoffOutranksGenericRecentLessonAtEqualRetrievalScore() {
+        let nowMs: Int64 = 2_000_000_000_000
+        let recent = String(nowMs - (60 * 60 * 1000))
+        let handoff = MemorySemantics.rankingReasons(
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.handoff.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.ephemeral.rawValue,
+                MemoryMetadataKeys.createdAtMs: recent,
+            ],
+            scope: nil,
+            nowMs: nowMs
+        )
+        let lesson = MemorySemantics.rankingReasons(
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.lesson.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                MemoryMetadataKeys.createdAtMs: recent,
+            ],
+            scope: nil,
+            nowMs: nowMs
+        )
+
+        #expect(handoff.adjustment > lesson.adjustment)
+        #expect(handoff.reasons.contains("recent handoff"))
+    }
+
+    @Test
+    func oldHandoffIsPenalizedAndMarkedStale() {
+        let nowMs: Int64 = 2_000_000_000_000
+        let old = String(nowMs - (30 * 24 * 60 * 60 * 1000))
+        let handoff = MemorySemantics.rankingReasons(
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.handoff.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.ephemeral.rawValue,
+                MemoryMetadataKeys.createdAtMs: old,
+            ],
+            scope: nil,
+            nowMs: nowMs
+        )
+
+        #expect(handoff.adjustment < 0)
+        #expect(handoff.reasons.contains("stale handoff"))
+    }
+}

--- a/Tests/WaxTests/VirtualSessionStoreTests.swift
+++ b/Tests/WaxTests/VirtualSessionStoreTests.swift
@@ -170,6 +170,83 @@ struct VirtualSessionStoreTests {
     }
 
     @Test
+    func endingSessionIsNotRoutableAcrossSuspension() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let started = try await startSession(store, agentID: "ending-agent", runID: "ending-run")
+            await store.setEndHoldForTesting(.milliseconds(200))
+
+            let ending = Task { try await store.end(sessionID: started.state.id) }
+            while !store.live.isEmpty {
+                await Task.yield()
+            }
+
+            #expect(throws: (any Error).self) {
+                _ = try store.lookup(started.state.id)
+            }
+            await #expect(throws: (any Error).self) {
+                _ = try await store.ensureLive(started.state.id)
+            }
+            await #expect(throws: (any Error).self) {
+                _ = try await store.resume(
+                    explicitSessionID: started.state.id,
+                    agentID: nil,
+                    runID: nil
+                )
+            }
+            await #expect(throws: (any Error).self) {
+                _ = try await startSession(store, agentID: "ending-agent", runID: "ending-run")
+            }
+            #expect(try await ending.value.ended == true)
+        }
+    }
+
+    @Test
+    func closeFailureKeepsSessionReservedAndExplicitEndCanRetry() async throws {
+        try await withVirtualSessionStore { store, _ in
+            let started = try await startSession(store, agentID: "retry-end-agent", runID: "retry-end-run")
+            await store.setEndCloseFailuresForTesting(1)
+
+            await #expect(throws: (any Error).self) {
+                _ = try await store.end(sessionID: started.state.id)
+            }
+            #expect(store.live.isEmpty)
+            #expect(throws: (any Error).self) {
+                _ = try store.lookup(started.state.id)
+            }
+
+            let retried = try await store.end(sessionID: started.state.id)
+            #expect(retried.ended == true)
+            #expect(retried.sessionID == started.state.id)
+        }
+    }
+
+    @Test
+    func endEventFailureLeavesManifestActiveAndSessionRetryable() async throws {
+        try await withVirtualSessionStore { store, root in
+            let started = try await startSession(store, agentID: "retry-event-agent", runID: "retry-event-run")
+            await store.setEndEventFailuresForTesting(1)
+
+            await #expect(throws: (any Error).self) {
+                _ = try await store.end(sessionID: started.state.id)
+            }
+            let manifest = try BrokerSessionPersistence.loadManifest(
+                rootURL: root,
+                sessionID: started.state.id
+            )
+            #expect(manifest.status == .active)
+            switch try store.lookup(started.state.id) {
+            case .live:
+                break
+            case .none:
+                Issue.record("event failure made the session unroutable")
+            }
+
+            let retried = try await store.end(sessionID: started.state.id)
+            #expect(retried.ended == true)
+        }
+    }
+
+    @Test
     func resumeStealsAForeignLeaseAndReportsRecoveredLease() async throws {
         try await withVirtualSessionStore(brokerInstanceID: "owner-a") { firstStore, root in
             let started = try await startSession(firstStore, agentID: "lease-agent", runID: "lease-run")


### PR DESCRIPTION
## Summary

This PR turns the repeated WaxMCP agent feedback into tested transport, retrieval, write-receipt, handoff, and lifecycle fixes.

- Default every successful MCP tool response to one compact JSON text block. The previous adapter emitted byte-identical JSON as both text and an embedded resource, while read tools also duplicated narrative and structured results.
- Add transport-wide `verbosity: compact|verbose`. Compact recursively removes broker presentation fields and host paths without deleting user metadata; verbose returns narrative text plus standard MCP `structuredContent` with diagnostic paths intact.
- Let omitted-mode recall use the configured hybrid path when stored vector coverage is partial. A degraded store no longer silently forces `effective_mode=text` when query embeddings are healthy.
- Return stable write receipts (`frame_id`, `memory_id`, horizon, semantics, searchable, deduplicated) from a typed per-write result instead of inferring them from reentrant store-wide counters.
- Ignore volatile creation timestamps in exact remember dedupe identity, so retrying the same semantic write returns the existing frame.
- Store handoff content and pending tasks once, normalize project lanes, and supersede only the prior handoff from the same session lineage. Pending mutations participate in predecessor lookup, and the handoff sequence is serialized.
- Raise recent handoffs above generic lessons while explicitly penalizing stale handoffs.
- Improve invalid-argument errors by listing accepted keys and reject malformed verbosity values at runtime.
- Harden session end: broker commands drain before close; ending sessions become unroutable before suspension; flush/event/manifest/close ordering is retryable; injected event and close failures have regression coverage.

## Root causes

1. `WaxMCPTools` deliberately constructed two equivalent MCP content blocks and only removed top-level `display_text`.
2. `LayeredRecall` treated partial saved-vector coverage as query-embedding unavailability and overrode the configured default mode to text.
3. `wax.created_at_ms` changed on every retry, defeating exact dedupe, while receipts compared global counters across actor suspension points.
4. Handoff replacement was project-wide, committed-only, and actor-reentrant, so concurrent sessions could hide each other or create conflicting supersede relations.
5. `VirtualSessionStore.end` removed a session before flush/close and did not reserve it from reentrant routing during teardown.

## Verification

- `swift test --traits MCPServer --filter WaxMCPServerTests -Xswiftc -suppress-warnings` — **182 passed**
- `swift test --filter VirtualSessionStoreTests -Xswiftc -suppress-warnings` — **23 passed**
- `swift test --traits MCPServer --filter WaxMCPReliabilityPlanContractsTests -Xswiftc -suppress-warnings` — **14 passed**
- `swift test --filter DeduplicationTests -Xswiftc -suppress-warnings` — **7 passed**
- `swift test --filter MemorySemanticsRankingTests -Xswiftc -suppress-warnings` — **2 passed**
- Real stdio JSON-RPC process canary (`compactToolResponseUsesOneWireContentBlock`) — **passed**
- `bash Resources/scripts/quality/check_corruption_assertions.sh` — **passed**
- MCP skill source and npm copy — **byte-identical**
- Public-repository hygiene query — **no matches**
- Independent code review — **APPROVE**; security review found no high/critical security issue after remediation

### Full-gate baseline limitation

`bash Resources/scripts/quality/production_readiness_gates.sh full` reached the default 1,311-test phase but failed on 11 existing issues before the MCP-trait phase. A detached worktree at exact `origin/main` (`572b7865b`) reproduces the same selected failures: stale surrogate-source expectations, five vector-delete chunk fixtures, the PDF chunk fixture, and VideoRAG equal-score tolerance. The embedding-readiness timeout is load-sensitive and passes focused on both trees. The affected code is outside this PR; the MCP trait target and session regressions pass independently as listed above.

## Remaining limitations

- Wax still has no operator verb to backfill/re-embed frames missing stored vectors. Hybrid recall now uses semantic retrieval where vectors exist and the text leg for the remainder.
- Compatibility aliases remain published; this PR documents canonical verbs but does not remove tool aliases.
- Arbitrary frame editing/relabeling is not added. Handoffs use safe same-lineage supersession; other corrections still append/supersede through existing APIs.
- Retrieval scores remain additive and intentionally unbounded rather than normalized probabilities.
