### PR TITLE
review: clamp breaker elapsed, drop zero-sentinel nowMs, share test clock

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -281,11 +281,12 @@ package actor MemoryOrchestrator {
     /// another timeout re-opens it for a fresh cooldown window.
     private var queryEmbeddingCircuitOpen: Bool {
         guard let openedAtMs = queryEmbeddingCircuitOpenedAtMs else { return false }
-        return nowProvider() - openedAtMs < Self.circuitCooldownMs(config.queryEmbeddingCircuitCooldown)
+        return max(0, nowProvider() - openedAtMs) < Self.circuitCooldownMs(config.queryEmbeddingCircuitCooldown)
     }
 
-    /// Mirrors the previous `ContinuousClock` comparison: open while elapsed < cooldown,
-    /// closed once elapsed >= cooldown (boundary inclusive half-close).
+    /// Circuit uses wall-clock epoch ms with the same open/half-open thresholds;
+    /// sub-ms `Duration` components truncate. A backward system-clock step can
+    /// extend an open window until wall time catches up (self-heals on next probe).
     private static func circuitCooldownMs(_ duration: Duration) -> Int64 {
         duration.components.seconds * 1000
             + duration.components.attoseconds / 1_000_000_000_000_000

--- a/Sources/Wax/RAG/FastRAGConfig.swift
+++ b/Sources/Wax/RAG/FastRAGConfig.swift
@@ -117,7 +117,9 @@ package struct FastRAGConfig: Sendable, Equatable {
     package var enableQueryAwareTierSelection: Bool = true
     
     /// Optional fixed "now" timestamp used for deterministic tier selection.
-    /// When nil, Wax uses wall clock time.
+    /// When nil, the builder resolves "now" as the max candidate frame timestamp;
+    /// if that is also unavailable, "now" is unknown and no access-recency signals
+    /// are produced (never wall clock time).
     package var deterministicNowMs: Int64? = nil
 
     package init(

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -91,13 +91,12 @@ package struct FastRAGContextBuilder: Sendable {
         //    that have not set deterministicNowMs (e.g., tests). Note: this may understate
         //    recency for stores where all frames are old relative to wall clock.
         // Both values derive from store state, so tier selection and access-recency
-        // explanations stay deterministic. The zero fallback is reachable only for
-        // direct callers that set neither deterministicNowMs nor prefetchable frame
-        // metas (production always sets deterministicNowMs via ragConfigForRecall);
-        // accessReasons clamps negative ages to zero in that case.
+        // explanations stay deterministic. When neither source exists, nowMs stays nil:
+        // unknown-now produces no access-recency signal (access-reason enrichment is
+        // skipped) instead of a maximal "recently used" signal from a zero sentinel,
+        // and surrogate tiers keep full fidelity rather than a fabricated zero age.
         let nowMs = clamped.deterministicNowMs
             ?? sourceFrameMetasTask.values.map(\.timestamp).max()
-            ?? 0
 
         // 2) Expansion: first result with valid UTF-8 frame content
         if clamped.expansionMaxTokens > 0, clamped.expansionMaxBytes > 0 {
@@ -213,15 +212,20 @@ package struct FastRAGContextBuilder: Sendable {
                     group.addTask {
                         guard let data = surrogateContents[item.surrogateFrameId] else { return (index, nil) }
 
-                        let frameTimestamp = frameMetaMap[item.result.frameId]?.timestamp ?? nowMs
-                        let context = TierSelectionContext(
-                            frameTimestamp: frameTimestamp,
-                            accessStats: accessStatsMap[item.result.frameId],
-                            querySignals: querySignals,
-                            nowMs: nowMs
-                        )
-
-                        let selectedTier = tierSelector.selectTier(context: context)
+                        let selectedTier: SurrogateTier
+                        if let nowMs {
+                            let frameTimestamp = frameMetaMap[item.result.frameId]?.timestamp ?? nowMs
+                            let context = TierSelectionContext(
+                                frameTimestamp: frameTimestamp,
+                                accessStats: accessStatsMap[item.result.frameId],
+                                querySignals: querySignals,
+                                nowMs: nowMs
+                            )
+                            selectedTier = tierSelector.selectTier(context: context)
+                        } else {
+                            // Unknown "now": no age/recency basis for compression.
+                            selectedTier = .full
+                        }
                         guard let text = SurrogateTierSelector.extractTier(from: data, tier: selectedTier),
                               !text.isEmpty else { return (index, nil) }
 
@@ -390,9 +394,13 @@ package struct FastRAGContextBuilder: Sendable {
         _ existing: [String],
         frameId: UInt64,
         accessStatsMap: [UInt64: FrameAccessStats],
-        nowMs: Int64
+        nowMs: Int64?
     ) -> [String] {
-        let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[frameId], nowMs: nowMs).reasons
+        // Unknown "now" skips access-reason enrichment: a zero sentinel would mark
+        // every frame with access stats as "recently used".
+        let accessReasons = nowMs.map {
+            MemorySemantics.accessReasons(stats: accessStatsMap[frameId], nowMs: $0).reasons
+        } ?? []
         var seen = Set<String>()
         var combined: [String] = []
         for reason in existing + accessReasons {

--- a/Tests/WaxIntegrationTests/DeterministicRecallTests.swift
+++ b/Tests/WaxIntegrationTests/DeterministicRecallTests.swift
@@ -3,25 +3,6 @@ import Testing
 @testable import Wax
 import WaxCore
 
-/// Injectable orchestrator clock for proving recall decisions depend only on
-/// `(store state, query, nowMs)`.
-private final class RecallClock: @unchecked Sendable {
-    private let lock = NSLock()
-    private var value: Int64
-
-    init(_ start: Int64) {
-        value = start
-    }
-
-    var nowMs: Int64 {
-        get { lock.withLock { value } }
-    }
-
-    func advance(ms: Int64) {
-        lock.withLock { value += ms }
-    }
-}
-
 @Suite
 struct DeterministicRecallTests {
     private static let fixedNowMs: Int64 = 1_700_000_000_000
@@ -144,7 +125,7 @@ struct DeterministicRecallTests {
                 try await ingest.close()
             }
 
-            let clock = RecallClock(Self.fixedNowMs)
+            let clock = MutableClock(Self.fixedNowMs)
             var config = TestHelpers.defaultMemoryConfig()
             config.enableAccessStatsScoring = true
             let orchestrator = try await MemoryOrchestrator(

--- a/Tests/WaxIntegrationTests/Mocks/TestHelpers.swift
+++ b/Tests/WaxIntegrationTests/Mocks/TestHelpers.swift
@@ -12,3 +12,21 @@ enum TestHelpers {
         return config
     }
 }
+
+/// Injectable orchestrator clock so tests advance time without sleeping.
+final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Int64
+
+    init(_ start: Int64) {
+        value = start
+    }
+
+    var nowMs: Int64 {
+        get { lock.withLock { value } }
+    }
+
+    func advance(ms: Int64) {
+        lock.withLock { value += ms }
+    }
+}

--- a/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
@@ -40,24 +40,6 @@ private actor HangingVectorEngine: VectorSearchEngine {
     }
 }
 
-/// Injectable orchestrator clock so breaker tests advance time without sleeping.
-private final class MutableClock: @unchecked Sendable {
-    private let lock = NSLock()
-    private var value: Int64
-
-    init(_ start: Int64) {
-        value = start
-    }
-
-    var nowMs: Int64 {
-        get { lock.withLock { value } }
-    }
-
-    func advance(ms: Int64) {
-        lock.withLock { value += ms }
-    }
-}
-
 @Suite
 struct TimeoutFallbackTests {
     @Test


### PR DESCRIPTION
Follow-up to #140 (swift-pr-review run e1d3f0f4, 9-lane multi-agent review of the merged head). Three multi-lane-consensus minors from that review, still present after merge:

- **Breaker skew floor** (`MemoryOrchestrator.queryEmbeddingCircuitOpen`): clamp elapsed to `max(0, nowProvider() - openedAtMs)` so a backward NTP/manual step can't hold the vector lane disabled past cooldown (restores the monotonic floor); comment rewritten to state the current wall-clock contract instead of claiming it mirrors ContinuousClock.
- **Zero-sentinel recency fabrication** (`FastRAGContextBuilder`): resolve `nowMs` as stamp → max frame timestamp → nil and skip access-recency enrichment when unresolved, so direct callers without `deterministicNowMs` no longer get universal '+0.15 recently used' reasons; `FastRAGConfig.deterministicNowMs` doc corrected (never wall clock).
- **Shared test clock**: one `MutableClock` in TestHelpers replaces byte-identical `RecallClock`/`MutableClock` copies in two suites.

Verification: DeterministicRecallTests 3/3 · TimeoutFallbackTests 4/4 · AccessStatsTests 10/10 · UnifiedSearchTests 38/38 · MatchPlanTests 4/4