### PR TITLE
refactor(core): explicit clock anchors in decision code

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -72,7 +72,7 @@ extension AgentBrokerService {
         kind: MarkdownProjectionKind,
         dateKey: String? = nil
     ) -> MarkdownProjectionMarker {
-        let info = MemorySemantics.parse(metadata: document.metadata)
+        let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
         return MarkdownProjectionMarker(
             managed: document.metadata[MemoryMetadataKeys.sourceManaged] != "false",
             sourceKind: kind.rawValue,
@@ -262,7 +262,8 @@ extension AgentBrokerService {
             metadata: metadata,
             semantics: semantics,
             sessionID: nil,
-            inferredScope: scopeContext
+            inferredScope: scopeContext,
+            nowMs: Self.nowMs()
         )
         return MemorySemantics.approvedPromotionMetadata(
             metadata: normalized,
@@ -284,6 +285,7 @@ extension AgentBrokerService {
     ) async throws -> MarkdownSyncCounts {
         var counts = MarkdownSyncCounts()
         var matchedFrameIDs = Set<UInt64>()
+        let syncAnchorMs = Self.nowMs()
 
         for entry in entries {
             let existingByMarker = trustedExistingDocument(
@@ -302,7 +304,7 @@ extension AgentBrokerService {
             let semantics = semanticsForEntry(entry, existing)
 
             if let existing {
-                let existingInfo = MemorySemantics.parse(metadata: existing.metadata)
+                let existingInfo = MemorySemantics.parse(metadata: existing.metadata, nowMs: syncAnchorMs)
                 if existing.text == entry.text,
                    existing.metadata[MemoryMetadataKeys.sourceLine] == String(entry.lineNumber),
                    existingInfo.type == (semantics.type ?? existingInfo.type),
@@ -370,7 +372,7 @@ extension AgentBrokerService {
     }
 
     private func isLockedMemory(_ document: MemoryOrchestrator.CorpusSourceDocument) -> Bool {
-        MemorySemantics.parse(metadata: document.metadata).durability == .locked
+        MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs()).durability == .locked
     }
 
     private func trustedExistingDocument(
@@ -524,7 +526,8 @@ extension AgentBrokerService {
             metadata: baseMetadata,
             semantics: semantics,
             sessionID: nil,
-            inferredScope: scopeContext
+            inferredScope: scopeContext,
+            nowMs: Self.nowMs()
         )
     }
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -284,7 +284,8 @@ extension AgentBrokerService {
             metadata: command.metadata,
             semantics: command.writeSemantics,
             sessionID: sessionID,
-            inferredScope: writeScope(for: sessionID, clientCWD: command.cwd)
+            inferredScope: writeScope(for: sessionID, clientCWD: command.cwd),
+            nowMs: Self.nowMs()
         )
         try validateDurableWriteContent(content: command.content, metadata: metadata)
         let memory = try await memory(for: sessionID)
@@ -738,7 +739,8 @@ extension AgentBrokerService {
             metadata: baseMetadata,
             semantics: writeSemantics,
             sessionID: nil,
-            inferredScope: writeScope(for: resolvedPromotionSessionID, clientCWD: command.cwd)
+            inferredScope: writeScope(for: resolvedPromotionSessionID, clientCWD: command.cwd),
+            nowMs: Self.nowMs()
         )
         if let resolvedPromotionSessionID {
             normalizedMetadata[MemoryMetadataKeys.promotedFromSession] = resolvedPromotionSessionID.uuidString
@@ -807,7 +809,8 @@ extension AgentBrokerService {
         let report = BrokerMemoryInsights.healthReport(
             documents: documents,
             accessStats: accessStats,
-            facts: facts
+            facts: facts,
+            nowMs: Self.nowMs()
         )
         return .object([
             "total_documents": .from(report.totalDocuments),
@@ -832,7 +835,8 @@ extension AgentBrokerService {
             metadata: command.metadata,
             semantics: command.writeSemantics,
             sessionID: nil,
-            inferredScope: writeScope(for: nil, clientCWD: command.cwd)
+            inferredScope: writeScope(for: nil, clientCWD: command.cwd),
+            nowMs: Self.nowMs()
         )
         try validateDurableWriteContent(content: command.content, metadata: metadata)
 
@@ -2503,7 +2507,7 @@ extension AgentBrokerService {
     }
 
     func validateDurableWriteContent(content: String, metadata: [String: String]) throws {
-        let semantics = MemorySemantics.parse(metadata: metadata)
+        let semantics = MemorySemantics.parse(metadata: metadata, nowMs: Self.nowMs())
         guard semantics.durability == .durable || semantics.durability == .locked else { return }
         if let detected = SecretHeuristics.detectSecretLikeContent(content, metadata: metadata) {
             throw BrokerValidationError.invalid("Refusing to store durable memory containing secret-like content (\(detected))")
@@ -2816,7 +2820,7 @@ extension AgentBrokerService {
     func renderMemoryMarkdown(documents: [MemoryOrchestrator.CorpusSourceDocument]) -> String {
         var sections: [MemoryType: [String]] = [:]
         for document in documents {
-            let info = MemorySemantics.parse(metadata: document.metadata)
+            let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
             guard info.durability == .durable || info.durability == .locked else { continue }
             let type = info.type
             let marker = marker(for: document, kind: .memory)

--- a/Sources/Wax/Broker/BrokerMemoryInsights.swift
+++ b/Sources/Wax/Broker/BrokerMemoryInsights.swift
@@ -292,7 +292,7 @@ package enum BrokerMemoryInsights {
         documents: [MemoryOrchestrator.CorpusSourceDocument],
         accessStats: [UInt64: FrameAccessStats],
         facts: StructuredFactsResult?,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        nowMs: Int64
     ) -> BrokerMemoryHealth {
         var typedCounts: [String: Int] = [:]
         var expired: [UInt64] = []

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -165,7 +165,7 @@ package enum MemorySemantics {
         semantics: MemoryWriteSemantics,
         sessionID: UUID?,
         inferredScope: MemoryScopeContext?,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        nowMs: Int64
     ) -> [String: String] {
         var normalized = metadata
         let resolvedType = semantics.type ?? defaultMemoryType(sessionID: sessionID, existing: metadata)
@@ -222,7 +222,7 @@ package enum MemorySemantics {
         return approved
     }
 
-    package static func parse(metadata: [String: String], nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) -> MemorySemanticInfo {
+    package static func parse(metadata: [String: String], nowMs: Int64) -> MemorySemanticInfo {
         let type = MemoryType(rawValue: metadata[MemoryMetadataKeys.type] ?? "") ?? .note
         let durability = MemoryDurability(rawValue: metadata[MemoryMetadataKeys.durability] ?? "") ?? defaultDurability(for: type)
         let createdAtMs = metadata[MemoryMetadataKeys.createdAtMs].flatMap(Int64.init)
@@ -245,7 +245,7 @@ package enum MemorySemantics {
     package static func rankingReasons(
         metadata: [String: String],
         scope: MemoryScopeContext?,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        nowMs: Int64
     ) -> (adjustment: Float, reasons: [String]) {
         let info = parse(metadata: metadata, nowMs: nowMs)
         if info.isExpired {
@@ -334,7 +334,7 @@ package enum MemorySemantics {
 
     package static func accessReasons(
         stats: FrameAccessStats?,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        nowMs: Int64
     ) -> (adjustment: Float, reasons: [String]) {
         guard let stats else { return (0, []) }
         var adjustment: Float = 0

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -951,7 +951,11 @@ package actor MemoryOrchestrator {
     }
 
     package func recall(query: String, embedding: [Float]) async throws -> RAGContext {
-        return try await buildRecallContext(query: query, embedding: embedding)
+        return try await buildRecallContext(
+            query: query,
+            embedding: embedding,
+            anchorMs: resolveOperationAnchorMs()
+        )
     }
 
     package func recall(
@@ -992,13 +996,14 @@ package actor MemoryOrchestrator {
     private func buildRecallContext(
         query: String,
         embedding: [Float]?,
+        anchorMs: Int64,
         frameFilter: FrameFilter? = nil,
         timeRange: SearchTimeRange? = nil,
         searchTopK: Int? = nil,
         searchMode: SearchMode? = nil
     ) async throws -> RAGContext {
         let preference = config.vectorEnginePreference
-        var recallConfig = ragConfigForRecall()
+        var recallConfig = ragConfigForRecall(nowMs: anchorMs)
         if let searchTopK {
             recallConfig.searchTopK = max(1, searchTopK)
         }
@@ -1025,13 +1030,13 @@ package actor MemoryOrchestrator {
         }
         let enrichedItems = context.items.map { item in
             var item = item
-            let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[item.frameId]).reasons
+            let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[item.frameId], nowMs: anchorMs).reasons
             if !accessReasons.isEmpty {
                 item.explanations = dedupedExplanations(item.explanations + accessReasons)
             }
             return item
         }
-        await recordAccessesIfEnabled(frameIds: context.items.map(\.frameId))
+        await recordAccessesIfEnabled(frameIds: context.items.map(\.frameId), nowMs: anchorMs)
         return RAGContext(query: context.query, items: enrichedItems, totalTokens: context.totalTokens)
     }
 
@@ -1086,6 +1091,7 @@ package actor MemoryOrchestrator {
         }
 
         let preference = config.vectorEnginePreference
+        let operationAnchorMs = resolveOperationAnchorMs()
 
         let snapshotEmbedder = embedderForCurrentSearch()
         if let hold = searchSnapshotHoldForTesting {
@@ -1110,6 +1116,7 @@ package actor MemoryOrchestrator {
             topK: topK,
             timeRange: timeRange,
             frameFilter: frameFilter,
+            nowMs: operationAnchorMs,
             scopeContext: config.defaultScopeContext,
             previewMaxBytes: config.rag.previewMaxBytes
         )
@@ -1121,7 +1128,7 @@ package actor MemoryOrchestrator {
             [:]
         }
         let hits = response.results.map { result in
-            let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[result.frameId]).reasons
+            let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[result.frameId], nowMs: operationAnchorMs).reasons
             return MemorySearchHit(
                 frameId: result.frameId,
                 score: result.score,
@@ -1131,7 +1138,7 @@ package actor MemoryOrchestrator {
                 explanations: dedupedExplanations(result.explanations + accessReasons)
             )
         }
-        await recordAccessesIfEnabled(frameIds: hits.map(\.frameId))
+        await recordAccessesIfEnabled(frameIds: hits.map(\.frameId), nowMs: operationAnchorMs)
         return SearchExecution(
             hits: hits,
             requestedMode: mode,
@@ -1301,10 +1308,17 @@ package actor MemoryOrchestrator {
         )
     }
 
-    private func ragConfigForRecall() -> FastRAGConfig {
+    /// Shell-side clock resolution: one anchor per search/recall operation. A config-level
+    /// deterministic override wins; otherwise the orchestrator reads the wall clock exactly
+    /// once and threads the value down so decision code never self-resolves time.
+    private func resolveOperationAnchorMs() -> Int64 {
+        config.rag.deterministicNowMs ?? Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private func ragConfigForRecall(nowMs: Int64) -> FastRAGConfig {
         var recallConfig = config.rag
         if recallConfig.deterministicNowMs == nil {
-            recallConfig.deterministicNowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            recallConfig.deterministicNowMs = nowMs
         }
         return recallConfig
     }
@@ -1493,7 +1507,8 @@ package actor MemoryOrchestrator {
         topK: Int?,
         requestedMode: SearchMode?
     ) async throws -> RecallExecution {
-        let recallConfig = ragConfigForRecall()
+        let operationAnchorMs = resolveOperationAnchorMs()
+        let recallConfig = ragConfigForRecall(nowMs: operationAnchorMs)
         let resolvedRequestedMode = requestedMode ?? recallConfig.searchMode
         let embeddingPolicy = requestedMode.map(Self.queryEmbeddingPolicy(for:)) ?? .ifAvailable
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1523,6 +1538,7 @@ package actor MemoryOrchestrator {
         let context = try await buildRecallContext(
             query: trimmedQuery,
             embedding: queryEmbedding.embedding,
+            anchorMs: operationAnchorMs,
             frameFilter: frameFilter,
             timeRange: timeRange,
             searchTopK: topK,
@@ -2231,9 +2247,9 @@ package actor MemoryOrchestrator {
         }
     }
 
-    private func recordAccessesIfEnabled(frameIds: [UInt64]) async {
+    private func recordAccessesIfEnabled(frameIds: [UInt64], nowMs: Int64) async {
         guard config.enableAccessStatsScoring, !frameIds.isEmpty else { return }
-        await accessStatsManager.recordAccesses(frameIds: frameIds)
+        await accessStatsManager.recordAccesses(frameIds: frameIds, nowMs: nowMs)
     }
 
     private func loadPersistedAccessStatsIfNeeded() async throws {

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -311,6 +311,7 @@ package actor PhotoRAGOrchestrator {
                 topK: max(query.resultLimit, config.searchTopK),
                 timeRange: timeRange,
                 frameFilter: frameFilter,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 1024,
                 allowTimelineFallback: false,
                 timelineFallbackLimit: max(query.resultLimit, config.searchTopK)

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -27,6 +27,11 @@ package struct FastRAGContextBuilder: Sendable {
         let clamped = clamp(config)
         let counter = try await TokenCounter.shared()
 
+        // One clock anchor per build operation for search-side semantic decisions
+        // (rerank explanations, expiry filtering). Config override wins; direct callers
+        // without a deterministic anchor keep wall-clock behavior.
+        let searchAnchorMs = clamped.deterministicNowMs ?? Int64(Date().timeIntervalSince1970 * 1000)
+
         // 1) Run unified search
         let request = SearchRequest(
             query: query,
@@ -36,6 +41,7 @@ package struct FastRAGContextBuilder: Sendable {
             topK: clamped.searchTopK,
             timeRange: timeRange,
             frameFilter: frameFilter,
+            nowMs: searchAnchorMs,
             scopeContext: scopeContext,
             rrfK: clamped.rrfK,
             previewMaxBytes: clamped.previewMaxBytes
@@ -109,7 +115,8 @@ package struct FastRAGContextBuilder: Sendable {
                             explanations: enrichedExplanations(
                                 result.explanations,
                                 frameId: result.frameId,
-                                accessStatsMap: accessStatsMap
+                                accessStatsMap: accessStatsMap,
+                                nowMs: searchAnchorMs
                             )
                         )
                     )
@@ -252,7 +259,8 @@ package struct FastRAGContextBuilder: Sendable {
                             explanations: enrichedExplanations(
                                 result.explanations,
                                 frameId: result.frameId,
-                                accessStatsMap: accessStatsMap
+                                accessStatsMap: accessStatsMap,
+                                nowMs: searchAnchorMs
                             )
                         )
                     )
@@ -345,7 +353,8 @@ package struct FastRAGContextBuilder: Sendable {
                             explanations: enrichedExplanations(
                                 result.explanations,
                                 frameId: result.frameId,
-                                accessStatsMap: accessStatsMap
+                                accessStatsMap: accessStatsMap,
+                                nowMs: searchAnchorMs
                             )
                         )
                     )
@@ -381,9 +390,10 @@ package struct FastRAGContextBuilder: Sendable {
     private func enrichedExplanations(
         _ existing: [String],
         frameId: UInt64,
-        accessStatsMap: [UInt64: FrameAccessStats]
+        accessStatsMap: [UInt64: FrameAccessStats],
+        nowMs: Int64
     ) -> [String] {
-        let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[frameId]).reasons
+        let accessReasons = MemorySemantics.accessReasons(stats: accessStatsMap[frameId], nowMs: nowMs).reasons
         var seen = Set<String>()
         var combined: [String] = []
         for reason in existing + accessReasons {

--- a/Sources/Wax/RAG/SurrogateTierSelector.swift
+++ b/Sources/Wax/RAG/SurrogateTierSelector.swift
@@ -18,7 +18,7 @@ package struct TierSelectionContext: Sendable {
         frameTimestamp: Int64,
         accessStats: FrameAccessStats? = nil,
         querySignals: QuerySignals? = nil,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        nowMs: Int64
     ) {
         self.frameTimestamp = frameTimestamp
         self.accessStats = accessStats

--- a/Sources/Wax/Stats/AccessStats.swift
+++ b/Sources/Wax/Stats/AccessStats.swift
@@ -14,14 +14,14 @@ package struct FrameAccessStats: Sendable, Equatable, Codable {
     /// First access timestamp (milliseconds since epoch)
     package var firstAccessMs: Int64
     
-    package init(frameId: UInt64, nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) {
+    package init(frameId: UInt64, nowMs: Int64) {
         self.frameId = frameId
         self.accessCount = 1
         self.lastAccessMs = nowMs
         self.firstAccessMs = nowMs
     }
     
-    package mutating func recordAccess(nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) {
+    package mutating func recordAccess(nowMs: Int64) {
         // Use saturating addition to prevent overflow
         accessCount = accessCount.addingReportingOverflow(1).partialValue
         lastAccessMs = nowMs
@@ -35,9 +35,8 @@ package actor AccessStatsManager {
     
     package init() {}
     
-    /// Record a single frame access.
-    package func recordAccess(frameId: UInt64) {
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+    /// Record a single frame access. The caller's shell supplies the operation anchor.
+    package func recordAccess(frameId: UInt64, nowMs: Int64) {
         if var existing = stats[frameId] {
             existing.recordAccess(nowMs: nowMs)
             stats[frameId] = existing
@@ -46,11 +45,10 @@ package actor AccessStatsManager {
         }
         dirty = true
     }
-    
-    /// Record accesses for multiple frames at once.
-    package func recordAccesses(frameIds: [UInt64]) {
+
+    /// Record accesses for multiple frames at once. The caller's shell supplies the operation anchor.
+    package func recordAccesses(frameIds: [UInt64], nowMs: Int64) {
         guard !frameIds.isEmpty else { return }
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
         for frameId in frameIds {
             if var existing = stats[frameId] {
                 existing.recordAccess(nowMs: nowMs)

--- a/Sources/Wax/UnifiedSearch/SearchRequest.swift
+++ b/Sources/Wax/UnifiedSearch/SearchRequest.swift
@@ -14,6 +14,10 @@ package struct SearchRequest: Sendable, Equatable {
     package var timeRange: SearchTimeRange?
     package var frameFilter: FrameFilter?
     package var asOfMs: Int64
+    /// Clock anchor (milliseconds since epoch) resolved once per operation by the caller's shell.
+    /// Semantic recency/expiry reranking uses this instead of reading the wall clock internally,
+    /// so identical requests on an unchanged store rank identically under the same anchor.
+    package var nowMs: Int64
     package var structuredMemory: StructuredMemorySearchOptions
     package var scopeContext: MemoryScopeContext?
 
@@ -38,6 +42,7 @@ package struct SearchRequest: Sendable, Equatable {
         timeRange: SearchTimeRange? = nil,
         frameFilter: FrameFilter? = nil,
         asOfMs: Int64 = Int64.max,
+        nowMs: Int64,
         structuredMemory: StructuredMemorySearchOptions = .init(),
         scopeContext: MemoryScopeContext? = nil,
         rrfK: Int = 60,
@@ -58,6 +63,7 @@ package struct SearchRequest: Sendable, Equatable {
         self.timeRange = timeRange
         self.frameFilter = frameFilter
         self.asOfMs = asOfMs
+        self.nowMs = nowMs
         self.structuredMemory = structuredMemory
         self.scopeContext = scopeContext
         self.rrfK = rrfK

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -579,7 +579,8 @@ extension Wax {
                     sources: item.sources,
                     rankingDiagnostics: rankingDiagnostics,
                     metadata: item.metadata,
-                    scopeContext: request.scopeContext
+                    scopeContext: request.scopeContext,
+                    nowMs: request.nowMs
                 )
             )
         }
@@ -594,6 +595,7 @@ extension Wax {
         filtered = Self.semanticMemoryRerank(
             results: filtered,
             scopeContext: request.scopeContext,
+            nowMs: request.nowMs,
             maxWindow: min(max(request.topK * 3, 12), 48)
         )
         if let identifierWindow, let trimmedQuery {
@@ -668,7 +670,8 @@ extension Wax {
                         sources: [.timeline],
                         rankingDiagnostics: nil,
                         metadata: meta.metadata?.entries ?? [:],
-                        scopeContext: request.scopeContext
+                        scopeContext: request.scopeContext,
+                        nowMs: request.nowMs
                     )
                 )
             )
@@ -684,7 +687,7 @@ extension Wax {
     private static func semanticMemoryRerank(
         results: [SearchResponse.Result],
         scopeContext: MemoryScopeContext?,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
+        nowMs: Int64,
         maxWindow: Int
     ) -> [SearchResponse.Result] {
         let cappedWindow = min(max(0, maxWindow), results.count)
@@ -799,7 +802,7 @@ extension Wax {
         rankingDiagnostics: SearchResponse.RankingDiagnostics?,
         metadata: [String: String],
         scopeContext: MemoryScopeContext?,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        nowMs: Int64
     ) -> [String] {
         var reasons: [String] = []
         if sources.contains(.vector) {

--- a/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
+++ b/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
@@ -255,6 +255,7 @@ package actor VideoRAGOrchestrator {
             topK: topK,
             timeRange: timeRange,
             frameFilter: frameFilter,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000),
             previewMaxBytes: 1024,
             allowTimelineFallback: isConstraintOnly,
             timelineFallbackLimit: timelineFallbackLimit

--- a/Tests/WaxIntegrationTests/AccessStatsTests.swift
+++ b/Tests/WaxIntegrationTests/AccessStatsTests.swift
@@ -15,17 +15,18 @@ import Testing
 
 @Test func accessStatsManagerRecordAndGetSingle() async {
     let manager = AccessStatsManager()
-    await manager.recordAccess(frameId: 42)
+    await manager.recordAccess(frameId: 42, nowMs: 1_000)
 
     let stats = await manager.getStats(frameId: 42)
     #expect(stats != nil)
     #expect(stats?.frameId == 42)
     #expect(stats?.accessCount == 1)
+    #expect(stats?.lastAccessMs == 1_000)
 }
 
 @Test func accessStatsManagerRecordMultiple() async {
     let manager = AccessStatsManager()
-    await manager.recordAccesses(frameIds: [1, 2, 3])
+    await manager.recordAccesses(frameIds: [1, 2, 3], nowMs: 2_000)
 
     let batch = await manager.getStats(frameIds: [1, 2, 3, 99])
     #expect(batch.count == 3)
@@ -35,15 +36,17 @@ import Testing
 
 @Test func accessStatsManagerRecordAccessesSameFrameTwice() async {
     let manager = AccessStatsManager()
-    await manager.recordAccesses(frameIds: [1, 1, 1])
+    await manager.recordAccesses(frameIds: [1, 1, 1], nowMs: 3_000)
 
     let stats = await manager.getStats(frameId: 1)
     #expect(stats?.accessCount == 3)
+    #expect(stats?.firstAccessMs == 3_000)
+    #expect(stats?.lastAccessMs == 3_000)
 }
 
 @Test func accessStatsManagerPruneStats() async {
     let manager = AccessStatsManager()
-    await manager.recordAccesses(frameIds: [1, 2, 3, 4])
+    await manager.recordAccesses(frameIds: [1, 2, 3, 4], nowMs: 4_000)
 
     await manager.pruneStats(keepingOnly: [2, 4])
     #expect(await manager.count == 2)
@@ -53,7 +56,7 @@ import Testing
 
 @Test func accessStatsManagerExportImport() async {
     let manager = AccessStatsManager()
-    await manager.recordAccesses(frameIds: [10, 20])
+    await manager.recordAccesses(frameIds: [10, 20], nowMs: 5_000)
 
     let exported = await manager.exportStats()
     #expect(exported.count == 2)
@@ -72,7 +75,7 @@ import Testing
 
 @Test func accessStatsManagerExportIfDirtyReturnsStatsWhenDirty() async {
     let manager = AccessStatsManager()
-    await manager.recordAccess(frameId: 1)
+    await manager.recordAccess(frameId: 1, nowMs: 6_000)
     let result = await manager.exportStatsIfDirty()
     #expect(result != nil)
     #expect(result?.count == 1)
@@ -80,7 +83,7 @@ import Testing
 
 @Test func accessStatsManagerMarkPersistedClearsDirty() async {
     let manager = AccessStatsManager()
-    await manager.recordAccess(frameId: 1)
+    await manager.recordAccess(frameId: 1, nowMs: 7_000)
     await manager.markPersisted()
     let result = await manager.exportStatsIfDirty()
     #expect(result == nil) // not dirty after markPersisted
@@ -88,6 +91,6 @@ import Testing
 
 @Test func accessStatsManagerRecordAccessesEmptyIsNoOp() async {
     let manager = AccessStatsManager()
-    await manager.recordAccesses(frameIds: [])
+    await manager.recordAccesses(frameIds: [], nowMs: 8_000)
     #expect(await manager.count == 0)
 }

--- a/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
+++ b/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
@@ -320,6 +320,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                 vectorEnginePreference: .cpuOnly,
                 mode: config.includeVectors ? .hybrid(alpha: config.searchAlpha) : .textOnly,
                 topK: config.topK,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 enableRankingDiagnostics: config.enableDiagnostics,
                 rankingDiagnosticsTopK: 10
             )
@@ -744,7 +745,8 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                 embedding: embedding,
                 vectorEnginePreference: .cpuOnly,
                 mode: includeVectors ? .hybrid(alpha: alpha) : .textOnly,
-                topK: topK
+                topK: topK,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
             _ = try await wax.search(request)
         }

--- a/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
+++ b/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
@@ -320,7 +320,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                 vectorEnginePreference: .cpuOnly,
                 mode: config.includeVectors ? .hybrid(alpha: config.searchAlpha) : .textOnly,
                 topK: config.topK,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 enableRankingDiagnostics: config.enableDiagnostics,
                 rankingDiagnosticsTopK: 10
             )

--- a/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
+++ b/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
@@ -153,7 +153,8 @@ final class ProductionReadinessStabilityTests: XCTestCase {
                         embedding: searchMode.usesVector ? Self.deterministicEmbedding(for: step.payload) : nil,
                         vectorEnginePreference: .cpuOnly,
                         mode: searchMode.searchMode,
-                        topK: 8
+                        topK: 8,
+                        nowMs: Int64(Date().timeIntervalSince1970 * 1000)
                     )
                 )
                 vectorSourceHits += response.results.filter { $0.sources.contains(.vector) }.count

--- a/Tests/WaxIntegrationTests/RAGBenchmarks.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarks.swift
@@ -312,7 +312,8 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 query: fixture.queryText,
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
-                topK: scale.searchTopK
+                topK: scale.searchTopK,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
             _ = try await fixture.wax.search(request)
 
@@ -334,7 +335,8 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 query: fixture.queryText,
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
-                topK: scale.searchTopK
+                topK: scale.searchTopK,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
             _ = try await fixture.wax.search(request)
 
@@ -534,7 +536,8 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 query: fixture.queryText,
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
-                topK: scale.searchTopK
+                topK: scale.searchTopK,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
             await fixture.close()
 
@@ -584,6 +587,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 512
             )
             let requestNoPreviews = SearchRequest(
@@ -591,6 +595,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 0
             )
 
@@ -629,6 +634,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 0
             )
 
@@ -657,6 +663,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 0
             )
 
@@ -870,7 +877,8 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 query: fixture.queryText,
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
-                topK: scale.searchTopK
+                topK: scale.searchTopK,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
             _ = try await fixture.wax.search(request)
 
@@ -903,7 +911,8 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 embedding: embedding,
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.7),
-                topK: scale.searchTopK
+                topK: scale.searchTopK,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
             _ = try await fixture.wax.search(request)
 

--- a/Tests/WaxIntegrationTests/RAGBenchmarks.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarks.swift
@@ -587,7 +587,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 512
             )
             let requestNoPreviews = SearchRequest(
@@ -595,7 +595,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 embedding: embedding,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 0
             )
 
@@ -634,7 +634,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 0
             )
 
@@ -663,7 +663,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.7),
                 topK: scale.searchTopK,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 previewMaxBytes: 0
             )
 

--- a/Tests/WaxIntegrationTests/READMEExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/READMEExamplesTests.swift
@@ -186,7 +186,7 @@ func readmeExampleUnifiedSearchAPI() async throws {
         try await text.commit()
         try await vec.commit()
 
-        let request = SearchRequest(query: "Hello", mode: .hybrid(alpha: 0.5), topK: 10)
+        let request = SearchRequest(query: "Hello", mode: .hybrid(alpha: 0.5), topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         let response = try await wax.search(request)
         #expect(response.results.count >= 0)
 

--- a/Tests/WaxIntegrationTests/SearchScoreOrderTests.swift
+++ b/Tests/WaxIntegrationTests/SearchScoreOrderTests.swift
@@ -48,7 +48,8 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
             SearchRequest(
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
-                topK: 2
+                topK: 2,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
                 textEngine: nil,
@@ -88,7 +89,8 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
                 textEngine: nil,
@@ -136,6 +138,7 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
                 topK: 2,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(

--- a/Tests/WaxIntegrationTests/SearchScoreOrderTests.swift
+++ b/Tests/WaxIntegrationTests/SearchScoreOrderTests.swift
@@ -138,7 +138,7 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
                 topK: 2,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(

--- a/Tests/WaxIntegrationTests/SurrogateMaintenanceTests.swift
+++ b/Tests/WaxIntegrationTests/SurrogateMaintenanceTests.swift
@@ -46,7 +46,7 @@ func optimizeSurrogatesCreatesSurrogateFramesAndExcludesFromDefaultSearch() asyn
         #expect(surrogates.allSatisfy { $0.metadata?.entries["source_content_hash"] != nil })
         #expect(surrogates.allSatisfy { $0.metadata?.entries["surrogate_max_tokens"] != nil })
 
-        let search = try await wax.search(.init(query: "actors", mode: .textOnly, topK: 50))
+        let search = try await wax.search(.init(query: "actors", mode: .textOnly, topK: 50, nowMs: Int64(Date().timeIntervalSince1970 * 1000)))
         for result in search.results {
             let meta = try await wax.frameMeta(frameId: result.frameId)
             #expect(meta.kind != "surrogate")

--- a/Tests/WaxIntegrationTests/TextSearchORFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TextSearchORFallbackTests.swift
@@ -27,7 +27,8 @@ import WaxVectorSearch
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
                 mode: .textOnly,
-                topK: 10
+                topK: 10,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -64,7 +65,8 @@ import WaxVectorSearch
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
                 mode: .textOnly,
-                topK: 10
+                topK: 10,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -97,7 +99,8 @@ import WaxVectorSearch
             SearchRequest(
                 query: "alpha drop",
                 mode: .textOnly,
-                topK: 10
+                topK: 10,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -128,7 +131,8 @@ import WaxVectorSearch
             SearchRequest(
                 query: "alpha beta drop",
                 mode: .textOnly,
-                topK: 10
+                topK: 10,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -159,7 +163,8 @@ import WaxVectorSearch
             SearchRequest(
                 query: "7f3a91",
                 mode: .textOnly,
-                topK: 10
+                topK: 10,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -195,7 +200,8 @@ import WaxVectorSearch
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
-                topK: 10
+                topK: 10,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
                 textEngine: nil,

--- a/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
@@ -61,7 +61,8 @@ func unifiedSearchVectorTimeoutFallsBackToTextLane() async throws {
             embedding: [1.0, 0.0],
             vectorSearchTimeout: .milliseconds(25),
             mode: .hybrid(alpha: 0.5),
-            topK: 10
+            topK: 10,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
 
         let response = try await wax.search(request, engineOverrides: overrides)
@@ -88,7 +89,8 @@ func unifiedSearchVectorTimeoutThrowsForVectorOnly() async throws {
             embedding: [1.0, 0.0],
             vectorSearchTimeout: .milliseconds(25),
             mode: .vectorOnly,
-            topK: 10
+            topK: 10,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
 
         do {

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -593,7 +593,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             frameFilter: FrameFilter(
                 metadataFilter: .init(requiredEntries: ["source": "email"])
             ),
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000),
             allowTimelineFallback: true,
             timelineFallbackLimit: 10
         )
@@ -1058,7 +1058,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             vectorEnginePreference: .cpuOnly,
             mode: .hybrid(alpha: 0.5),
             topK: 3,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000),
             enableRankingDiagnostics: true,
             rankingDiagnosticsTopK: 1
         )
@@ -1112,7 +1112,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.3),
                 topK: 2,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 2
             ),
@@ -1169,7 +1169,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 query: "auth rollout decision",
                 mode: .textOnly,
                 topK: 2,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
         )
@@ -1243,7 +1243,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 query: "concise release notes",
                 mode: .textOnly,
                 topK: 3,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
         )
@@ -1298,7 +1298,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 query: token,
                 mode: .textOnly,
                 topK: 5,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
         )
@@ -1311,7 +1311,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
                 topK: 5,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
@@ -1378,7 +1378,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
                 topK: 5,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
@@ -1442,7 +1442,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 vectorEnginePreference: .cpuOnly,
                 mode: .vectorOnly,
                 topK: 5,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
@@ -1578,7 +1578,7 @@ nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
                 topK: 10,
-nowMs: Int64(Date().timeIntervalSince1970 * 1000),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 10
             ),

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -53,7 +53,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         try await text.commit()
 
-        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10)
+        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         let response = try await wax.search(request)
 
         #expect(response.results.count == 1)
@@ -76,7 +76,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         try await text.commit()
 
-        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10, minScore: 0.9)
+        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10, minScore: 0.9, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         let response = try await wax.search(request)
 
         #expect(response.results.map(\.frameId) == [exact])
@@ -97,7 +97,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await vec.commit()
 
         let queryEmbedding = VectorMath.normalizeL2([0.9, 0.1, 0.0, 0.0])
-        let request = SearchRequest(embedding: queryEmbedding, mode: .vectorOnly, topK: 10)
+        let request = SearchRequest(embedding: queryEmbedding, mode: .vectorOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         let response = try await wax.search(request)
 
         #expect(response.results.first?.frameId == id0)
@@ -126,7 +126,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             query: "Swift",
             embedding: [1.0, 0.0, 0.0, 0.0],
             mode: .hybrid(alpha: 0.5),
-            topK: 10
+            topK: 10,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
         let response = try await wax.search(request)
 
@@ -146,7 +147,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await text.index(frameId: id0, text: "Swift")
         try await text.commit()
 
-        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 0)
+        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 0, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         let response = try await wax.search(request)
 
         #expect(response.results.isEmpty)
@@ -202,7 +203,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 mode: .textOnly,
                 topK: 5,
                 timeRange: SearchTimeRange(before: 200),
-                asOfMs: .max
+                asOfMs: .max,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -215,7 +217,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 mode: .textOnly,
                 topK: 5,
                 timeRange: SearchTimeRange(before: 50),
-                asOfMs: .max
+                asOfMs: .max,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -226,7 +229,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 query: "F027 Alice",
                 mode: .textOnly,
                 topK: 5,
-                asOfMs: 200
+                asOfMs: 200,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -282,7 +286,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await session.commit()
 
         let response = try await session.search(
-            SearchRequest(query: "F025ObjectParis", mode: .textOnly, topK: 5, asOfMs: .max)
+            SearchRequest(query: "F025ObjectParis", mode: .textOnly, topK: 5, asOfMs: .max, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
 
         #expect(response.results.map(\.frameId) == [evidenceFrame])
@@ -309,7 +313,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             embedding: [1.0, 0.0],
             mode: .vectorOnly,
             topK: 2,
-            frameFilter: allowlist
+            frameFilter: allowlist,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
         let response = try await wax.search(request)
 
@@ -346,7 +351,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             query: "alpha",
             mode: .textOnly,
             topK: 10,
-            frameFilter: filter
+            frameFilter: filter,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
         let response = try await wax.search(request)
 
@@ -386,7 +392,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 topK: 1,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "allowed"])
-                )
+                ),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -423,7 +430,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 topK: 1,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "allowed"])
-                )
+                ),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
                 textEngine: nil,
@@ -460,7 +468,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 topK: 1_100,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "allowed"])
-                )
+                ),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
                 textEngine: nil,
@@ -496,7 +505,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 topK: 1,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "pending"])
-                )
+                ),
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
                 textEngine: nil,
@@ -547,7 +557,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             query: "Quarterly summary",
             mode: .textOnly,
             topK: 10,
-            frameFilter: filter
+            frameFilter: filter,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
         let response = try await wax.search(request)
 
@@ -582,6 +593,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             frameFilter: FrameFilter(
                 metadataFilter: .init(requiredEntries: ["source": "email"])
             ),
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
             allowTimelineFallback: true,
             timelineFallbackLimit: 10
         )
@@ -644,7 +656,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let request = SearchRequest(
             embedding: [0.0, 1.0],
             mode: .vectorOnly,
-            topK: 5
+            topK: 5,
+            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
         let response = try await wax.search(request)
 
@@ -668,7 +681,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let wax = try await Wax.create(at: url)
 
         do {
-            _ = try await wax.search(SearchRequest(mode: .vectorOnly, topK: 5))
+            _ = try await wax.search(SearchRequest(mode: .vectorOnly, topK: 5, nowMs: Int64(Date().timeIntervalSince1970 * 1000)))
             Issue.record("Expected WaxError for vectorOnly search without embedding")
         } catch let error as WaxError {
             guard case .io(let message) = error else {
@@ -708,7 +721,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: "Which city did Person18 move to",
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -741,7 +755,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: "What is the public launch date for Atlas 10",
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -773,7 +788,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: #"What is the public launch date for "Atlas-10"? -- !!!"#,
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -805,7 +821,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: "Which city did Priya move to",
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -840,7 +857,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: "which city noah moved to",
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -878,7 +896,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: "for noah on atlas-10 in 2026 what is the public launch date",
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -916,7 +935,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: #"what is "Atlas-10 launch date" ???"#,
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -954,7 +974,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: "what is 'Atlas-10 launch date' ???",
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -992,7 +1013,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             SearchRequest(
                 query: "What is the public launch date for Atlas-10?",
                 mode: .textOnly,
-                topK: 5
+                topK: 5,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
 
@@ -1036,6 +1058,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             vectorEnginePreference: .cpuOnly,
             mode: .hybrid(alpha: 0.5),
             topK: 3,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
             enableRankingDiagnostics: true,
             rankingDiagnosticsTopK: 1
         )
@@ -1089,6 +1112,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.3),
                 topK: 2,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 2
             ),
@@ -1145,6 +1169,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 query: "auth rollout decision",
                 mode: .textOnly,
                 topK: 2,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
         )
@@ -1186,7 +1211,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.commit()
 
         let response = try await wax.search(
-            SearchRequest(query: "rollout note", mode: .textOnly, topK: 5)
+            SearchRequest(query: "rollout note", mode: .textOnly, topK: 5, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
 
         #expect(response.results.map(\.frameId).contains(activeID))
@@ -1218,6 +1243,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 query: "concise release notes",
                 mode: .textOnly,
                 topK: 3,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
         )
@@ -1272,6 +1298,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 query: token,
                 mode: .textOnly,
                 topK: 5,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
         )
@@ -1284,6 +1311,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
                 topK: 5,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
@@ -1350,6 +1378,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
                 topK: 5,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
@@ -1413,6 +1442,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 vectorEnginePreference: .cpuOnly,
                 mode: .vectorOnly,
                 topK: 5,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
             engineOverrides: UnifiedSearchEngineOverrides(
@@ -1448,7 +1478,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.commit()
 
         let response = try await wax.search(
-            SearchRequest(query: "cats OR dogs", mode: .textOnly, topK: 10)
+            SearchRequest(query: "cats OR dogs", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
         let catsHit = try #require(response.results.first { $0.frameId == catsOnly })
         let dogsHit = try #require(response.results.first { $0.frameId == dogsOnly })
@@ -1469,12 +1499,12 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.commit()
 
         let stopwordOnly = try await wax.search(
-            SearchRequest(query: "the and or", mode: .textOnly, topK: 10)
+            SearchRequest(query: "the and or", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
         #expect(stopwordOnly.results.isEmpty)
 
         let operatorOnly = try await wax.search(
-            SearchRequest(query: "NOT NEAR", mode: .textOnly, topK: 10)
+            SearchRequest(query: "NOT NEAR", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
         #expect(operatorOnly.results.isEmpty)
 
@@ -1548,6 +1578,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 vectorEnginePreference: .cpuOnly,
                 mode: .hybrid(alpha: 0.5),
                 topK: 10,
+nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 10
             ),
@@ -1583,6 +1614,123 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         for (previous, next) in zip(response.results, response.results.dropFirst()) {
             #expect(previous.score >= next.score)
         }
+
+        await session.close()
+        try await wax.close()
+    }
+}
+
+// MARK: - T3 clock-anchor determinism (AC-003)
+
+@Test func memorySemanticsClassificationChangesWithAnchorAndIsStablePerAnchor() {
+    let baseMs: Int64 = 1_700_000_000_000
+    let dayMs: Int64 = 24 * 60 * 60 * 1000
+    var metadata: [String: String] = [
+        MemoryMetadataKeys.type: MemoryType.taskState.rawValue,
+        MemoryMetadataKeys.durability: MemoryDurability.working.rawValue,
+    ]
+    metadata[MemoryMetadataKeys.createdAtMs] = String(baseMs)
+    metadata[MemoryMetadataKeys.expiresAtMs] = String(baseMs + 10 * dayMs)
+
+    // Different anchors must classify the same content differently, predictably.
+    let freshInfo = MemorySemantics.parse(metadata: metadata, nowMs: baseMs + dayMs)
+    #expect(freshInfo.isExpired == false)
+    let staleInfo = MemorySemantics.parse(metadata: metadata, nowMs: baseMs + 20 * dayMs)
+    #expect(staleInfo.isExpired == true)
+
+    let freshReasons = MemorySemantics.rankingReasons(metadata: metadata, scope: nil, nowMs: baseMs + dayMs)
+    #expect(freshReasons.reasons.contains("recent task state"))
+    #expect(!freshReasons.reasons.contains("expired memory"))
+    let staleReasons = MemorySemantics.rankingReasons(metadata: metadata, scope: nil, nowMs: baseMs + 20 * dayMs)
+    #expect(staleReasons.reasons.contains("expired memory"))
+
+    // The same anchor must produce identical results on repeated calls.
+    for _ in 0..<3 {
+        let repeatFresh = MemorySemantics.rankingReasons(metadata: metadata, scope: nil, nowMs: baseMs + dayMs)
+        #expect(repeatFresh.adjustment == freshReasons.adjustment)
+        #expect(repeatFresh.reasons == freshReasons.reasons)
+        let repeatStale = MemorySemantics.rankingReasons(metadata: metadata, scope: nil, nowMs: baseMs + 20 * dayMs)
+        #expect(repeatStale.adjustment == staleReasons.adjustment)
+        #expect(repeatStale.reasons == staleReasons.reasons)
+    }
+}
+
+@Test func unifiedSearchRankingIsByteIdenticalUnderFixedAnchorAndShiftsWithNewAnchor() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        var config = WaxSession.Config()
+        config.enableVectorSearch = false
+        let session = try await wax.openSession(.readWrite(.fail), config: config)
+
+        let baseMs: Int64 = 1_700_000_000_000
+        let dayMs: Int64 = 24 * 60 * 60 * 1000
+
+        // Durable decision: strong positive semantic adjustment at both anchors.
+        let decisionFrame = try await session.put(
+            Data("anchor determinism alpha release decision".utf8),
+            options: FrameMetaSubset(
+                searchText: "anchor determinism alpha release decision",
+                metadata: Metadata([
+                    MemoryMetadataKeys.type: MemoryType.decision.rawValue,
+                    MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                ])
+            ),
+            timestampMs: baseMs
+        )
+        try await session.indexText(frameId: decisionFrame, text: "anchor determinism alpha release decision")
+
+        // Short-lived ephemeral note: alive at anchor A, expired by anchor B.
+        let ephemeralFrame = try await session.put(
+            Data("anchor determinism beta scratch note".utf8),
+            options: FrameMetaSubset(
+                searchText: "anchor determinism beta scratch note",
+                metadata: Metadata([
+                    MemoryMetadataKeys.type: MemoryType.note.rawValue,
+                    MemoryMetadataKeys.durability: MemoryDurability.ephemeral.rawValue,
+                    MemoryMetadataKeys.createdAtMs: String(baseMs),
+                    MemoryMetadataKeys.expiresAtMs: String(baseMs + 10 * dayMs),
+                ])
+            ),
+            timestampMs: baseMs
+        )
+        try await session.indexText(frameId: ephemeralFrame, text: "anchor determinism beta scratch note")
+        try await session.commit()
+
+        let anchorA = baseMs + dayMs
+        let anchorB = baseMs + 30 * dayMs
+
+        func request(nowMs: Int64) -> SearchRequest {
+            SearchRequest(query: "anchor determinism", mode: .textOnly, topK: 10, nowMs: nowMs)
+        }
+
+        let firstA = try await session.search(request(nowMs: anchorA))
+        let secondA = try await session.search(request(nowMs: anchorA))
+        // Byte-identical ranking under a repeated fixed anchor.
+        #expect(firstA.results.map(\.frameId) == secondA.results.map(\.frameId))
+        #expect(firstA.results.map(\.score) == secondA.results.map(\.score))
+        #expect(firstA.results.map(\.explanations) == secondA.results.map(\.explanations))
+
+        // At anchor A both documents are live; the durable decision outranks the ephemeral note.
+        #expect(firstA.results.map(\.frameId).prefix(2).contains(decisionFrame))
+        #expect(firstA.results.map(\.frameId).prefix(2).contains(ephemeralFrame))
+        if let decisionIndex = firstA.results.firstIndex(where: { $0.frameId == decisionFrame }),
+           let ephemeralIndex = firstA.results.firstIndex(where: { $0.frameId == ephemeralFrame }) {
+            #expect(decisionIndex < ephemeralIndex)
+            #expect(firstA.results[decisionIndex].explanations.contains("decision memory"))
+            #expect(firstA.results[decisionIndex].explanations.contains("durable"))
+        } else {
+            Issue.record("expected both frames to be returned at anchor A")
+        }
+
+        // At anchor B the ephemeral note has expired and must drop out entirely,
+        // while the decision frame remains.
+        let firstB = try await session.search(request(nowMs: anchorB))
+        let secondB = try await session.search(request(nowMs: anchorB))
+        #expect(firstB.results.map(\.frameId) == secondB.results.map(\.frameId))
+        #expect(firstB.results.map(\.score) == secondB.results.map(\.score))
+        #expect(firstB.results.map(\.explanations) == secondB.results.map(\.explanations))
+        #expect(firstB.results.map(\.frameId) == [decisionFrame])
+        #expect(firstB.results.first?.explanations.contains("expired memory") != true)
 
         await session.close()
         try await wax.close()

--- a/Tests/WaxIntegrationTests/VectorSearchEngineTests.swift
+++ b/Tests/WaxIntegrationTests/VectorSearchEngineTests.swift
@@ -329,7 +329,8 @@ import WaxVectorSearch
         embedding: [1.0, 0.0],
         vectorEnginePreference: .auto,
         mode: .vectorOnly,
-        topK: 5
+        topK: 5,
+        nowMs: Int64(Date().timeIntervalSince1970 * 1000)
     )
     let response = try await wax.search(request)
     #expect(response.results.contains(where: { $0.frameId == 0 }))

--- a/Tests/WaxIntegrationTests/WaxSessionTests.swift
+++ b/Tests/WaxIntegrationTests/WaxSessionTests.swift
@@ -127,7 +127,8 @@ import WaxCore
             SearchRequest(
                 embedding: [1.0, 0.0],
                 mode: .vectorOnly,
-                topK: 2
+                topK: 2,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
         #expect(beforeCommit.results.first?.frameId == frameA)
@@ -142,7 +143,8 @@ import WaxCore
             SearchRequest(
                 embedding: [1.0, 0.0],
                 mode: .vectorOnly,
-                topK: 2
+                topK: 2,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
         #expect(afterCommit.results.first?.frameId == frameA)
@@ -218,7 +220,8 @@ import WaxCore
             SearchRequest(
                 embedding: [1.0, 0.0],
                 mode: .vectorOnly,
-                topK: 2
+                topK: 2,
+                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
         )
         #expect(response.results.first?.frameId == frameIds[0])
@@ -254,7 +257,8 @@ struct WaxSessionCacheIsolationTests {
                 SearchRequest(
                     embedding: [1.0, 0.0],
                     mode: .vectorOnly,
-                    topK: 1
+                    topK: 1,
+                    nowMs: Int64(Date().timeIntervalSince1970 * 1000)
                 )
             )
 


### PR DESCRIPTION
## Ticket T3 — functional-evolution spec (candidate 02). Stacked on #152.

Spec: /var/folders/ns/xmz0zmpj7p148vdgr4bwzp8h0000gn/T/swift-arch-0b27937a/spec/spec-architecture-functional-evolution.md

### What
Removes every `= Int64(Date()...)` default from decision signatures (`semanticMemoryRerank`, `baseExplanations`, `MemorySemantics.parse/rankingReasons/accessReasons/normalizeWriteMetadata`, `AccessStats` ×4, `TierSelectionContext`, `healthReport`); adds required `SearchRequest.nowMs`. Shells resolve ONE anchor per operation (`resolveOperationAnchorMs()` = `config.rag.deterministicNowMs ?? wall`; builder `searchAnchorMs`; broker handlers `Self.nowMs()`). Decision functions can no longer self-resolve time — it's a compile error. Boundary/persistence clocks untouched by design. No public-signature change (all package/private).

### Determinism proof (AC-003)
Two new tests: classification flips fresh→expired across anchors and is repeat-stable ×3; full-search ranking is byte-identical (frameIds+scores+explanations) under repeated same anchor and predictably drops an expired ephemeral frame under a shifted anchor.

### Review
Implementer: fresh subagent (`309546a80`) · Review 1: swift-adversarial-pr-review → completeness audit of every remaining clock hit in Sources/Wax (all classified shell/boundary), determinism tests verified non-tautological, one whitespace fix (`a82945043`) · Final pass: second fresh adversarial reviewer → APPROVE, all 6 claims independently re-verified.

### Verification
UnifiedSearchTests 40✓ · AccessStatsTests 10✓ · RAGConfigClampingTests 13✓ · MemoryOrchestratorTests 16✓ · WaxSession+BrokerCommandDecode 30✓ · PackageTraitManifestTests 9✓ · both determinism tests ✓ · builds green MiniLMEmbeddings + MCPServer, zero warnings.