### PR TITLE
fix(mcp): prevent broker auto-start EBADF

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerClient.swift
+++ b/Sources/Wax/Broker/AgentBrokerClient.swift
@@ -133,10 +133,15 @@ package enum AgentBrokerClient {
         }
         process.environment = ProcessInfo.processInfo.environment
 
-        let nullDevice = FileHandle(forWritingAtPath: "/dev/null")
+        // Keep stdin and stdout on separate descriptors. Foundation may close a
+        // shared descriptor while it configures the child process stdio actions.
+        guard let nullInput = FileHandle(forReadingAtPath: "/dev/null"),
+              let nullOutput = FileHandle(forWritingAtPath: "/dev/null") else {
+            throw BrokerClientError("Unable to open /dev/null for broker stdio")
+        }
         let stderrPipe = Pipe()
-        process.standardInput = nullDevice
-        process.standardOutput = nullDevice
+        process.standardInput = nullInput
+        process.standardOutput = nullOutput
         process.standardError = stderrPipe
 
         do {

--- a/Tests/WaxTests/PackageTraitManifestTests.swift
+++ b/Tests/WaxTests/PackageTraitManifestTests.swift
@@ -42,6 +42,16 @@ import Testing
     #expect(!source.contains("envKey: \"WAX_BROKER_START_TIMEOUT_SECS\",\n        defaultValue: 5.0"))
 }
 
+@Test func brokerAutostartUsesIndependentNullDeviceDescriptors() throws {
+    let source = try PackageSource.load("Sources/Wax/Broker/AgentBrokerClient.swift")
+
+    #expect(source.contains("FileHandle(forReadingAtPath: \"/dev/null\")"))
+    #expect(source.contains("FileHandle(forWritingAtPath: \"/dev/null\")"))
+    #expect(source.contains("process.standardInput = nullInput"))
+    #expect(source.contains("process.standardOutput = nullOutput"))
+    #expect(!source.contains("let nullDevice = FileHandle(forWritingAtPath: \"/dev/null\")"))
+}
+
 @Test func brokerCorpusStoreBuildDoesNotDeleteExistingCorpusBeforeReplacement() throws {
     let source = try PackageSource.load("Sources/Wax/Broker/BrokerCorpusStore.swift")
 


### PR DESCRIPTION
## Summary

- Open separate read-only and write-only `/dev/null` descriptors for broker stdin/stdout.
- Fail with an actionable error if broker stdio setup cannot open `/dev/null`.
- Add a regression contract for the independent descriptor wiring.

This fixes the macOS broker auto-start path that surfaced `NSPOSIXErrorDomain error 9 (Bad file descriptor)` during `waxmcp_session_open`.

## Verification

- `swift build --traits MCPServer --product wax-mcp --disable-automatic-resolution`
- `swift test --traits MCPServer --disable-automatic-resolution --filter brokerAutostartUsesIndependentNullDeviceDescriptors`
- `swift test --traits MCPServer --filter WaxMCPProcessTests` — 30 passed
- Isolated patched-binary stdio canary — `session_open` returned `status: ok`, no broker startup error
- `bash Resources/scripts/quality/check_corruption_assertions.sh`
- `git diff --check`

The repository-wide `bash Resources/scripts/quality/production_readiness_gates.sh full` was also run. It remains red on unrelated existing/flaky suites (embedding-readiness timing, TUI demo text, surrogate/vector/PDF/video tests, and memory-delete durability); the MCP process suite and this change's focused tests pass.
