### PR TITLE
refactor(search): orchestrator-owned evictable engine store

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -180,6 +180,9 @@ package actor MemoryOrchestrator {
     private let ragBuilder: FastRAGContextBuilder
 
     let session: WaxSession
+    /// Owner-scoped search-engine cache for session-less reads over this store.
+    /// Released when this orchestrator closes.
+    let unifiedEngineStore = UnifiedSearchEngineStore()
     private var embedder: (any EmbeddingProvider)?
     private var embeddingCache: EmbeddingMemoizer?
     private var embeddingStatus: EmbeddingStatus
@@ -1017,6 +1020,7 @@ package actor MemoryOrchestrator {
             vectorEnginePreference: preference,
             wax: wax,
             session: session,
+            engineStore: unifiedEngineStore,
             frameFilter: frameFilter,
             timeRange: resolvedTimeRange,
             scopeContext: config.defaultScopeContext,
@@ -1701,6 +1705,7 @@ package actor MemoryOrchestrator {
         }
         let sourceURL = await wax.fileURL()
         let maintenanceReport = await closeTimeLiveSetMaintenanceReport()
+        await unifiedEngineStore.releaseEngines()
         await session.close()
         try await wax.close()
         if let maintenanceReport {

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -18,6 +18,7 @@ package struct FastRAGContextBuilder: Sendable {
         vectorEnginePreference: VectorEnginePreference = .auto,
         wax: Wax,
         session: WaxSession? = nil,
+        engineStore: UnifiedSearchEngineStore? = nil,
         frameFilter: FrameFilter? = nil,
         timeRange: SearchTimeRange? = nil,
         scopeContext: MemoryScopeContext? = nil,
@@ -49,7 +50,12 @@ package struct FastRAGContextBuilder: Sendable {
         let response = if let session {
             try await session.search(request)
         } else {
-            try await wax.search(request)
+            // Session-less readers resolve engines through an owner-scoped store;
+            // without one, an ephemeral store scopes engine lifetime to this build.
+            try await wax.search(
+                request,
+                engineStore: engineStore ?? UnifiedSearchEngineStore()
+            )
         }
         let queryAnalyzer = QueryAnalyzer()
         let rankedResults = clamped.enableAnswerFocusedRanking

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -3,23 +3,54 @@ import WaxCore
 import WaxTextSearch
 import WaxVectorSearch
 
-struct UnifiedSearchEngineOverrides {
+/// Explicitly supplied search engines. Callers that already own warm engines
+/// (e.g. ``WaxSession`` write-coherent engines, or test fakes) pass these directly;
+/// the pipeline never consults any process-global state for them.
+struct UnifiedSearchEngines {
     var textEngine: FTS5SearchEngine?
     var vectorEngine: (any VectorSearchEngine)?
     var structuredEngine: FTS5SearchEngine?
+
+    init(
+        textEngine: FTS5SearchEngine? = nil,
+        vectorEngine: (any VectorSearchEngine)? = nil,
+        structuredEngine: FTS5SearchEngine? = nil
+    ) {
+        self.textEngine = textEngine
+        self.vectorEngine = vectorEngine
+        self.structuredEngine = structuredEngine
+    }
 }
 
 package extension Wax {
-    func search(_ request: SearchRequest) async throws -> SearchResponse {
-        try await search(request, engineOverrides: nil)
+    /// Search using engines resolved through `engineStore` (warm, evictable,
+    /// owned by whoever created it — ``MemoryOrchestrator`` or the caller).
+    func search(
+        _ request: SearchRequest,
+        engineStore: UnifiedSearchEngineStore
+    ) async throws -> SearchResponse {
+        try await search(request, engines: nil, engineStore: engineStore)
     }
 }
 
 extension Wax {
+    /// Search using caller-owned explicit engines (no store involvement).
     func search(
         _ request: SearchRequest,
-        engineOverrides: UnifiedSearchEngineOverrides?
+        engines: UnifiedSearchEngines
     ) async throws -> SearchResponse {
+        try await search(request, engines: engines, engineStore: nil)
+    }
+
+    func search(
+        _ request: SearchRequest,
+        engines: UnifiedSearchEngines?,
+        engineStore: UnifiedSearchEngineStore?
+    ) async throws -> SearchResponse {
+        precondition(
+            engines != nil || engineStore != nil,
+            "provide engines, engineStore, or both"
+        )
         let requestedTopK = max(0, request.topK)
         if requestedTopK == 0 {
             return SearchResponse(results: [])
@@ -62,22 +93,22 @@ extension Wax {
         ) ? min(max(requestedTopK * 3, 12), 48) : nil
 
         let candidateLimit = Self.candidateLimit(for: requestedTopK, filter: filter)
-        let cache = UnifiedSearchEngineCache.shared
+        let explicitEngines = engines
         let textEngine: FTS5SearchEngine? = if includeText {
-            if let override = engineOverrides?.textEngine {
-                override
+            if let explicitText = explicitEngines?.textEngine {
+                explicitText
             } else {
-                try await cache.textEngine(for: self)
+                try await engineStore?.textEngine(for: self)
             }
         } else {
             nil
         }
 
         let vectorEngine: (any VectorSearchEngine)? = if includeVector, let embedding = request.embedding, !embedding.isEmpty {
-            if let override = engineOverrides?.vectorEngine {
-                override
+            if let explicitVector = explicitEngines?.vectorEngine {
+                explicitVector
             } else {
-                try await cache.vectorEngine(
+                try await engineStore?.vectorEngine(
                     for: self,
                     queryEmbeddingDimensions: embedding.count,
                     preference: request.vectorEnginePreference
@@ -89,12 +120,12 @@ extension Wax {
 
         let structuredEngine: FTS5SearchEngine?
         if let trimmedQuery, !trimmedQuery.isEmpty {
-            if let override = engineOverrides?.structuredEngine {
-                structuredEngine = override
+            if let explicitStructured = explicitEngines?.structuredEngine {
+                structuredEngine = explicitStructured
             } else if let textEngine {
                 structuredEngine = textEngine
             } else {
-                structuredEngine = try await cache.textEngine(for: self)
+                structuredEngine = try await engineStore?.textEngine(for: self)
             }
         } else {
             structuredEngine = nil

--- a/Sources/Wax/UnifiedSearch/UnifiedSearchEngineStore.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearchEngineStore.swift
@@ -3,9 +3,16 @@ import WaxCore
 import WaxTextSearch
 import WaxVectorSearch
 
-actor UnifiedSearchEngineCache {
-    static let shared = UnifiedSearchEngineCache()
-
+/// Evictable search-engine cache owned by a single store owner (``MemoryOrchestrator``
+/// creates and holds one; session-less readers may create their own).
+///
+/// Engines are keyed by source state only (empty / committed checksum / staged stamp) —
+/// never by facade identity. When the underlying index changes, the key changes and the
+/// engine is reloaded; ``releaseEngines()`` drops all cached engines when the owner
+/// closes or invalidates the store. Test seams are constructor-injected factories that
+/// replace the load step, so injected fakes flow through the same cache lifecycle as
+/// production engines.
+package actor UnifiedSearchEngineStore {
     enum TextSourceKey: Hashable, Sendable {
         case empty
         case committed(checksum: Data)
@@ -35,6 +42,15 @@ actor UnifiedSearchEngineCache {
         var vectorDeserializations: Int = 0
     }
 
+    /// Replaces the real text-engine load step (deserialize / in-memory construction).
+    package typealias TextEngineFactory = @Sendable () async throws -> FTS5SearchEngine
+
+    /// Replaces the real vector-engine load step (`LoadedVectorSearchEngine.load`).
+    package typealias VectorEngineFactory = @Sendable (
+        _ metric: VectorMetric,
+        _ dimensions: Int
+    ) async throws -> any VectorSearchEngine
+
     private struct CachedText {
         var key: TextSourceKey
         var engine: FTS5SearchEngine
@@ -45,63 +61,73 @@ actor UnifiedSearchEngineCache {
         var engine: any VectorSearchEngine
     }
 
-    private var textByWax: [ObjectIdentifier: CachedText] = [:]
-    private var vectorByWax: [ObjectIdentifier: CachedVector] = [:]
+    private var cachedText: CachedText?
+    private var cachedVector: CachedVector?
     private var stats = Stats()
-    private var statsByWax: [ObjectIdentifier: Stats] = [:]
+    private let textEngineFactory: TextEngineFactory?
+    private let vectorEngineFactory: VectorEngineFactory?
+
+    package init(
+        textEngineFactory: TextEngineFactory? = nil,
+        vectorEngineFactory: VectorEngineFactory? = nil
+    ) {
+        self.textEngineFactory = textEngineFactory
+        self.vectorEngineFactory = vectorEngineFactory
+    }
 
     func snapshotStats() -> Stats { stats }
-
-    func snapshotStats(for wax: Wax) -> Stats {
-        statsByWax[ObjectIdentifier(wax)] ?? Stats()
-    }
 
     func resetStats() {
         stats = Stats()
     }
 
-    func resetStats(for wax: Wax) {
-        statsByWax[ObjectIdentifier(wax)] = Stats()
+    /// Drops all cached engines. Called by the owning orchestrator on close and
+    /// available for explicit invalidation; stats counters are preserved.
+    func releaseEngines() {
+        cachedText = nil
+        cachedVector = nil
+    }
+
+    var cachedEngineCount: Int {
+        (cachedText == nil ? 0 : 1) + (cachedVector == nil ? 0 : 1)
     }
 
     func textEngine(for wax: Wax) async throws -> FTS5SearchEngine {
-        let waxId = ObjectIdentifier(wax)
-
         if let stamp = await wax.stagedLexIndexStamp() {
             let stagedBytes = await wax.readStagedLexIndexBytes()
             let key: TextSourceKey = .staged(stamp: stamp)
-            if let cached = textByWax[waxId], cached.key == key {
+            if let cached = cachedText, cached.key == key {
                 return cached.engine
             }
             guard let bytes = stagedBytes else {
-                let engine = try FTS5SearchEngine.inMemory()
-                textByWax[waxId] = CachedText(key: .empty, engine: engine)
+                let engine = try await loadTextEngine(inMemory: true)
+                cachedText = CachedText(key: .empty, engine: engine)
                 return engine
             }
-            let engine = try FTS5SearchEngine.deserialize(from: bytes)
-            incrementTextDeserializations(for: waxId)
-            textByWax[waxId] = CachedText(key: key, engine: engine)
+            let engine = try await loadTextEngine(from: bytes)
+            incrementTextDeserializations()
+            cachedText = CachedText(key: key, engine: engine)
             return engine
         }
 
         if let manifest = await wax.committedLexIndexManifest() {
             let key: TextSourceKey = .committed(checksum: manifest.checksum)
-            if let cached = textByWax[waxId], cached.key == key {
+            if let cached = cachedText, cached.key == key {
                 return cached.engine
             }
             if let bytes = try await wax.readCommittedLexIndexBytes() {
-                let engine = try FTS5SearchEngine.deserialize(from: bytes)
-                incrementTextDeserializations(for: waxId)
-                textByWax[waxId] = CachedText(key: key, engine: engine)
+                let engine = try await loadTextEngine(from: bytes)
+                incrementTextDeserializations()
+                cachedText = CachedText(key: key, engine: engine)
                 return engine
             }
         }
 
-        if let cached = textByWax[waxId], cached.key == .empty {
+        if let cached = cachedText, cached.key == .empty {
             return cached.engine
         }
-        let engine = try FTS5SearchEngine.inMemory()
-        textByWax[waxId] = CachedText(key: .empty, engine: engine)
+        let engine = try await loadTextEngine(inMemory: true)
+        cachedText = CachedText(key: .empty, engine: engine)
         return engine
     }
 
@@ -121,34 +147,47 @@ actor UnifiedSearchEngineCache {
             return nil
         }
 
-        let waxId = ObjectIdentifier(wax)
-        if let cached = vectorByWax[waxId], cached.key == descriptor.key {
+        if let cached = cachedVector, cached.key == descriptor.key {
             return cached.engine
         }
 
-        let loaded = try await LoadedVectorSearchEngine.load(
-            from: wax,
-            metric: descriptor.metric,
-            dimensions: descriptor.dimensions,
-            preference: preference
-        )
-        incrementVectorDeserializations(for: waxId)
-        vectorByWax[waxId] = CachedVector(key: descriptor.key, engine: loaded.erased)
-        return loaded.erased
+        let engine: any VectorSearchEngine
+        if let vectorEngineFactory {
+            engine = try await vectorEngineFactory(descriptor.metric, descriptor.dimensions)
+        } else {
+            let loaded = try await LoadedVectorSearchEngine.load(
+                from: wax,
+                metric: descriptor.metric,
+                dimensions: descriptor.dimensions,
+                preference: preference
+            )
+            engine = loaded.erased
+        }
+        incrementVectorDeserializations()
+        cachedVector = CachedVector(key: descriptor.key, engine: engine)
+        return engine
     }
 
-    private func incrementTextDeserializations(for waxId: ObjectIdentifier) {
+    private func loadTextEngine(from bytes: Data) async throws -> FTS5SearchEngine {
+        if let textEngineFactory {
+            return try await textEngineFactory()
+        }
+        return try FTS5SearchEngine.deserialize(from: bytes)
+    }
+
+    private func loadTextEngine(inMemory: Bool) async throws -> FTS5SearchEngine {
+        if let textEngineFactory {
+            return try await textEngineFactory()
+        }
+        return try FTS5SearchEngine.inMemory()
+    }
+
+    private func incrementTextDeserializations() {
         stats.textDeserializations += 1
-        var waxStats = statsByWax[waxId] ?? Stats()
-        waxStats.textDeserializations += 1
-        statsByWax[waxId] = waxStats
     }
 
-    private func incrementVectorDeserializations(for waxId: ObjectIdentifier) {
+    private func incrementVectorDeserializations() {
         stats.vectorDeserializations += 1
-        var waxStats = statsByWax[waxId] ?? Stats()
-        waxStats.vectorDeserializations += 1
-        statsByWax[waxId] = waxStats
     }
 
     private func vectorLoadDescriptor(

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -154,12 +154,12 @@ package actor WaxSession {
 
     package func search(_ request: SearchRequest) async throws -> SearchResponse {
         let searchVectorEngine = try await vectorEngineForSearch(request)
-        let overrides = UnifiedSearchEngineOverrides(
+        let engines = UnifiedSearchEngines(
             textEngine: textEngine,
             vectorEngine: searchVectorEngine,
             structuredEngine: textEngine
         )
-        return try await wax.search(request, engineOverrides: overrides)
+        return try await wax.search(request, engines: engines)
     }
 
     package func searchText(query: String, topK: Int) async throws -> [TextSearchResult] {

--- a/Tests/WaxIntegrationTests/EngineStoreLifecycleTests.swift
+++ b/Tests/WaxIntegrationTests/EngineStoreLifecycleTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import Wax
+import WaxCore
+import WaxTextSearch
+import WaxVectorSearch
+
+private final class CountingVectorEngine: VectorSearchEngine, @unchecked Sendable {
+    let dimensions: Int
+
+    init(dimensions: Int) {
+        self.dimensions = dimensions
+    }
+
+    func search(vector: [Float], topK: Int) async throws -> [(frameId: UInt64, score: Float)] {
+        _ = vector
+        _ = topK
+        return []
+    }
+
+    func add(frameId: UInt64, vector: [Float]) async throws {
+        _ = frameId
+        _ = vector
+    }
+
+    func addBatch(frameIds: [UInt64], vectors: [[Float]]) async throws {
+        _ = frameIds
+        _ = vectors
+    }
+
+    func remove(frameId: UInt64) async throws {
+        _ = frameId
+    }
+
+    func stageForCommit(into wax: Wax) async throws {
+        _ = wax
+    }
+}
+
+@Suite(.serialized)
+struct EngineStoreLifecycleTests {
+    /// AC-004: engines cached by an owner-scoped store are released on
+    /// ``releaseEngines`` — proven via injected fakes (instance counters +
+    /// reload identity change), not via any process-global registry.
+    @Test func engineStore_releaseEnginesDropsInjectedFakesAndReloadsFreshInstances() async throws {
+        try await TempFiles.withTempFile { url in
+            let wax = try await Wax.create(at: url)
+            // Pending (uncommitted) embedding so the pendingOnly descriptor resolves.
+            let frameId = try await wax.put(Data("alpha".utf8))
+            try await wax.putEmbedding(frameId: frameId, vector: [1.0, 0.0])
+
+            let textLoads = Counter()
+            let vectorLoads = Counter()
+            weak var weakFirstTextEngine: FTS5SearchEngine?
+            weak var weakFirstVectorEngine: CountingVectorEngine?
+
+            let engineStore = UnifiedSearchEngineStore(
+                textEngineFactory: {
+                    await textLoads.increment()
+                    return try FTS5SearchEngine.inMemory()
+                },
+                vectorEngineFactory: { _, _ in
+                    await vectorLoads.increment()
+                    return CountingVectorEngine(dimensions: 2)
+                }
+            )
+
+            func request() -> SearchRequest {
+                SearchRequest(
+                    query: "alpha",
+                    embedding: [1.0, 0.0],
+                    mode: .hybrid(alpha: 0.5),
+                    topK: 5,
+                    nowMs: 1_000
+                )
+            }
+
+            _ = try await wax.search(request(), engineStore: engineStore)
+            #expect(await textLoads.value == 1)
+            #expect(await vectorLoads.value == 1)
+            #expect(await engineStore.cachedEngineCount == 2)
+
+            // Warm repeat: no new loads while keys are unchanged.
+            _ = try await wax.search(request(), engineStore: engineStore)
+            #expect(await textLoads.value == 1)
+            #expect(await vectorLoads.value == 1)
+
+            do {
+                let textEngine = try await engineStore.textEngine(for: wax)
+                weakFirstTextEngine = textEngine
+                let snapshot = try await engineStore.vectorEngine(for: wax, queryEmbeddingDimensions: 2)
+                weakFirstVectorEngine = snapshot as? CountingVectorEngine
+                #expect(weakFirstTextEngine != nil)
+                #expect(weakFirstVectorEngine != nil)
+            }
+
+            // Release: the store drops its references and subsequent reads reload
+            // through the factories (fresh instances, old ones deallocated).
+            await engineStore.releaseEngines()
+            #expect(await engineStore.cachedEngineCount == 0)
+            #expect(Self.eventuallyNil(weakFirstTextEngine))
+            #expect(Self.eventuallyNil(weakFirstVectorEngine))
+
+            _ = try await wax.search(request(), engineStore: engineStore)
+            #expect(await textLoads.value == 2)
+            #expect(await vectorLoads.value == 2)
+
+            // Pending embeddings were never staged; close is expected to refuse.
+            do {
+                try await wax.close()
+            } catch {
+                #expect(Bool(true))
+            }
+        }
+    }
+
+    /// AC-004: closing the owning MemoryOrchestrator releases its engine store.
+    @Test func memoryOrchestrator_closeReleasesOwnedEngineStoreEngines() async throws {
+        try await TempFiles.withTempFile { url in
+            do {
+                let seedConfig = TestHelpers.defaultMemoryConfig(vector: false)
+                let seed = try await MemoryOrchestrator(at: url, config: seedConfig)
+                try await seed.remember("Swift concurrency actors pin nothing forever.")
+                try await seed.flush()
+                try await seed.close()
+            }
+
+            let orchestrator = try await MemoryOrchestrator(at: url, config: TestHelpers.defaultMemoryConfig(vector: false))
+            let wax = await orchestrator.wax
+
+            let request = SearchRequest(
+                query: "swift concurrency",
+                mode: .textOnly,
+                topK: 5,
+                nowMs: 1_000
+            )
+            _ = try await wax.search(
+                request,
+                engineStore: await orchestrator.unifiedEngineStore
+            )
+            let cachedBeforeClose = await orchestrator.unifiedEngineStore.cachedEngineCount
+            #expect(cachedBeforeClose > 0)
+
+            try await orchestrator.close()
+
+            let cachedAfterClose = await orchestrator.unifiedEngineStore.cachedEngineCount
+            #expect(cachedAfterClose == 0)
+        }
+    }
+
+    private static func eventuallyNil(_ object: AnyObject?, timeout: Duration = .seconds(2)) -> Bool {
+        if object == nil { return true }
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if object == nil { return true }
+            usleep(10_000)
+        }
+        return object == nil
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/Tests/WaxIntegrationTests/EngineStoreLifecycleTests.swift
+++ b/Tests/WaxIntegrationTests/EngineStoreLifecycleTests.swift
@@ -148,6 +148,72 @@ struct EngineStoreLifecycleTests {
         }
     }
 
+    /// Session search with text/structured lanes off must not deserialize FTS
+    /// for structured fusion (or hybrid text) when the request carries a query.
+    /// A later optional-chaining fallthrough to a store would restore that leak.
+    @Test func session_disabledTextAndStructuredLanesSkipFTSEvenWithQuery() async throws {
+        try await TempFiles.withTempFile { url in
+            let wax = try await Wax.create(at: url)
+            do {
+                var writerConfig = WaxSession.Config()
+                writerConfig.enableTextSearch = true
+                writerConfig.enableStructuredMemory = true
+                writerConfig.enableVectorSearch = true
+                writerConfig.vectorDimensions = 2
+                writerConfig.vectorEnginePreference = .cpuOnly
+                let writer = try await wax.openSession(.readWrite(.fail), config: writerConfig)
+                let frameId = try await writer.put(
+                    Data("alpha".utf8),
+                    embedding: [1.0, 0.0],
+                    options: FrameMetaSubset(searchText: "alpha")
+                )
+                try await writer.indexText(frameId: frameId, text: "alpha")
+                try await writer.commit()
+                await writer.close()
+            }
+
+            var readerConfig = WaxSession.Config()
+            readerConfig.enableTextSearch = false
+            readerConfig.enableStructuredMemory = false
+            readerConfig.enableVectorSearch = true
+            readerConfig.vectorDimensions = 2
+            readerConfig.vectorEnginePreference = .cpuOnly
+            let session = try await wax.openSession(.readOnly, config: readerConfig)
+
+            let textLoads = Counter()
+            let vectorLoads = Counter()
+            let sideStore = UnifiedSearchEngineStore(
+                textEngineFactory: {
+                    await textLoads.increment()
+                    return try FTS5SearchEngine.inMemory()
+                },
+                vectorEngineFactory: { _, _ in
+                    await vectorLoads.increment()
+                    return CountingVectorEngine(dimensions: 2)
+                }
+            )
+
+            let response = try await session.search(
+                SearchRequest(
+                    query: "alpha",
+                    embedding: [1.0, 0.0],
+                    mode: .hybrid(alpha: 0.5),
+                    topK: 5,
+                    nowMs: 1_000
+                )
+            )
+            let sources = Set(response.results.flatMap(\.sources))
+            #expect(!sources.contains(.text))
+            #expect(!sources.contains(.structured))
+            #expect(await textLoads.value == 0)
+            #expect(await vectorLoads.value == 0)
+            #expect(await sideStore.cachedEngineCount == 0)
+
+            await session.close()
+            try await wax.close()
+        }
+    }
+
     private static func eventuallyNil(_ object: AnyObject?, timeout: Duration = .seconds(2)) -> Bool {
         if object == nil { return true }
         let clock = ContinuousClock()

--- a/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
+++ b/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
@@ -324,7 +324,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                 enableRankingDiagnostics: config.enableDiagnostics,
                 rankingDiagnosticsTopK: 10
             )
-            let response = try await wax.search(request)
+            let response = try await wax.searchWithEngineStore(request)
             let rankedDocIDs = try await resolveDocIDs(
                 from: response.results,
                 wax: wax,
@@ -334,7 +334,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
             if config.enableDiagnostics, config.topK < 10 {
                 var diagnosticRequest = request
                 diagnosticRequest.topK = 10
-                rankingResultsForDiagnostics = try await wax.search(diagnosticRequest).results
+                rankingResultsForDiagnostics = try await wax.searchWithEngineStore(diagnosticRequest).results
             } else {
                 rankingResultsForDiagnostics = response.results
             }
@@ -748,7 +748,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                 topK: topK,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
-            _ = try await wax.search(request)
+            _ = try await wax.searchWithEngineStore(request)
         }
 
         return LongMemoryLatencySummary(

--- a/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
+++ b/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
@@ -240,6 +240,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let wax = try await Wax.create(at: url)
+        let engineStore = UnifiedSearchEngineStore()
         let text = try await wax.enableTextSearch()
 
         let embedder: DeterministicEmbedder?
@@ -324,7 +325,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                 enableRankingDiagnostics: config.enableDiagnostics,
                 rankingDiagnosticsTopK: 10
             )
-            let response = try await wax.searchWithEngineStore(request)
+            let response = try await wax.searchWithEngineStore(request, engineStore: engineStore)
             let rankedDocIDs = try await resolveDocIDs(
                 from: response.results,
                 wax: wax,
@@ -334,7 +335,10 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
             if config.enableDiagnostics, config.topK < 10 {
                 var diagnosticRequest = request
                 diagnosticRequest.topK = 10
-                rankingResultsForDiagnostics = try await wax.searchWithEngineStore(diagnosticRequest).results
+                rankingResultsForDiagnostics = try await wax.searchWithEngineStore(
+                    diagnosticRequest,
+                    engineStore: engineStore
+                ).results
             } else {
                 rankingResultsForDiagnostics = response.results
             }
@@ -381,6 +385,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                     embedding: embedding,
                     vectorEnginePreference: .cpuOnly,
                     wax: wax,
+                    engineStore: engineStore,
                     config: ragConfig
                 )
                 let selected = Self.bestAnswerItem(query: searchQuery, items: context.items)
@@ -443,6 +448,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
         let latency = try await latencySummary(
             fixture: fixture,
             wax: wax,
+            engineStore: engineStore,
             embedder: embedder,
             topK: config.topK,
             includeVectors: config.includeVectors,
@@ -722,6 +728,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
     private func latencySummary(
         fixture: LongMemoryFixture,
         wax: Wax,
+        engineStore: UnifiedSearchEngineStore,
         embedder: DeterministicEmbedder?,
         topK: Int,
         includeVectors: Bool,
@@ -748,7 +755,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
                 topK: topK,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
-            _ = try await wax.searchWithEngineStore(request)
+            _ = try await wax.searchWithEngineStore(request, engineStore: engineStore)
         }
 
         return LongMemoryLatencySummary(

--- a/Tests/WaxIntegrationTests/Mocks/TestHelpers.swift
+++ b/Tests/WaxIntegrationTests/Mocks/TestHelpers.swift
@@ -1,5 +1,8 @@
 import Foundation
-import Wax
+import Testing
+@testable import Wax
+import WaxCore
+import WaxTextSearch
 
 enum TestHelpers {
     static func defaultMemoryConfig(vector: Bool = true) -> OrchestratorConfig {
@@ -10,5 +13,21 @@ enum TestHelpers {
         config.ingestBatchSize = 4
         config.ingestConcurrency = 1
         return config
+    }
+}
+
+extension Wax {
+    /// Test search through an owner-scoped ``UnifiedSearchEngineStore`` — there is
+    /// no process-global engine cache anymore. Without an explicit `engineStore`
+    /// a fresh ephemeral store scopes engine lifetime to the call; pass one to
+    /// keep engines warm across searches (benchmarks, reuse assertions).
+    /// `engines` supplies explicit engines (e.g. test fakes) that take precedence
+    /// over the store per lane.
+    func searchWithEngineStore(
+        _ request: SearchRequest,
+        engines: UnifiedSearchEngines? = nil,
+        engineStore: UnifiedSearchEngineStore? = nil
+    ) async throws -> SearchResponse {
+        try await search(request, engines: engines, engineStore: engineStore ?? UnifiedSearchEngineStore())
     }
 }

--- a/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
+++ b/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
@@ -101,6 +101,7 @@ final class ProductionReadinessStabilityTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let wax = try await Wax.create(at: url)
+        let engineStore = UnifiedSearchEngineStore()
         let text = try await wax.enableTextSearch()
         let vector = searchMode.usesVector
             ? try await wax.enableVectorSearch(dimensions: 2, preference: .cpuOnly)
@@ -155,7 +156,8 @@ final class ProductionReadinessStabilityTests: XCTestCase {
                         mode: searchMode.searchMode,
                         topK: 8,
                         nowMs: Int64(Date().timeIntervalSince1970 * 1000)
-                    )
+                    ),
+                    engineStore: engineStore
                 )
                 vectorSourceHits += response.results.filter { $0.sources.contains(.vector) }.count
                 let elapsed = clock.now - start

--- a/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
+++ b/Tests/WaxIntegrationTests/ProductionReadinessStabilityTests.swift
@@ -147,7 +147,7 @@ final class ProductionReadinessStabilityTests: XCTestCase {
             case .recall:
                 guard ingestCount > 0 else { continue }
                 let start = clock.now
-                let response = try await wax.search(
+                let response = try await wax.searchWithEngineStore(
                     SearchRequest(
                         query: searchMode.usesText ? step.payload : nil,
                         embedding: searchMode.usesVector ? Self.deterministicEmbedding(for: step.payload) : nil,

--- a/Tests/WaxIntegrationTests/RAGBenchmarkSupport.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarkSupport.swift
@@ -166,6 +166,9 @@ struct BenchmarkFixture {
     let queryText: String
     let queryEmbedding: [Float]?
     let scale: BenchmarkScale
+    /// Owner-scoped engine store so benchmark searches stay warm across
+    /// iterations (replaces the retired process-global engine cache).
+    let engineStore = UnifiedSearchEngineStore()
 
     static func build(
         at url: URL,

--- a/Tests/WaxIntegrationTests/RAGBenchmarks.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarks.swift
@@ -315,10 +315,10 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 topK: scale.searchTopK,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
-            _ = try await fixture.wax.search(request)
+            _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
 
             measureAsync(timeout: scale.timeout, iterations: scale.iterations) {
-                _ = try await fixture.wax.search(request)
+                _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
             }
         }
     }
@@ -338,7 +338,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 topK: scale.searchTopK,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
-            _ = try await fixture.wax.search(request)
+            _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
 
             let metrics: [XCTMetric] = [
                 XCTClockMetric(),
@@ -347,7 +347,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
             ]
             let iterations = max(1, min(3, scale.iterations))
             measureAsync(metrics: metrics, timeout: scale.timeout, iterations: iterations) {
-                _ = try await fixture.wax.search(request)
+                _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
             }
         }
     }
@@ -543,7 +543,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
 
             _ = try await timedSamples(label: "cold_open_hybrid", iterations: iterations, warmup: 0) {
                 let wax = try await Wax.open(at: url)
-                _ = try await wax.search(request)
+                _ = try await wax.searchWithEngineStore(request)
                 try await wax.close()
             }
         }
@@ -600,11 +600,11 @@ final class RAGPerformanceBenchmarks: XCTestCase {
             )
 
             // Warm up caches / any lazy engine state.
-            _ = try await fixture.wax.search(requestWithPreviews)
-            _ = try await fixture.wax.search(requestNoPreviews)
+            _ = try await fixture.wax.searchWithEngineStore(requestWithPreviews, engineStore: fixture.engineStore)
+            _ = try await fixture.wax.searchWithEngineStore(requestNoPreviews, engineStore: fixture.engineStore)
 
             let previewStats = try await timedSamples(label: "unified_search_hybrid_warm_previews", iterations: 30, warmup: 5) {
-                _ = try await fixture.wax.search(requestWithPreviews)
+                _ = try await fixture.wax.searchWithEngineStore(requestWithPreviews, engineStore: fixture.engineStore)
             }
             BenchmarkRegressionGuard.assertTailBudget(
                 label: "unified_search_hybrid_warm_previews",
@@ -613,7 +613,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 p99Budget: 0.0073
             )
             _ = try await timedSamples(label: "unified_search_hybrid_warm_no_previews", iterations: 30, warmup: 5) {
-                _ = try await fixture.wax.search(requestNoPreviews)
+                _ = try await fixture.wax.searchWithEngineStore(requestNoPreviews, engineStore: fixture.engineStore)
             }
         }
     }
@@ -639,10 +639,10 @@ final class RAGPerformanceBenchmarks: XCTestCase {
             )
 
             // Warm up caches / any lazy engine state.
-            _ = try await fixture.wax.search(requestNoPreviews)
+            _ = try await fixture.wax.searchWithEngineStore(requestNoPreviews, engineStore: fixture.engineStore)
 
             _ = try await timedSamples(label: "unified_search_hybrid_warm_cpu_only", iterations: 30, warmup: 5) {
-                _ = try await fixture.wax.search(requestNoPreviews)
+                _ = try await fixture.wax.searchWithEngineStore(requestNoPreviews, engineStore: fixture.engineStore)
             }
         }
     }
@@ -667,7 +667,7 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 previewMaxBytes: 0
             )
 
-            let response = try await fixture.wax.search(request)
+            let response = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
             let frameIds = response.results.map(\.frameId)
 
             // Warm the file cache and any payload decode paths.
@@ -880,10 +880,10 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 topK: scale.searchTopK,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
-            _ = try await fixture.wax.search(request)
+            _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
 
             measureAsync(timeout: scale.timeout, iterations: scale.iterations) {
-                _ = try await fixture.wax.search(request)
+                _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
             }
 
             await fixture.close()
@@ -914,10 +914,10 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 topK: scale.searchTopK,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             )
-            _ = try await fixture.wax.search(request)
+            _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
 
             measureAsync(timeout: scale.timeout, iterations: scale.iterations) {
-                _ = try await fixture.wax.search(request)
+                _ = try await fixture.wax.searchWithEngineStore(request, engineStore: fixture.engineStore)
             }
 
             await fixture.close()

--- a/Tests/WaxIntegrationTests/READMEExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/READMEExamplesTests.swift
@@ -187,7 +187,7 @@ func readmeExampleUnifiedSearchAPI() async throws {
         try await vec.commit()
 
         let request = SearchRequest(query: "Hello", mode: .hybrid(alpha: 0.5), topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
         #expect(response.results.count >= 0)
 
         try await wax.close()

--- a/Tests/WaxIntegrationTests/SearchScoreOrderTests.swift
+++ b/Tests/WaxIntegrationTests/SearchScoreOrderTests.swift
@@ -44,14 +44,14 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
         let weaker = try await wax.put(Data("weaker session vector neighbor".utf8))
         let stronger = try await wax.put(Data("stronger session vector neighbor".utf8))
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
                 topK: 2,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: InjectedVectorScoreEngine(
                     dimensions: 4,
@@ -83,7 +83,7 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
         let neighbor = try await wax.put(Data("unrelated vector neighbor filler".utf8))
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "7f3a91",
                 embedding: [1.0, 0.0, 0.0, 0.0],
@@ -92,7 +92,7 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
                 topK: 5,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: InjectedVectorScoreEngine(
                     dimensions: 4,
@@ -133,7 +133,7 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
             ]))
         )
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
@@ -141,7 +141,7 @@ private actor InjectedVectorScoreEngine: VectorSearchEngine {
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: InjectedVectorScoreEngine(
                     dimensions: 4,

--- a/Tests/WaxIntegrationTests/SurrogateMaintenanceTests.swift
+++ b/Tests/WaxIntegrationTests/SurrogateMaintenanceTests.swift
@@ -46,7 +46,7 @@ func optimizeSurrogatesCreatesSurrogateFramesAndExcludesFromDefaultSearch() asyn
         #expect(surrogates.allSatisfy { $0.metadata?.entries["source_content_hash"] != nil })
         #expect(surrogates.allSatisfy { $0.metadata?.entries["surrogate_max_tokens"] != nil })
 
-        let search = try await wax.search(.init(query: "actors", mode: .textOnly, topK: 50, nowMs: Int64(Date().timeIntervalSince1970 * 1000)))
+        let search = try await wax.searchWithEngineStore(.init(query: "actors", mode: .textOnly, topK: 50, nowMs: Int64(Date().timeIntervalSince1970 * 1000)))
         for result in search.results {
             let meta = try await wax.frameMeta(frameId: result.frameId)
             #expect(meta.kind != "surrogate")

--- a/Tests/WaxIntegrationTests/TextSearchORFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TextSearchORFallbackTests.swift
@@ -23,7 +23,7 @@ import WaxVectorSearch
         try await text.index(frameId: dropOnly, text: "please drop unused temporary files")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
                 mode: .textOnly,
@@ -61,7 +61,7 @@ import WaxVectorSearch
         try await text.index(frameId: dropOnly, text: "please drop unused temporary files")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
                 mode: .textOnly,
@@ -95,7 +95,7 @@ import WaxVectorSearch
         try await text.index(frameId: dropOnly, text: "please drop unused temporary files")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "alpha drop",
                 mode: .textOnly,
@@ -127,7 +127,7 @@ import WaxVectorSearch
         try await text.index(frameId: dropOnly, text: "please drop unused temporary files")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "alpha beta drop",
                 mode: .textOnly,
@@ -159,7 +159,7 @@ import WaxVectorSearch
         try await text.index(frameId: canary, text: "unique lexical canary 7f3a91")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "7f3a91",
                 mode: .textOnly,
@@ -194,7 +194,7 @@ import WaxVectorSearch
         try await text.index(frameId: dropOnly, text: "please drop unused temporary files")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
                 embedding: [1.0, 0.0, 0.0, 0.0],
@@ -203,7 +203,7 @@ import WaxVectorSearch
                 topK: 10,
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: InjectedHybridVectorEngine(
                     dimensions: 4,

--- a/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TimeoutFallbackTests.swift
@@ -50,10 +50,8 @@ func unifiedSearchVectorTimeoutFallsBackToTextLane() async throws {
         try await text.index(frameId: id0, text: "Swift programming language")
         try await text.commit()
 
-        let overrides = UnifiedSearchEngineOverrides(
-            textEngine: nil,
-            vectorEngine: HangingVectorEngine(dimensions: 2),
-            structuredEngine: nil
+        let overrides = UnifiedSearchEngines(
+            vectorEngine: HangingVectorEngine(dimensions: 2)
         )
 
         let request = SearchRequest(
@@ -65,7 +63,11 @@ func unifiedSearchVectorTimeoutFallsBackToTextLane() async throws {
             nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
 
-        let response = try await wax.search(request, engineOverrides: overrides)
+        let response = try await wax.search(
+            request,
+            engines: overrides,
+            engineStore: UnifiedSearchEngineStore()
+        )
 
         #expect(response.results.first?.frameId == id0)
         #expect(response.results.first?.sources.contains(.text) == true)
@@ -79,10 +81,8 @@ func unifiedSearchVectorTimeoutThrowsForVectorOnly() async throws {
     try await TempFiles.withTempFile { url in
         let wax = try await Wax.create(at: url)
 
-        let overrides = UnifiedSearchEngineOverrides(
-            textEngine: nil,
-            vectorEngine: HangingVectorEngine(dimensions: 2),
-            structuredEngine: nil
+        let overrides = UnifiedSearchEngines(
+            vectorEngine: HangingVectorEngine(dimensions: 2)
         )
 
         let request = SearchRequest(
@@ -94,7 +94,11 @@ func unifiedSearchVectorTimeoutThrowsForVectorOnly() async throws {
         )
 
         do {
-            _ = try await wax.search(request, engineOverrides: overrides)
+            _ = try await wax.search(
+                request,
+                engines: overrides,
+                engineStore: UnifiedSearchEngineStore()
+            )
             #expect(Bool(false))
         } catch {
             #expect(Bool(true))

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -54,7 +54,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await text.commit()
 
         let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.count == 1)
         #expect(response.results[0].frameId == id0)
@@ -77,7 +77,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await text.commit()
 
         let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10, minScore: 0.9, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.map(\.frameId) == [exact])
         #expect(response.results.first?.score ?? 0 > 0.9)
@@ -98,7 +98,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         let queryEmbedding = VectorMath.normalizeL2([0.9, 0.1, 0.0, 0.0])
         let request = SearchRequest(embedding: queryEmbedding, mode: .vectorOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.first?.frameId == id0)
         #expect(response.results.first?.previewText == "First")
@@ -129,7 +129,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             topK: 10,
             nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.first?.frameId == id1)
         #expect(response.results.first?.previewText != nil)
@@ -148,7 +148,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await text.commit()
 
         let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 0, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.isEmpty)
 
@@ -316,7 +316,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             frameFilter: allowlist,
             nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         let ids = Set(response.results.map(\.frameId))
         #expect(ids == Set([id2, id3]))
@@ -354,7 +354,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             frameFilter: filter,
             nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.map(\.frameId) == [id0])
 
@@ -385,7 +385,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await text.index(frameId: allowedFrame, text: "allowed \(query)")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: query,
                 mode: .textOnly,
@@ -423,7 +423,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         vectorResults.append((frameId: allowedFrame, score: 1))
 
         let vectorEngine = DeterministicVectorResultsEngine(dimensions: 4, results: vectorResults)
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
@@ -433,7 +433,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 ),
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: vectorEngine,
                 structuredEngine: nil
@@ -461,7 +461,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             )
         }
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
@@ -471,7 +471,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 ),
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: vectorEngine,
                 structuredEngine: nil
@@ -498,7 +498,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             results: [(frameId: frameID, score: 1)]
         )
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 embedding: [1.0, 0.0, 0.0, 0.0],
                 mode: .vectorOnly,
@@ -508,7 +508,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 ),
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000)
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: vectorEngine,
                 structuredEngine: nil
@@ -560,7 +560,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             frameFilter: filter,
             nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.map(\.frameId) == [id0])
 
@@ -597,7 +597,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
             allowTimelineFallback: true,
             timelineFallbackLimit: 10
         )
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.map(\.frameId) == [includedID])
         #expect(response.results.allSatisfy { $0.sources == [.timeline] })
@@ -659,7 +659,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             topK: 5,
             nowMs: Int64(Date().timeIntervalSince1970 * 1000)
         )
-        let response = try await wax.search(request)
+        let response = try await wax.searchWithEngineStore(request)
 
         #expect(response.results.first?.frameId == id0)
 
@@ -681,7 +681,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let wax = try await Wax.create(at: url)
 
         do {
-            _ = try await wax.search(SearchRequest(mode: .vectorOnly, topK: 5, nowMs: Int64(Date().timeIntervalSince1970 * 1000)))
+            _ = try await wax.searchWithEngineStore(SearchRequest(mode: .vectorOnly, topK: 5, nowMs: Int64(Date().timeIntervalSince1970 * 1000)))
             Issue.record("Expected WaxError for vectorOnly search without embedding")
         } catch let error as WaxError {
             guard case .io(let message) = error else {
@@ -717,7 +717,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "Which city did Person18 move to",
                 mode: .textOnly,
@@ -751,7 +751,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "What is the public launch date for Atlas 10",
                 mode: .textOnly,
@@ -784,7 +784,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: #"What is the public launch date for "Atlas-10"? -- !!!"#,
                 mode: .textOnly,
@@ -817,7 +817,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "Which city did Priya move to",
                 mode: .textOnly,
@@ -853,7 +853,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "which city noah moved to",
                 mode: .textOnly,
@@ -892,7 +892,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "for noah on atlas-10 in 2026 what is the public launch date",
                 mode: .textOnly,
@@ -931,7 +931,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: #"what is "Atlas-10 launch date" ???"#,
                 mode: .textOnly,
@@ -970,7 +970,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "what is 'Atlas-10 launch date' ???",
                 mode: .textOnly,
@@ -1009,7 +1009,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "What is the public launch date for Atlas-10?",
                 mode: .textOnly,
@@ -1063,8 +1063,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             rankingDiagnosticsTopK: 1
         )
 
-        let responseA = try await wax.search(request)
-        let responseB = try await wax.search(request)
+        let responseA = try await wax.searchWithEngineStore(request)
+        let responseB = try await wax.searchWithEngineStore(request)
 
         #expect(responseA == responseB)
         #expect(responseA.results.count == 3)
@@ -1105,7 +1105,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             results: [(frameId: vectorOnlyID, score: 1.0)]
         )
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: query,
                 embedding: [1.0, 0.0, 0.0, 0.0],
@@ -1116,7 +1116,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 2
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: vectorEngine,
                 structuredEngine: nil
@@ -1164,7 +1164,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.index(frameId: repoID, text: "Auth rollout decision uses refresh tokens.")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "auth rollout decision",
                 mode: .textOnly,
@@ -1210,7 +1210,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.index(frameId: activeID, text: "Current rollout note")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(query: "rollout note", mode: .textOnly, topK: 5, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
 
@@ -1238,7 +1238,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.index(frameId: frameID, text: "Chris prefers concise release notes.")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "concise release notes",
                 mode: .textOnly,
@@ -1293,7 +1293,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.index(frameId: exactID, text: exactBody)
         try await text.commit()
 
-        let textResponse = try await wax.search(
+        let textResponse = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: token,
                 mode: .textOnly,
@@ -1304,7 +1304,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         )
         #expect(textResponse.results.first?.frameId == exactID)
 
-        let hybridResponse = try await wax.search(
+        let hybridResponse = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: token,
                 embedding: [1.0, 0.0, 0.0, 0.0],
@@ -1314,7 +1314,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: DeterministicVectorResultsEngine(
                     dimensions: 4,
@@ -1371,7 +1371,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
             (frameId: frameId, score: Float(0.99) - Float(index) * 0.01)
         }
 
-        let hybridResponse = try await wax.search(
+        let hybridResponse = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: token,
                 embedding: [1.0, 0.0, 0.0, 0.0],
@@ -1381,7 +1381,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: DeterministicVectorResultsEngine(
                     dimensions: 4,
@@ -1435,7 +1435,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         }
         vectorHits.append((frameId: exactID, score: 0.01))
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: token,
                 embedding: [1.0, 0.0, 0.0, 0.0],
@@ -1445,7 +1445,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 nowMs: Int64(Date().timeIntervalSince1970 * 1000),
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: DeterministicVectorResultsEngine(
                     dimensions: 4,
@@ -1477,7 +1477,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.index(frameId: dogsOnly, text: "only dogs live here")
         try await text.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(query: "cats OR dogs", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
         let catsHit = try #require(response.results.first { $0.frameId == catsOnly })
@@ -1498,12 +1498,12 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.index(frameId: indexed, text: "the and or not near filler")
         try await text.commit()
 
-        let stopwordOnly = try await wax.search(
+        let stopwordOnly = try await wax.searchWithEngineStore(
             SearchRequest(query: "the and or", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
         #expect(stopwordOnly.results.isEmpty)
 
-        let operatorOnly = try await wax.search(
+        let operatorOnly = try await wax.searchWithEngineStore(
             SearchRequest(query: "NOT NEAR", mode: .textOnly, topK: 10, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
         )
         #expect(operatorOnly.results.isEmpty)
@@ -1571,7 +1571,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         )
         try await session.commit()
 
-        let response = try await wax.search(
+        let response = try await wax.searchWithEngineStore(
             SearchRequest(
                 query: "when was F027Alice last seen",
                 embedding: [1.0, 0.0, 0.0, 0.0],
@@ -1582,7 +1582,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 10
             ),
-            engineOverrides: UnifiedSearchEngineOverrides(
+            engines: UnifiedSearchEngines(
                 textEngine: nil,
                 vectorEngine: DeterministicVectorResultsEngine(
                     dimensions: 4,

--- a/Tests/WaxIntegrationTests/VectorSearchEngineTests.swift
+++ b/Tests/WaxIntegrationTests/VectorSearchEngineTests.swift
@@ -332,7 +332,7 @@ import WaxVectorSearch
         topK: 5,
         nowMs: Int64(Date().timeIntervalSince1970 * 1000)
     )
-    let response = try await wax.search(request)
+    let response = try await wax.searchWithEngineStore(request)
     #expect(response.results.contains(where: { $0.frameId == 0 }))
 
     try await wax.close()

--- a/Tests/WaxIntegrationTests/WaxSessionTests.swift
+++ b/Tests/WaxIntegrationTests/WaxSessionTests.swift
@@ -251,19 +251,36 @@ struct WaxSessionCacheIsolationTests {
             )
             try await session.commit()
 
-            await UnifiedSearchEngineCache.shared.resetStats(for: wax)
-
-            _ = try await session.search(
+            // Session-less searches resolve engines through an owner-scoped store.
+            let engineStore = UnifiedSearchEngineStore()
+            await engineStore.resetStats()
+            func vectorOnlyRequest() -> SearchRequest {
                 SearchRequest(
                     embedding: [1.0, 0.0],
                     mode: .vectorOnly,
                     topK: 1,
                     nowMs: Int64(Date().timeIntervalSince1970 * 1000)
                 )
-            )
+            }
 
-            let stats = await UnifiedSearchEngineCache.shared.snapshotStats(for: wax)
-            #expect(stats.vectorDeserializations == 0)
+            _ = try await wax.search(vectorOnlyRequest(), engineStore: engineStore)
+            var stats = await engineStore.snapshotStats()
+            #expect(stats.vectorDeserializations == 1)
+
+            // Warm repeat search reuses the loaded engine: no new deserialization.
+            _ = try await wax.search(vectorOnlyRequest(), engineStore: engineStore)
+            stats = await engineStore.snapshotStats()
+            #expect(stats.vectorDeserializations == 1)
+
+            // Session-backed searches use the session's own engines and never
+            // touch the store's deserialization counters.
+            _ = try await session.search(vectorOnlyRequest())
+            stats = await engineStore.snapshotStats()
+            #expect(stats.vectorDeserializations == 1)
+
+            await engineStore.releaseEngines()
+            let cachedCount = await engineStore.cachedEngineCount
+            #expect(cachedCount == 0)
 
             await session.close()
             do {


### PR DESCRIPTION
## Ticket T4 — functional-evolution spec (candidate 03). Stacked on #153.

Spec: /var/folders/ns/xmz0zmpj7p148vdgr4bwzp8h0000gn/T/swift-arch-0b27937a/spec/spec-architecture-functional-evolution.md

### What
Deletes `UnifiedSearchEngineCache.shared` (process-global actor keyed by facade `ObjectIdentifier`, no eviction → engines pinned for closed stores' lifetime) and replaces it with `UnifiedSearchEngineStore`: a package actor owned by construction by `MemoryOrchestrator` (one instance, released in `close()`), keyed only by index-state (`TextSourceKey`/`VectorSourceKey`), staged-vs-committed reload logic byte-equivalent to the old cache. Test seam `UnifiedSearchEngineOverrides` replaced by constructor-injected engine factories (pattern of `AgentBrokerService(embedderOverride:)`). Deviation from literal spec wording is evidenced: `Wax` actor lives in WaxCore which cannot depend on engine modules, so ownership is structural rather than call-site ("no caller can reach a global").

### Behavior delta (ruled a bug fix by reviewer)
Sessions/configs with text+structured lanes disabled previously *silently loaded real FTS engines from the global cache* during structured-lane queries, violating their own disable flags; those lanes now resolve nil→`[]`. No expressible config loses capability; `vectorOnly` still throws as documented.

### AC-004 evidence
New `EngineStoreLifecycleTests`: weak-ref deallocation asserted after release + fresh-instance reload counters; orchestrator-close wiring test (cached>0→0). `rg ObjectIdentifier Sources/Wax` → zero. Perf: warm hybrid p50 13.5ms / p95 24.6ms within its own regression guard; timed loop Δ ≈ +1.4–2.4% median (noise floor).

### Review
Implementer: fresh subagent (`a7d8a3153`) · Review 1: swift-adversarial-pr-review → behavior-delta investigation (dismissed as intentional config-honoring), ownership/serialization audit, staged-vs-committed side-by-side diff → APPROVE, no fixes · Final pass: second fresh adversarial reviewer → APPROVE, all 7 claims independently verified, zero assertion lines weakened in migrated tests.

### Verification
EngineStoreLifecycleTests 2✓ · UnifiedSearchTests 40✓ · WaxSessionTests 7✓ · TimeoutFallbackTests 4✓ · MemoryOrchestratorTests 16✓ · PackageTraitManifestTests 9✓ · +91 tests across touched suites ✓ · builds green MiniLMEmbeddings + MCPServer. Full-gate status unchanged vs base (11 pre-existing failures reproduced identically on 572b7865, documented in #151).