### PR TITLE
Reposition waxmcp as shared memory for agent teams

### DIFF
--- a/Resources/npm/waxmcp/README.md
+++ b/Resources/npm/waxmcp/README.md
@@ -1,119 +1,172 @@
-# waxmcp
+# WAX
 
 [![Discord](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FNHgNh7HJ6M%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&logo=discord&label=Discord&color=5865F2)](https://discord.gg/NHgNh7HJ6M)
 
-`waxmcp` is an npm launcher for the Wax MCP server.
+One shared memory for your entire agent team.
 
-## Usage
+Grok Bot, Claude Code, Codex, Cursor, and any other MCP-compatible agent read
+and write the same durable store: a single `.wax` file on your machine.
+Decisions, facts, and session handoffs survive across agents, sessions, tools,
+and reboots.
+
+WAX is local, portable, and inspectable. No cloud account, no hosted database.
+MCP is just the transport your agents use to reach the store; the product is
+the shared memory itself.
+
+## Install
 
 ```bash
 npx -y waxmcp@latest mcp serve
 ```
 
-For Claude Code, register with `wax-cli` (not this launcher):
+This starts a WAX MCP server over stdio against `~/.wax/memory.wax`. Register
+that command as an MCP server in your agent host and it gets the full tool set:
+`remember`, `recall`, `search`, `session_open`, `handoff_latest`, `stats`.
+
+Running more than one agent at a time? Start exactly one HTTP server and point
+every host at the same URL:
+
+```bash
+npx -y waxmcp@latest \
+  --transport http \
+  --http-host 127.0.0.1 \
+  --http-port 3000 \
+  --http-endpoint /mcp \
+  --embedder minilm
+```
+
+A second server pointed at the same `.wax` file will hit the store lock, so one
+shared HTTP endpoint is the right shape for multi-agent setups.
+
+## How it works
+
+```
+Claude Code ─┐
+Codex ───────┤
+Cursor ──────┼─→  WAX runtime  ─→  one ~/.wax/memory.wax file
+Grok Bot ────┘     (MCP stdio
+                    or HTTP)
+```
+
+Every agent connects through MCP. Every tool call lands in the same runtime,
+which serializes access to a single `.wax` file. What that buys you:
+
+- **Shared context across agents.** A decision written by one agent is
+  retrievable by every other agent on the machine.
+- **Persistence across sessions.** Memory outlives chats, restarts, and tool
+  switches by default.
+- **User-owned storage.** One plain file under your home directory. Inspect it,
+  back it up, sync it with iCloud or AirDrop, delete it whenever you like.
+- **No cloud account required.** Everything runs locally on your hardware.
+- **Portable across hosts.** Any MCP-compatible client works against the same
+  endpoint, so swapping agents never means migrating memory.
+
+WAX complements each host's native scratchpad memory. It does not replace it.
+
+## Agent team example
+
+One agent records a decision. Another agent, days later in a different repo,
+retrieves it.
+
+Monday, Claude Code closes out a refactor:
+
+```json
+{
+  "tool": "remember",
+  "arguments": {
+    "content": "Decision: auth middleware runs before rate limiting in shop-api. Reversing them breaks checkout tests.",
+    "project": "shop-api",
+    "memory_type": "decision",
+    "durability": "durable"
+  }
+}
+```
+
+Thursday, Codex debugs checkout from another workspace:
+
+```json
+{
+  "tool": "recall",
+  "arguments": {
+    "query": "middleware order auth rate limit",
+    "project": "shop-api"
+  }
+}
+```
+
+The response contains Monday's decision with its provenance. Nobody re-derives
+the middleware order or argues with a stale assumption.
+
+## Wiring up your hosts
+
+Host-by-host configuration for Claude Code, Codex, Cursor, Hermes, and generic
+MCP clients lives in
+[Resources/docs/wax-mcp-hosts.md](https://github.com/christopherkarani/Wax/blob/main/Resources/docs/wax-mcp-hosts.md).
+
+### Claude Code
+
+From a Wax checkout, `wax-cli` is the registrar:
 
 ```bash
 swift run --traits MCPServer wax-cli mcp install --scope user
 ```
 
-This launcher (`npx waxmcp`) **serves** MCP. It does not implement `mcp install --scope`.
-
-Shared HTTP (required when more than one client uses `~/.wax/memory.wax`):
-
-```bash
-npx -y waxmcp@latest --transport http --http-host 127.0.0.1 --http-port 3000 --http-endpoint /mcp --embedder minilm
-```
-
-Then add the URL to Codex / Cursor / Hermes. Full host snippets: repo `Resources/docs/wax-mcp-hosts.md`.
-
-That install flow:
-
-1. `npx waxmcp install` stages the bundled runtime into a stable local directory
-2. `wax-cli mcp install` registers the staged `wax-mcp` binary with Claude Code
-3. The skill is staged to `~/.local/share/waxmcp/skills/wax-mcp`
-4. `claude install-skill` is best-effort; other hosts copy the skill or paste project-rules
-
-So regular MCP sessions do not keep launching through raw `npx`, and agents get a
-session lifecycle playbook (also embedded in MCP server instructions).
+That command stages the runtime under `~/.local/share/waxmcp`, registers the
+server with Claude Code via `claude mcp add`, stages the operator skill to
+`~/.local/share/waxmcp/skills/wax-mcp`, and runs `claude install-skill` when
+available. If skill auto-install did not run:
 
 ```bash
-# If skill auto-install did not run (Claude):
 claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
 ```
 
-> `wax-mcp` skill = agent operator playbook for MCP tools.
-> `wax` skill (separate, in the monorepo) = Swift framework integration guidance.
+If you already run the shared HTTP server, register the URL instead of stdio.
+The hosts doc shows the exact snippet per host.
 
-> Note: the bundled npm runtime currently ships `darwin-arm64` artifacts (Apple Silicon).
-> Intel Mac (`darwin-x64`) builds are not packaged because MetalANNS Float16 requires Apple Silicon.
-> The underlying `wax-mcp` server itself supports local Swift builds on macOS and Linux, including
-> `--transport http` for gateway deployments.
+Two skills ship in this ecosystem. `wax-mcp` is the operator playbook for using
+the memory tools. The separate `wax` skill (in the monorepo) covers Swift
+framework integration.
 
-To publish a new version:
+## Launcher reference
 
-```bash
-cd /path/to/Wax/Resources/npm/waxmcp
-npm version patch   # or minor/major/1.2.3 (requires npm publish access)
-npm publish --access public
-```
+`waxmcp` wraps the native binaries (`wax-mcp` server and `wax-cli`) and resolves
+them in this order:
 
-This repo also ships a release script that updates `version`, syncs
-`Sources/WaxMCPServer/main.swift`'s `serverVersion`, and rebuilds the Darwin binaries
-and resource bundles:
+1. `$WAX_MCP_BIN` or `$WAX_CLI_BIN`
+2. Bundled `dist/darwin-arm64/` binaries
+3. Same-named binary on `PATH`
+4. `./.build/debug/<binary>` in the current working directory
 
-```bash
-cd /path/to/Wax
-./scripts/release-waxmcp.sh 0.1.18
-git add Resources/npm/waxmcp/package.json Sources/WaxMCPServer/main.swift Resources/npm/waxmcp/dist
-git commit -m "release: bump waxmcp version"
-```
+| Command | Purpose |
+|---|---|
+| `npx -y waxmcp@latest mcp serve` | Serve MCP over stdio |
+| `npx -y waxmcp@latest --transport http ...` | Serve MCP over HTTP for multi-agent setups |
+| `npx -y waxmcp@latest mcp doctor` | Validate setup and run a tools/list smoke check |
+| `npx -y waxmcp@latest vector-health` | Check vector search status of the HTTP endpoint |
+| `npx -y waxmcp@latest install` | Locate or build (`--build`) the `wax-mcp` binary |
+| `npx -y waxmcp@latest install-hermes-plugin` | Install the Hermes wax-memory plugin |
+| `npx -y waxmcp@latest install-openclaw-plugin` | Print OpenClaw plugin install steps |
+| `npx -y waxmcp@latest install-all-plugins` | Install all plugins |
 
-`package.json` and `Sources/WaxMCPServer/main.swift` are required to stay in lockstep; the release
-workflow checks this before publishing.
+### Configuration
 
-Artifacts are packaged with `wax-cli.sha256` and `wax-mcp.sha256` checksums generated by the release
-scripts for each platform binary.
+| Setting | How |
+|---|---|
+| Store path | `--store-path <path>` (default `~/.wax/memory.wax`) |
+| Embedder | `--embedder minilm` or `--embedder arctic`; omit and the launcher defaults to arctic |
+| Text-only mode | `--no-embedder` |
+| Binary override | `WAX_MCP_BIN` / `WAX_CLI_BIN` environment variables |
+| Endpoint override | `WAX_MCP_HTTP_PORT` / `WAX_MCP_HTTP_ENDPOINT` (used by `vector-health`) |
 
-### MCP mode (default)
+Vector search needs both binaries built with embedder traits; the bundled npm
+artifacts already are. Without an embedder, search runs text-only.
 
-When invoked with no arguments or with `mcp serve`, the launcher directly invokes the `wax-mcp`
-binary using this search order:
+## Platform support
 
-1. `$WAX_MCP_BIN`
-2. Bundled `dist/darwin-${arch}/wax-mcp` on macOS arm64/x64
-3. `wax-mcp` in PATH
-4. `./.build/debug/wax-mcp` (current working directory)
-
-You can also serve Wax over HTTP instead of stdio:
-
-```bash
-./.build/debug/wax-mcp --no-embedder --transport http --http-host 127.0.0.1 --http-port 3000
-```
-
-### CLI mode
-
-For all other subcommands (remember, recall, search, etc.), the launcher invokes the `wax-cli`
-binary using this search order:
-
-1. `$WAX_CLI_BIN`
-2. Bundled `dist/darwin-${arch}/wax-cli` on macOS arm64/x64
-3. `wax-cli` in PATH
-4. `./.build/debug/wax-cli` (current working directory)
-
-Vector-capable CLI commands now auto-start and reuse a background daemon by default, so
-coding agents can keep calling normal `wax-cli`/`waxmcp` commands without learning a
-separate workflow.
-
-You can still run the daemon directly when you want an explicit long-lived session:
-
-```bash
-waxmcp daemon --store-path ~/.wax/memory.wax
-```
-
-The daemon keeps one `MemoryOrchestrator` open, so repeated `remember` / `search` / `recall`
-requests do not reload the CoreML embedder every time. Simple text-only usage still runs
-one-shot. Hybrid/vector searches now fail explicitly if vector search is unavailable instead
-of silently degrading to text-only mode.
+The bundled npm runtime ships `darwin-arm64` artifacts (Apple Silicon). Intel
+Mac builds are not packaged because MetalANNS Float16 requires Apple Silicon.
+The underlying server builds from source on macOS and Linux, including HTTP
+transport for gateway deployments.
 
 ## Local development
 
@@ -124,3 +177,21 @@ swift build --product wax-mcp --traits MCPServer
 export WAX_CLI_BIN=/path/to/Wax/.build/debug/wax-cli
 npx --yes ./Resources/npm/waxmcp mcp doctor
 ```
+
+## Maintainers
+
+Release with the version sync script. It bumps `package.json`, the MCP server
+version, and the CLI version together, then rebuilds the Darwin binaries:
+
+```bash
+cd /path/to/Wax
+./Resources/scripts/release-waxmcp.sh 0.1.33
+git add Resources/npm/waxmcp/package.json Sources/WaxMCPServer/main.swift Sources/WaxCLI/WaxCLICommand.swift Resources/npm/waxmcp/dist
+git commit -m "release: bump waxmcp version"
+```
+
+Pushing tag `waxmcp-v<version>` triggers the publish workflow
+(`.github/workflows/release-waxmcp.yml`). `package.json` and
+`Sources/WaxMCPServer/main.swift` must stay in lockstep; CI checks that before
+publishing. Dist artifacts carry `sha256` checksums, verified at pack time by
+`scripts/verify-dist.mjs`.

--- a/Resources/npm/waxmcp/bin/waxmcp.js
+++ b/Resources/npm/waxmcp/bin/waxmcp.js
@@ -7,12 +7,14 @@
  *   npx waxmcp                    # Start MCP server (stdio, default store)
  *   npx waxmcp --transport http   # Start HTTP MCP server on :3000
  *   npx waxmcp --no-embedder      # Text-only search (no vector search)
- *   npx waxmcp --embedder arctic  # Use Arctic embeddings (default: minilm)
+ *   npx waxmcp --embedder arctic  # Use Arctic embeddings (default: arctic)
+ *   npx waxmcp mcp doctor         # Validate setup (routes to wax-cli)
  *
  * Environment:
- *   WAX_MCP_BIN        — Override path to wax-mcp binary
- *   WAX_STORE_PATH     — Override default ~/.wax/memory.wax
- *   WAX_MCP_HTTP_PORT  — Override default HTTP port (3000)
+ *   WAX_MCP_BIN            Path to the wax-mcp server binary
+ *   WAX_CLI_BIN            Path to the wax-cli binary
+ *   WAX_MCP_HTTP_PORT      HTTP port assumed by vector-health (default 3000)
+ *   WAX_MCP_HTTP_ENDPOINT  Full endpoint URL assumed by vector-health
  */
 
 const { spawnSync, spawn } = require("node:child_process");
@@ -308,7 +310,7 @@ if (forwardedArgs[0] === "install-all-plugins") {
 }
 
 // --- Default: run MCP server ---
-// Translate 'mcp serve' to native wax-mcp flags
+// Translate the legacy 'mcp' prefix to native wax-mcp flags
 const mcpFlags = [];
 let i = 0;
 while (i < forwardedArgs.length) {
@@ -321,9 +323,11 @@ while (i < forwardedArgs.length) {
       i++;
       continue;
     }
-    // 'mcp' without 'serve' — pass through
-    mcpFlags.push(arg);
-    i++;
+    if (i < forwardedArgs.length) {
+      // Management subcommands (doctor/install/uninstall) belong to wax-cli.
+      runBinary("wax-cli", forwardedArgs.slice(i - 1));
+    }
+    // Trailing bare 'mcp': nothing to forward, start a plain server.
     continue;
   }
 

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,7 +1,17 @@
 {
   "name": "waxmcp",
   "version": "0.1.32",
-  "description": "npx launcher for the Wax MCP server",
+  "description": "Shared memory runtime for AI agents. One local .wax store shared by your whole agent team over MCP.",
+  "keywords": [
+    "agent-memory",
+    "ai-agents",
+    "shared-memory",
+    "mcp",
+    "claude-code",
+    "codex",
+    "cursor",
+    "grok"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/christopherkarani/Wax.git"


### PR DESCRIPTION
## Summary

The npm package now presents WAX as what it is: one shared, user-owned memory for an entire agent team, not "an MCP server launcher".

- README hero leads with the product: one shared memory for Grok Bot, Claude Code, Codex, Cursor, and any MCP-compatible agent, backed by a single local `.wax` file
- New core-model diagram (multiple agents -> WAX runtime -> one `.wax` file), why-it-matters list (shared context across agents, persistence across sessions, user-owned storage, no cloud account, portable across hosts), and a two-agent remember/recall example using the real tool schemas (`remember` / `recall` arguments verified against `ToolSchemas.swift`)
- MCP framed as transport; explicit line that WAX complements native agent memory rather than replacing it
- Simplest working install (`npx -y waxmcp@latest mcp serve`) sits directly under the hero, with the multi-agent shared HTTP command next to it
- Technical setup (host wiring, Claude Code registrar, launcher reference, configuration, platform support, local development) moved below the product explanation

The npm package name remains **waxmcp**. No rename in this PR.

## Factual / setup changes

Commands were verified against the implementation before being kept:

- Corrected the release path from `./scripts/release-waxmcp.sh` to `Resources/scripts/release-waxmcp.sh`, and the version-sync note to include `Sources/WaxCLI/WaxCLICommand.swift` (what `sync-waxmcp-version.sh` actually updates)
- Removed claims that are not true of the shipped launcher:
  - "`npx waxmcp install` stages the bundled runtime into a stable local directory" (it only locates or builds a binary; staging happens in `wax-cli mcp install`)
  - "CLI mode routes `remember`/`recall`/`search` to wax-cli" (the launcher always invoked wax-mcp)
  - `WAX_STORE_PATH` environment override (read nowhere)
- Fixed a real routing bug in `bin/waxmcp.js`: `waxmcp mcp <sub>` used to drop `<sub>` and pass a stray `mcp` positional to `wax-mcp` (guaranteed parse error). Management subcommands (`doctor`, `install`, `uninstall`) now route to `wax-cli`, so the documented `npx --yes ./Resources/npm/waxmcp mcp doctor` works end to end. `mcp serve` behavior is unchanged.
- Launcher header comments updated to match reality (embedder default is arctic, env vars that actually exist)

## package.json

- Description: "Shared memory runtime for AI agents. One local .wax store shared by your whole agent team over MCP."
- Keywords added around: agent-memory, ai-agents, shared-memory, mcp, claude-code, codex, cursor, grok
- Name, version, os/cpu/bin/files/engines unchanged

## Validation

- `node --check bin/waxmcp.js`; `package.json` parses as JSON
- Launcher routing exercised with stub binaries: `mcp doctor` -> wax-cli, `mcp install --scope user` -> wax-cli, `mcp serve` and flag passthrough -> wax-mcp with arctic default, bare invocation unchanged
- Real-binary smoke: bundled/staged `wax-cli mcp doctor` against a throwaway store exits 0 ("Doctor passed.")
- `npm prepack` gate (`verify-dist.mjs`) passes against release artifacts
- `swift test --filter npmReadmeLocalDevelopmentUsesRepoRootPackagePath` (guards this README) passes, plus root-README quick-start and project-rules lockstep tests
- Diff checked for broken links (hosts doc URL exists on main) and em dashes
