### PR TITLE
refactor(broker): close horizon lane selection behind HorizonSet

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -572,45 +572,28 @@ extension AgentBrokerService {
         let query = command.query
         let topK = command.topK
         let mode = command.mode
-        let requestedWorking = command.includeWorking
-        let requestedEpisodic = command.includeEpisodic
-        let requestedDurable = command.includeDurable
+        let requested = command.horizons
+        let sessionLanes = requested.intersection([.working, .episodic])
         let policy: SessionResolutionPolicy
-        if requestedWorking || requestedEpisodic {
-            policy = requestedDurable ? .durableOnlyWhenAmbiguous : .requireUnambiguousWorking
-        } else {
+        if sessionLanes.isEmpty {
             policy = .unscoped
+        } else {
+            policy = requested.contains(.durable) ? .durableOnlyWhenAmbiguous : .requireUnambiguousWorking
         }
         let scope = try resolveSessionScope(command.sessionID, policy: policy)
         let sessionID: UUID?
-        let includeWorking: Bool
-        let includeEpisodic: Bool
-        let includeDurable: Bool
-        switch scope {
-        case .session(let resolved):
+        if case .session(let resolved) = scope {
             sessionID = resolved
-            includeWorking = requestedWorking
-            includeEpisodic = requestedEpisodic
-            includeDurable = requestedDurable
-        case .durableOnly:
+        } else {
             sessionID = nil
-            includeWorking = false
-            includeEpisodic = false
-            includeDurable = true
-        case .none:
-            sessionID = nil
-            includeWorking = false
-            includeEpisodic = requestedEpisodic
-            includeDurable = requestedDurable
         }
+        let horizons = Self.scopedHorizons(scope: scope, requested: requested)
         let hits = try await layeredMemorySearch(
             query: query,
             mode: mode,
             topK: topK,
             sessionID: sessionID,
-            includeWorking: includeWorking,
-            includeEpisodic: includeEpisodic,
-            includeDurable: includeDurable
+            horizons: horizons
         )
 
         if let sessionID {
@@ -1791,9 +1774,7 @@ extension AgentBrokerService {
         mode: Memory.RetrievalMode,
         topK: Int,
         sessionID: UUID?,
-        includeWorking: Bool,
-        includeEpisodic: Bool,
-        includeDurable: Bool
+        horizons: HorizonSet
     ) async throws -> [LayeredMemoryHit] {
         try await LayeredRecall.search(
             request: LayeredRecall.SearchRequest(
@@ -1801,9 +1782,7 @@ extension AgentBrokerService {
                 mode: mode,
                 topK: topK,
                 sessionID: sessionID,
-                includeWorking: includeWorking,
-                includeEpisodic: includeEpisodic,
-                includeDurable: includeDurable
+                horizons: horizons
             ),
             stores: layeredRecallStores()
         )
@@ -2463,6 +2442,19 @@ extension AgentBrokerService {
         case session(UUID)
         case durableOnly
         case none
+    }
+
+    /// Lane visibility after session-scope resolution: a resolved session keeps
+    /// the request, an unscoped search drops working, ambiguity keeps durable only.
+    static func scopedHorizons(scope: ResolvedSessionScope, requested: HorizonSet) -> HorizonSet {
+        switch scope {
+        case .session:
+            return requested
+        case .durableOnly:
+            return .durable
+        case .none:
+            return requested.subtracting(.working)
+        }
     }
 
     func resolveSessionScope(

--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -81,9 +81,7 @@ package enum BrokerCommand: Sendable, Equatable {
         package var mode: RetrievalMode
         package var topK: Int
         package var sessionID: UUID?
-        package var includeWorking: Bool
-        package var includeEpisodic: Bool
-        package var includeDurable: Bool
+        package var horizons: HorizonSet
     }
 
     package struct SessionStart: Sendable, Equatable {
@@ -418,14 +416,27 @@ extension BrokerCommand.MemorySearch {
             modeRaw: modeRaw,
             alpha: try args.optionalDouble("alpha")
         )
+        var horizons = HorizonSet()
+        if try args.optionalBool("include_working") ?? true {
+            horizons.insert(.working)
+        }
+        if try args.optionalBool("include_episodic") ?? true {
+            horizons.insert(.episodic)
+        }
+        if try args.optionalBool("include_durable") ?? true {
+            horizons.insert(.durable)
+        }
+        guard !horizons.isEmpty else {
+            throw BrokerValidationError.invalid(
+                "at least one horizon lane must stay enabled; include_working, include_episodic and include_durable are all false"
+            )
+        }
         return Self(
             query: query,
             mode: mode,
             topK: topK,
             sessionID: try BrokerCommand.parseOptionalSessionID(args),
-            includeWorking: try args.optionalBool("include_working") ?? true,
-            includeEpisodic: try args.optionalBool("include_episodic") ?? true,
-            includeDurable: try args.optionalBool("include_durable") ?? true
+            horizons: horizons
         )
     }
 }

--- a/Sources/Wax/Broker/HorizonSet.swift
+++ b/Sources/Wax/Broker/HorizonSet.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Selectable ``LayeredRecall/Horizon`` lanes for layered memory search.
+package struct HorizonSet: OptionSet, Sendable, Hashable {
+    package let rawValue: UInt8
+
+    package init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    package static let working = HorizonSet(rawValue: 1 << 0)
+    package static let episodic = HorizonSet(rawValue: 1 << 1)
+    package static let durable = HorizonSet(rawValue: 1 << 2)
+
+    package static let all: HorizonSet = [.working, .episodic, .durable]
+}

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -162,26 +162,20 @@ package enum LayeredRecall {
         package var mode: Memory.RetrievalMode
         package var topK: Int
         package var sessionID: UUID?
-        package var includeWorking: Bool
-        package var includeEpisodic: Bool
-        package var includeDurable: Bool
+        package var horizons: HorizonSet
 
         package init(
             query: String,
             mode: Memory.RetrievalMode,
             topK: Int,
             sessionID: UUID? = nil,
-            includeWorking: Bool,
-            includeEpisodic: Bool,
-            includeDurable: Bool
+            horizons: HorizonSet
         ) {
             self.query = query
             self.mode = mode
             self.topK = topK
             self.sessionID = sessionID
-            self.includeWorking = includeWorking
-            self.includeEpisodic = includeEpisodic
-            self.includeDurable = includeDurable
+            self.horizons = horizons
         }
     }
 
@@ -696,7 +690,7 @@ package enum LayeredRecall {
     ) async throws -> [Hit] {
         var hits: [Hit] = []
 
-        if request.includeWorking, let sessionID = request.sessionID, let lane = stores.workingLane(sessionID) {
+        if request.horizons.contains(.working), let sessionID = request.sessionID, let lane = stores.workingLane(sessionID) {
             let execution = try await lane.memory.searchExecution(
                 query: request.query,
                 mode: request.mode,
@@ -732,7 +726,7 @@ package enum LayeredRecall {
             }
         }
 
-        if request.includeDurable {
+        if request.horizons.contains(.durable) {
             let execution = try await stores.longTermMemory.searchExecution(
                 query: request.query,
                 mode: request.mode,
@@ -765,7 +759,7 @@ package enum LayeredRecall {
             }
         }
 
-        if request.includeEpisodic {
+        if request.horizons.contains(.episodic) {
             let manifests = try stores.endedManifests()
             let scopedManifests = manifests
                 .filter { manifest in

--- a/Tests/WaxTests/BrokerCommandDecodeTests.swift
+++ b/Tests/WaxTests/BrokerCommandDecodeTests.swift
@@ -147,10 +147,54 @@ struct BrokerCommandDecodeTests {
             Issue.record("expected memory_search")
             return
         }
-        #expect(payload.includeWorking == false)
-        #expect(payload.includeEpisodic == false)
-        #expect(payload.includeDurable == true)
+        #expect(payload.horizons == [.durable])
         #expect(payload.mode == .textOnly)
+    }
+
+    @Test
+    func memorySearchDefaultsToAllLanes() throws {
+        let decoded = try BrokerCommand.decode(
+            command: "memory_search",
+            arguments: ["query": .string("needle")]
+        )
+        guard case .memorySearch(let payload) = decoded else {
+            Issue.record("expected memory_search")
+            return
+        }
+        #expect(payload.horizons == HorizonSet.all)
+    }
+
+    @Test
+    func memorySearchMapsIndividualLaneFlags() throws {
+        let workingOnly = try BrokerCommand.decode(
+            command: "memory_search",
+            arguments: ["query": .string("q"), "include_episodic": .bool(false), "include_durable": .bool(false)]
+        )
+        guard case .memorySearch(let payload) = workingOnly else {
+            Issue.record("expected memory_search")
+            return
+        }
+        #expect(payload.horizons == [.working])
+    }
+
+    @Test
+    func memorySearchRejectsEmptyLaneSelection() throws {
+        var thrownMessage: String?
+        do {
+            _ = try BrokerCommand.decode(
+                command: "memory_search",
+                arguments: [
+                    "query": .string("needle"),
+                    "include_working": .bool(false),
+                    "include_episodic": .bool(false),
+                    "include_durable": .bool(false),
+                ]
+            )
+        } catch let error as BrokerValidationError {
+            thrownMessage = error.errorDescription ?? String(describing: error)
+        }
+        let message = try #require(thrownMessage, "empty lane selection must be rejected at decode")
+        #expect(message.lowercased().contains("lane"))
     }
 
     @Test

--- a/Tests/WaxTests/HorizonScopeSelectionTests.swift
+++ b/Tests/WaxTests/HorizonScopeSelectionTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import Wax
+
+/// Pins HorizonSet lane visibility after session-scope resolution to the exact
+/// Bool-table behavior that preceded HorizonSet: a resolved session keeps the
+/// request, durableOnly forces the durable lane, unscoped drops working.
+struct HorizonScopeSelectionTests {
+    private static let allRequests: [HorizonSet] = [
+        [],
+        [.working],
+        [.episodic],
+        [.durable],
+        [.working, .episodic],
+        [.working, .durable],
+        [.episodic, .durable],
+        HorizonSet.all,
+    ]
+
+    @Test
+    func sessionScopeKeepsRequestedLanes() {
+        let resolved = AgentBrokerService.ResolvedSessionScope.session(
+            UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+        )
+        for requested in Self.allRequests {
+            #expect(
+                AgentBrokerService.scopedHorizons(scope: resolved, requested: requested) == requested,
+                "session scope must keep \(requested.rawValue)"
+            )
+        }
+    }
+
+    @Test
+    func unscopedScopeDropsWorkingLaneOnly() {
+        for requested in Self.allRequests {
+            #expect(
+                AgentBrokerService.scopedHorizons(scope: .none, requested: requested) == requested.subtracting(.working),
+                "unscoped scope must drop only working from \(requested.rawValue)"
+            )
+        }
+    }
+
+    @Test
+    func durableOnlyScopeSelectsDurableLane() {
+        for requested in Self.allRequests {
+            #expect(
+                AgentBrokerService.scopedHorizons(scope: .durableOnly, requested: requested) == [.durable],
+                "durableOnly scope must select durable over \(requested.rawValue)"
+            )
+        }
+    }
+
+    @Test
+    func laneMembershipMirrorsHorizonVocabulary() {
+        #expect(HorizonSet.working.contains(.working))
+        #expect(HorizonSet.episodic.contains(.episodic))
+        #expect(HorizonSet.durable.contains(.durable))
+        #expect(HorizonSet.working.intersection([.episodic, .durable]).isEmpty)
+        #expect(HorizonSet.all.subtracting([.working, .episodic, .durable]).isEmpty)
+    }
+}


### PR DESCRIPTION
Spec: spec/spec-architecture-type-system-hardening.md (ticket T1)

## What
Replaces the includeWorking/includeEpisodic/includeDurable Bool×3 threading across BrokerCommand -> AgentBrokerService -> LayeredRecall.SearchRequest with a package-internal `HorizonSet` OptionSet over the existing Horizon lanes.

## Compiler gain
An empty lane selection no longer compiles through: decode rejects it with a named error mentioning lanes (previously it silently searched nothing). The hand-written scope override table collapses into pure set algebra pinned by an exhaustive 24-cell test against the old behavior.

## Wire compatibility
Wire keys include_working/include_episodic/include_durable unchanged, defaults unchanged (absent = all lanes). Only behavior delta: all-false requests now fail decode instead of returning empty results.

## Verification
Targeted suites green: HorizonScopeSelectionTests 4/4, BrokerCommandDecodeTests 25/25, LayeredRecallTests 37/37 combined run, brokerMemorySearch end-to-end 4/4. Two WaxMCPServerTests source-scanner failures proven pre-existing at base 572b7865b.

Review skills used: swift-adversarial-pr-review x2 (fresh-context fix-allowed review + independent final pass, both APPROVE, zero code findings).
