### PR TITLE
refactor(types): deduplicate QueryEmbeddingState and Source twins

### DIFF
--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -167,7 +167,7 @@ public actor Memory {
         results.diagnostics = RAGContext.Diagnostics(
             requestedMode: execution.requestedMode,
             effectiveMode: execution.effectiveMode,
-            queryEmbeddingState: RAGContext.QueryEmbeddingState(execution.queryEmbeddingState)
+            queryEmbeddingState: execution.queryEmbeddingState
         )
         return results
     }

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -11,16 +11,6 @@ package actor MemoryOrchestrator {
         case always
     }
 
-    package enum QueryEmbeddingState: String, Sendable, Equatable {
-        case notRequested = "not_requested"
-        case available = "available"
-        case timeout = "timeout"
-        case circuitOpen = "circuit_open"
-        case noEmbedder = "no_embedder"
-        case vectorDisabled = "vector_disabled"
-        case failed = "failed"
-    }
-
     /// Stable search hit DTO for MCP and other raw-search callers.
     package struct MemorySearchHit: Sendable, Equatable {
         package var frameId: UInt64
@@ -51,13 +41,13 @@ package actor MemoryOrchestrator {
         package var hits: [MemorySearchHit]
         package var requestedMode: SearchMode
         package var effectiveMode: SearchMode
-        package var queryEmbeddingState: QueryEmbeddingState
+        package var queryEmbeddingState: RAGContext.QueryEmbeddingState
 
         package init(
             hits: [MemorySearchHit],
             requestedMode: SearchMode,
             effectiveMode: SearchMode,
-            queryEmbeddingState: QueryEmbeddingState
+            queryEmbeddingState: RAGContext.QueryEmbeddingState
         ) {
             self.hits = hits
             self.requestedMode = requestedMode
@@ -70,13 +60,13 @@ package actor MemoryOrchestrator {
         package var context: RAGContext
         package var requestedMode: SearchMode
         package var effectiveMode: SearchMode
-        package var queryEmbeddingState: QueryEmbeddingState
+        package var queryEmbeddingState: RAGContext.QueryEmbeddingState
 
         package init(
             context: RAGContext,
             requestedMode: SearchMode,
             effectiveMode: SearchMode,
-            queryEmbeddingState: QueryEmbeddingState
+            queryEmbeddingState: RAGContext.QueryEmbeddingState
         ) {
             self.context = context
             self.requestedMode = requestedMode
@@ -1549,7 +1539,7 @@ package actor MemoryOrchestrator {
 
     private struct QueryEmbeddingResult {
         let embedding: [Float]?
-        let state: QueryEmbeddingState
+        let state: RAGContext.QueryEmbeddingState
     }
 
     private static func queryEmbeddingPolicy(for mode: SearchMode) -> QueryEmbeddingPolicy {

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -103,7 +103,7 @@ package struct FastRAGContextBuilder: Sendable {
                             kind: .expanded,
                             frameId: result.frameId,
                             score: result.score,
-                            sources: RAGContext.Source.fromSearchSources(result.sources),
+                            sources: result.sources.isEmpty ? [.unknown] : result.sources,
                             text: expanded,
                             metadata: result.metadata,
                             explanations: enrichedExplanations(
@@ -246,7 +246,7 @@ package struct FastRAGContextBuilder: Sendable {
                             kind: .surrogate,
                             frameId: surrogateFrameId,
                             score: result.score,
-                            sources: RAGContext.Source.fromSearchSources(result.sources),
+                            sources: result.sources.isEmpty ? [.unknown] : result.sources,
                             text: capped,
                             metadata: result.metadata,
                             explanations: enrichedExplanations(
@@ -339,7 +339,7 @@ package struct FastRAGContextBuilder: Sendable {
                             kind: .snippet,
                             frameId: result.frameId,
                             score: result.score,
-                            sources: RAGContext.Source.fromSearchSources(result.sources),
+                            sources: result.sources.isEmpty ? [.unknown] : result.sources,
                             text: capped,
                             metadata: result.metadata,
                             explanations: enrichedExplanations(

--- a/Sources/Wax/RAG/RAGContext.swift
+++ b/Sources/Wax/RAG/RAGContext.swift
@@ -103,27 +103,6 @@ public struct RAGContext: Sendable, Equatable {
     }
 }
 
-package extension RAGContext.QueryEmbeddingState {
-    init(_ state: MemoryOrchestrator.QueryEmbeddingState) {
-        switch state {
-        case .notRequested:
-            self = .notRequested
-        case .available:
-            self = .available
-        case .timeout:
-            self = .timeout
-        case .circuitOpen:
-            self = .circuitOpen
-        case .noEmbedder:
-            self = .noEmbedder
-        case .vectorDisabled:
-            self = .vectorDisabled
-        case .failed:
-            self = .failed
-        }
-    }
-}
-
 public extension RAGContext.Source {
     var rawValue: String {
         switch self {
@@ -138,25 +117,5 @@ public extension RAGContext.Source {
         case .unknown:
             return "unknown"
         }
-    }
-}
-
-package extension RAGContext.Source {
-    static func fromSearchSource(_ source: SearchResponse.Source) -> RAGContext.Source {
-        switch source {
-        case .text:
-            return .text
-        case .vector:
-            return .vector
-        case .timeline:
-            return .timeline
-        case .structuredMemory:
-            return .structured
-        }
-    }
-
-    static func fromSearchSources(_ sources: [SearchResponse.Source]) -> [RAGContext.Source] {
-        if sources.isEmpty { return [.unknown] }
-        return sources.map(fromSearchSource)
     }
 }

--- a/Sources/Wax/UnifiedSearch/SearchResponse.swift
+++ b/Sources/Wax/UnifiedSearch/SearchResponse.swift
@@ -1,11 +1,7 @@
 /// Unified search response.
 package struct SearchResponse: Sendable, Equatable {
-    package enum Source: String, Sendable, Equatable, CaseIterable {
-        case text
-        case vector
-        case timeline
-        case structuredMemory
-    }
+    /// Single source-vocabulary type shared with `RAGContext`.
+    package typealias Source = RAGContext.Source
 
     package enum RankingTieBreakReason: String, Sendable, Equatable {
         case topResult

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -301,7 +301,7 @@ extension Wax {
                 let fused = Self.rrfFusionResults(
                     lists: [
                         (source: .text, weight: weights.bm25, frameIds: textIds),
-                        (source: .structuredMemory, weight: structuredWeight, frameIds: structuredIds),
+                        (source: .structured, weight: structuredWeight, frameIds: structuredIds),
                     ],
                     k: request.rrfK,
                     includeDiagnostics: diagnosticsEnabled,
@@ -310,7 +310,7 @@ extension Wax {
 
                 baseResults = fused.map { entry in
                     let sources = entry.sources.isEmpty
-                        ? (textSet.contains(entry.frameId) ? [.text] : [.structuredMemory])
+                        ? (textSet.contains(entry.frameId) ? [.text] : [.structured])
                         : entry.sources
                     return BaseResult(
                         frameId: entry.frameId,
@@ -352,7 +352,7 @@ extension Wax {
                 let fused = Self.rrfFusionResults(
                     lists: [
                         (source: .vector, weight: weights.vector, frameIds: vectorIds),
-                        (source: .structuredMemory, weight: structuredWeight, frameIds: structuredIds),
+                        (source: .structured, weight: structuredWeight, frameIds: structuredIds),
                     ],
                     k: request.rrfK,
                     includeDiagnostics: diagnosticsEnabled,
@@ -361,7 +361,7 @@ extension Wax {
 
                 baseResults = fused.map { entry in
                     let sources = entry.sources.isEmpty
-                        ? (vectorSet.contains(entry.frameId) ? [.vector] : [.structuredMemory])
+                        ? (vectorSet.contains(entry.frameId) ? [.vector] : [.structured])
                         : entry.sources
                     return BaseResult(
                         frameId: entry.frameId,
@@ -384,7 +384,7 @@ extension Wax {
             if textWeight > 0, !textIds.isEmpty { lists.append((source: .text, weight: textWeight, frameIds: textIds)) }
             if vectorWeight > 0, !vectorIds.isEmpty { lists.append((source: .vector, weight: vectorWeight, frameIds: vectorIds)) }
             if weights.temporal > 0, !timelineIds.isEmpty { lists.append((source: .timeline, weight: weights.temporal, frameIds: timelineIds)) }
-            if structuredWeight > 0, !structuredIds.isEmpty { lists.append((source: .structuredMemory, weight: structuredWeight, frameIds: structuredIds)) }
+            if structuredWeight > 0, !structuredIds.isEmpty { lists.append((source: .structured, weight: structuredWeight, frameIds: structuredIds)) }
 
             var fused = Self.rrfFusionResults(
                 lists: lists,
@@ -426,7 +426,7 @@ extension Wax {
                     if textSet.contains(entry.frameId) { sources.append(.text) }
                     if vectorSet.contains(entry.frameId) { sources.append(.vector) }
                     if timelineSet.contains(entry.frameId) { sources.append(.timeline) }
-                    if structuredSet.contains(entry.frameId) { sources.append(.structuredMemory) }
+                    if structuredSet.contains(entry.frameId) { sources.append(.structured) }
                 }
                 return BaseResult(
                     frameId: entry.frameId,
@@ -808,7 +808,7 @@ extension Wax {
         if sources.contains(.text) {
             reasons.append("keyword match")
         }
-        if sources.contains(.structuredMemory) {
+        if sources.contains(.structured) {
             reasons.append("linked entity or fact evidence")
         }
         if sources.contains(.timeline) {

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -207,7 +207,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         )
 
         #expect(latestResponse.results.map(\.frameId) == [evidenceFrame])
-        #expect(latestResponse.results.first?.sources == [.structuredMemory])
+        #expect(latestResponse.results.first?.sources == [.structured])
 
         let outOfFrameRangeResponse = try await session.search(
             SearchRequest(
@@ -286,7 +286,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         )
 
         #expect(response.results.map(\.frameId) == [evidenceFrame])
-        #expect(response.results.first?.sources == [.structuredMemory])
+        #expect(response.results.first?.sources == [.structured])
 
         await session.close()
         try await wax.close()
@@ -1568,7 +1568,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let timelineResult = try #require(byID[timelineOnly])
         #expect(textResult.sources.contains(.text))
         #expect(vectorResult.sources.contains(.vector))
-        #expect(evidenceResult.sources.contains(.structuredMemory))
+        #expect(evidenceResult.sources.contains(.structured))
         #expect(timelineResult.sources.contains(.timeline))
         #expect(timelineResult.sources.contains(.text) == false)
 
@@ -1578,7 +1578,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         #expect(laneSources.contains(.text))
         #expect(laneSources.contains(.vector))
         #expect(laneSources.contains(.timeline))
-        #expect(laneSources.contains(.structuredMemory))
+        #expect(laneSources.contains(.structured))
 
         for (previous, next) in zip(response.results, response.results.dropFirst()) {
             #expect(previous.score >= next.score)


### PR DESCRIPTION
## Ticket T2 — functional-evolution spec (candidate 01b). Stacked on #151.

Spec: /var/folders/ns/xmz0zmpj7p148vdgr4bwzp8h0000gn/T/swift-arch-0b27937a/spec/spec-architecture-functional-evolution.md

### What
One declaration each: `RAGContext.QueryEmbeddingState` (public twin kept; package copy in MemoryOrchestrator deleted, raw values byte-stable) and `RAGContext.Source` (`SearchResponse.Source` is now a typealias; converter pair deleted; `CaseIterable` dropped as dead surface — zero allCases/(rawValue:) uses). Empty-sources `[.unknown]` defaulting inlined at 3 FastRAGContextBuilder sites. Net −55 lines.

### Wire-format note (CON-004 ruled by reviewer)
Structured-lane emitted source label changes `"structuredMemory"` → `"structured"`. Ruled ACCEPT with evidence: the only parse-back site (`LayeredRecall.ragSources(from:)`) never accepted the old string — it silently dropped structured labels to `.unknown`; rename **repairs** that latent loss. Zero consumers/docs/hermes/npm pin the old label; decode side untouched.

### Review
Implementer: fresh subagent (`3d3a7f99b`) · Review 1: swift-adversarial-pr-review → APPROVE, no fixes · Final pass: second fresh adversarial reviewer → APPROVE, all 6 prior claims independently verified, no fixes.

### Verification
UnifiedSearchTests 38✓ · WaxPublicDocsTests 4✓ · DocsPasteHarnessTests 9✓ · BrokerCommandDecodeTests 23✓ · MemoryOrchestratorTests 16✓×2 · builds green under MiniLMEmbeddings + MCPServer traits.