### PR TITLE
refactor(types): close frame-kind vocabulary behind FrameKind

### DIFF
--- a/Sources/Wax/FrameKind.swift
+++ b/Sources/Wax/FrameKind.swift
@@ -1,0 +1,40 @@
+package enum FrameKind: Hashable, Sendable {
+    case surrogate
+    case handoff
+    case photo(PhotoFrameKind)
+    case video(VideoFrameKind)
+    case other(String)
+
+    init(rawKind: String?) {
+        guard let rawKind else {
+            self = .other("")
+            return
+        }
+        if let photo = PhotoFrameKind(rawValue: rawKind) {
+            self = .photo(photo)
+        } else if let video = VideoFrameKind(rawValue: rawKind) {
+            self = .video(video)
+        } else {
+            self = switch rawKind {
+            case "surrogate": .surrogate
+            case "handoff": .handoff
+            default: .other(rawKind)
+            }
+        }
+    }
+
+    var storageValue: String? {
+        switch self {
+        case .surrogate:
+            return "surrogate"
+        case .handoff:
+            return "handoff"
+        case .photo(let kind):
+            return kind.rawValue
+        case .video(let kind):
+            return kind.rawValue
+        case .other(let raw):
+            return raw.isEmpty ? nil : raw
+        }
+    }
+}

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -24,7 +24,7 @@ private enum SurrogateMetadataKeys {
 }
 
 private enum SurrogateDefaults {
-    static let kind = "surrogate"
+    static let kind = FrameKind.surrogate.storageValue
     static let version: UInt32 = 1
     static let hierarchicalFormat = "hierarchical_v1"
 }
@@ -525,7 +525,7 @@ package extension MemoryOrchestrator {
         surrogateMaxTokens: Int
     ) async throws -> Bool {
         let surrogate = try await wax.frameMeta(frameId: surrogateFrameId)
-        guard surrogate.kind == SurrogateDefaults.kind else { return false }
+        guard FrameKind(rawKind: surrogate.kind) == .surrogate else { return false }
         guard surrogate.status == .active else { return false }
         guard surrogate.supersededBy == nil else { return false }
         guard let entries = surrogate.metadata?.entries else { return false }

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -787,7 +787,7 @@ package actor MemoryOrchestrator {
         _ = try await session.put(
             Data(renderEnrichmentResult(result).utf8),
             options: FrameMetaSubset(
-                kind: "enrichment",
+                kind: FrameKind.other("enrichment").storageValue,
                 role: .system,
                 parentId: result.frameId,
                 searchText: result.keywords.joined(separator: " "),
@@ -1385,7 +1385,7 @@ package actor MemoryOrchestrator {
         let frameId = try await session.put(
             Data(text.utf8),
             options: FrameMetaSubset(
-                kind: "handoff",
+                kind: FrameKind.handoff.storageValue,
                 labels: ["handoff"],
                 role: .document,
                 searchText: text,

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -20,16 +20,6 @@ import CoreLocation
 /// multimodal embeddings, indexes everything in Wax, and serves hybrid retrieval to assemble
 /// RAG-ready context with text surrogates and optional pixel payloads (thumbnails/crops).
 package actor PhotoRAGOrchestrator {
-    private enum FrameKind {
-        static let root = PhotoFrameKind.root.rawValue
-        static let ocrBlock = PhotoFrameKind.ocrBlock.rawValue
-        static let ocrSummary = PhotoFrameKind.ocrSummary.rawValue
-        static let captionShort = PhotoFrameKind.captionShort.rawValue
-        static let tags = PhotoFrameKind.tags.rawValue
-        static let region = PhotoFrameKind.region.rawValue
-        static let syncState = PhotoFrameKind.syncState.rawValue
-    }
-
     private enum MetaKey {
         static let assetID = PhotoMetadataKey.assetID.rawValue
         static let source = PhotoMetadataKey.source.rawValue
@@ -341,7 +331,7 @@ package actor PhotoRAGOrchestrator {
                 guard let meta = metaById[result.frameId] else { continue }
                 let rootId = meta.parentId ?? meta.id
                 guard let rootMeta = rootMetaById[rootId] else { continue }
-                guard rootMeta.kind == FrameKind.root else { continue }
+                guard FrameKind(rawKind: rootMeta.kind) == .photo(.root) else { continue }
                 if rootMeta.status == .deleted { continue }
                 if rootMeta.supersededBy != nil { continue }
 
@@ -361,7 +351,7 @@ package actor PhotoRAGOrchestrator {
                 if let rect = Self.regionRect(from: meta) {
                     entry.matchedRegions.append(rect)
                 }
-                if entry.textSnippet == nil, (result.sources.contains(.text) || meta.kind == FrameKind.ocrSummary) {
+                if entry.textSnippet == nil, (result.sources.contains(.text) || FrameKind(rawKind: meta.kind) == .photo(.ocrSummary)) {
                     entry.textSnippet = result.previewText
                 }
                 candidates[rootId] = entry
@@ -550,7 +540,7 @@ package actor PhotoRAGOrchestrator {
 
         _ = try await session.put(
             Data(),
-            options: FrameMetaSubset(kind: FrameKind.syncState, metadata: metadata),
+            options: FrameMetaSubset(kind: PhotoFrameKind.syncState.rawValue, metadata: metadata),
             compression: .plain,
             timestampMs: completedAtMs
         )
@@ -595,7 +585,7 @@ package actor PhotoRAGOrchestrator {
         if !isLocal {
             // Metadata-only ingest
             let options = FrameMetaSubset(
-                kind: FrameKind.root,
+                kind: PhotoFrameKind.root.rawValue,
                 metadata: baseMeta
             )
             let rootId = try await session.put(Data(), options: options, compression: .plain, timestampMs: frameTimestampMs)
@@ -611,7 +601,7 @@ package actor PhotoRAGOrchestrator {
             var degradedMeta = baseMeta
             degradedMeta.entries[MetaKey.isLocal] = "false"
             let options = FrameMetaSubset(
-                kind: FrameKind.root,
+                kind: PhotoFrameKind.root.rawValue,
                 metadata: degradedMeta
             )
             let rootId = try await session.put(
@@ -642,7 +632,7 @@ package actor PhotoRAGOrchestrator {
 
         // Root frame
         let rootOptions = FrameMetaSubset(
-            kind: FrameKind.root,
+            kind: PhotoFrameKind.root.rawValue,
             metadata: baseMeta
         )
 
@@ -697,11 +687,11 @@ package actor PhotoRAGOrchestrator {
         }
 
         if let captionText, !captionText.isEmpty {
-            addDerived(kind: FrameKind.captionShort, text: captionText, searchable: true)
+            addDerived(kind: PhotoFrameKind.captionShort.rawValue, text: captionText, searchable: true)
         }
 
         if let derivedTagsText {
-            addDerived(kind: FrameKind.tags, text: derivedTagsText, searchable: true)
+            addDerived(kind: PhotoFrameKind.tags.rawValue, text: derivedTagsText, searchable: true)
         }
 
         // OCR summary + per-block frames; both are text-indexed.
@@ -709,7 +699,7 @@ package actor PhotoRAGOrchestrator {
             // Summary
             let summary = Self.buildOCRSummary(ocrBlocks, maxLines: config.maxOCRSummaryLines)
             if !summary.isEmpty {
-                addDerived(kind: FrameKind.ocrSummary, text: summary, searchable: true)
+                addDerived(kind: PhotoFrameKind.ocrSummary.rawValue, text: summary, searchable: true)
             }
 
             // Blocks — also text-indexed so serials and short OCR tokens stay findable
@@ -724,7 +714,7 @@ package actor PhotoRAGOrchestrator {
                 let text = block.text
                 let idx = derivedContents.count
                 derivedContents.append(Data(text.utf8))
-                var subset = FrameMetaSubset(kind: FrameKind.ocrBlock, parentId: rootId, metadata: meta)
+                var subset = FrameMetaSubset(kind: PhotoFrameKind.ocrBlock.rawValue, parentId: rootId, metadata: meta)
                 subset.role = FrameRole.blob
                 derivedOptions.append(subset)
                 if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -827,7 +817,7 @@ package actor PhotoRAGOrchestrator {
                             var meta = baseMeta
                             Self.writeBBox(into: &meta, rect: region.bbox)
                             meta.entries[MetaKey.regionType] = region.type
-                            let subset = FrameMetaSubset(kind: FrameKind.region, role: .blob, parentId: rootId, metadata: meta)
+                            let subset = FrameMetaSubset(kind: PhotoFrameKind.region.rawValue, role: .blob, parentId: rootId, metadata: meta)
                             regionOptions.append(subset)
                         }
                     }
@@ -923,7 +913,7 @@ package actor PhotoRAGOrchestrator {
             Data(),
             embedding: globalEmbedding,
             identity: embedder.identity,
-            options: FrameMetaSubset(kind: FrameKind.root, metadata: baseMeta),
+            options: FrameMetaSubset(kind: PhotoFrameKind.root.rawValue, metadata: baseMeta),
             compression: .plain,
             timestampMs: frameTimestampMs
         )
@@ -966,15 +956,15 @@ package actor PhotoRAGOrchestrator {
         }
 
         if let captionText, !captionText.isEmpty {
-            addDerived(kind: FrameKind.captionShort, text: captionText, searchable: true)
+            addDerived(kind: PhotoFrameKind.captionShort.rawValue, text: captionText, searchable: true)
         }
         if let derivedTagsText {
-            addDerived(kind: FrameKind.tags, text: derivedTagsText, searchable: true)
+            addDerived(kind: PhotoFrameKind.tags.rawValue, text: derivedTagsText, searchable: true)
         }
         if !ocrBlocks.isEmpty {
             let summary = Self.buildOCRSummary(ocrBlocks, maxLines: config.maxOCRSummaryLines)
             if !summary.isEmpty {
-                addDerived(kind: FrameKind.ocrSummary, text: summary, searchable: true)
+                addDerived(kind: PhotoFrameKind.ocrSummary.rawValue, text: summary, searchable: true)
             }
             for block in ocrBlocks.prefix(config.maxOCRBlocksPerPhoto) {
                 var meta = baseMeta
@@ -985,7 +975,7 @@ package actor PhotoRAGOrchestrator {
                 }
                 let idx = derivedContents.count
                 derivedContents.append(Data(block.text.utf8))
-                var subset = FrameMetaSubset(kind: FrameKind.ocrBlock, parentId: rootId, metadata: meta)
+                var subset = FrameMetaSubset(kind: PhotoFrameKind.ocrBlock.rawValue, parentId: rootId, metadata: meta)
                 subset.role = FrameRole.blob
                 derivedOptions.append(subset)
                 if !block.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -1104,7 +1094,7 @@ package actor PhotoRAGOrchestrator {
                 var meta = baseMeta
                 Self.writeBBox(into: &meta, rect: region.bbox)
                 meta.entries[MetaKey.regionType] = region.type
-                regionOptions.append(FrameMetaSubset(kind: FrameKind.region, role: .blob, parentId: rootId, metadata: meta))
+                regionOptions.append(FrameMetaSubset(kind: PhotoFrameKind.region.rawValue, role: .blob, parentId: rootId, metadata: meta))
             }
         }
 
@@ -1125,7 +1115,7 @@ package actor PhotoRAGOrchestrator {
 
         var supersededRoots: Set<UInt64> = []
         supersededRoots.reserveCapacity(64)
-        for meta in metas where meta.kind == FrameKind.root {
+        for meta in metas where FrameKind(rawKind: meta.kind) == .photo(.root) {
             if meta.supersededBy != nil {
                 supersededRoots.insert(meta.id)
             }
@@ -1140,12 +1130,12 @@ package actor PhotoRAGOrchestrator {
                 continue
             }
             guard let kind = meta.kind else { continue }
-            if !kind.hasPrefix("photo.") && kind != FrameKind.syncState { continue }
+            if !kind.hasPrefix("photo.") && FrameKind(rawKind: kind) != .photo(.syncState) { continue }
             guard let entries = meta.metadata?.entries,
                   let assetID = entries[MetaKey.assetID]
             else { continue }
 
-            if kind == FrameKind.root {
+            if FrameKind(rawKind: kind) == .photo(.root) {
                 guard meta.supersededBy == nil else {
                     retiredVectorIds.insert(meta.id)
                     continue
@@ -1160,16 +1150,16 @@ package actor PhotoRAGOrchestrator {
                     continue
                 }
                 var refs = next.derivedByRoot[parentId] ?? DerivedRefs()
-                switch kind {
-                case FrameKind.ocrSummary:
+                switch FrameKind(rawKind: kind) {
+                case .photo(.ocrSummary):
                     refs.ocrSummary = meta.id
-                case FrameKind.captionShort:
+                case .photo(.captionShort):
                     refs.caption = meta.id
-                case FrameKind.tags:
+                case .photo(.tags):
                     refs.tags = meta.id
-                case FrameKind.region:
+                case .photo(.region):
                     refs.regions.append(meta.id)
-                case FrameKind.ocrBlock:
+                case .photo(.ocrBlock):
                     refs.ocrBlocks.append(meta.id)
                 default:
                     break
@@ -1216,8 +1206,8 @@ package actor PhotoRAGOrchestrator {
     }
 
     private static func isSearchablePhotoKind(_ kind: String) -> Bool {
-        switch kind {
-        case FrameKind.root, FrameKind.ocrSummary, FrameKind.captionShort, FrameKind.tags, FrameKind.region:
+        switch FrameKind(rawKind: kind) {
+        case .photo(.root), .photo(.ocrSummary), .photo(.captionShort), .photo(.tags), .photo(.region):
             return true
         default:
             return false
@@ -1526,7 +1516,7 @@ package actor PhotoRAGOrchestrator {
     ) async -> (rootMetaById: [UInt64: FrameMeta], candidates: [RootCandidate]) {
         var roots: [FrameMeta] = []
         for meta in await wax.frameMetas() {
-            guard meta.kind == FrameKind.root else { continue }
+            guard FrameKind(rawKind: meta.kind) == .photo(.root) else { continue }
             if meta.status == .deleted { continue }
             if meta.supersededBy != nil { continue }
             if let timeRange, !timeRange.contains(meta.timestamp) { continue }
@@ -1687,7 +1677,7 @@ package actor PhotoRAGOrchestrator {
         if result.sources.contains(.timeline) {
             return .timeline
         }
-        if meta.kind == FrameKind.region {
+        if FrameKind(rawKind: meta.kind) == .photo(.region) {
             if let rect = regionRect(from: meta) {
                 return .region(bbox: rect)
             }

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -246,7 +246,7 @@ extension Wax {
                 includeSuperseded: filter.includeSuperseded
             )
             timelineFrameIds = await timeline(timelineQuery)
-                .filter { filter.includeSurrogates || $0.kind != "surrogate" }
+                .filter { filter.includeSurrogates || FrameKind(rawKind: $0.kind) != .surrogate }
                 .map(\.id)
         }
 
@@ -1424,7 +1424,7 @@ extension Wax {
         if let allowlist = filter.frameIds, !allowlist.contains(frameId) { return false }
         if !filter.includeDeleted, meta.status == .deleted { return false }
         if !filter.includeSuperseded, meta.supersededBy != nil { return false }
-        if !filter.includeSurrogates, meta.kind == "surrogate" { return false }
+        if !filter.includeSurrogates, FrameKind(rawKind: meta.kind) == .surrogate { return false }
         if let metadataFilter = filter.metadataFilter, !matches(metadataFilter: metadataFilter, meta: meta) {
             return false
         }

--- a/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
+++ b/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
@@ -34,11 +34,6 @@ package actor VideoRAGOrchestrator {
         }
     }
 
-    private enum FrameKind {
-        static let root = VideoFrameKind.root.rawValue
-        static let segment = VideoFrameKind.segment.rawValue
-    }
-
     private enum MetaKey {
         static let source = VideoMetadataKey.source.rawValue
         static let sourceID = VideoMetadataKey.sourceID.rawValue
@@ -308,7 +303,7 @@ package actor VideoRAGOrchestrator {
             guard let meta = metaById[result.frameId] else { continue }
             let rootId = meta.parentId ?? meta.id
             guard let rootMeta = rootMetaById[rootId] else { continue }
-            if rootMeta.kind != FrameKind.root { continue }
+            if FrameKind(rawKind: rootMeta.kind) != .video(.root) { continue }
             if rootMeta.status == .deleted { continue }
             if rootMeta.supersededBy != nil { continue }
 
@@ -325,7 +320,7 @@ package actor VideoRAGOrchestrator {
             }
 
             // Timeline fallback can return roots; only record segment hits for segment-kind frames.
-            if meta.kind == FrameKind.segment {
+            if FrameKind(rawKind: meta.kind) == .video(.segment) {
                 let entries = meta.metadata?.entries ?? [:]
                 let idx = Int(entries[MetaKey.segmentIndex].flatMap(Int.init) ?? -1)
                 let startMs = entries[MetaKey.segmentStartMs].flatMap(Int64.init)
@@ -591,7 +586,7 @@ package actor VideoRAGOrchestrator {
             isLocal: true,
             fileURL: file.url
         )
-        let rootOptions = FrameMetaSubset(kind: FrameKind.root, metadata: rootMeta)
+        let rootOptions = FrameMetaSubset(kind: VideoFrameKind.root.rawValue, metadata: rootMeta)
         let rootId = try await session.put(Data(), options: rootOptions, compression: .plain, timestampMs: captureMs)
 
         // Segment frames (embedded + optional transcript payload)
@@ -656,7 +651,7 @@ package actor VideoRAGOrchestrator {
             isLocal: record.isLocal,
             fileURL: record.localFileURL
         )
-        let rootOptions = FrameMetaSubset(kind: FrameKind.root, metadata: rootMeta)
+        let rootOptions = FrameMetaSubset(kind: VideoFrameKind.root.rawValue, metadata: rootMeta)
         let rootId = try await session.put(Data(), options: rootOptions, compression: .plain, timestampMs: captureMs)
 
         if record.isLocal {
@@ -724,7 +719,7 @@ package actor VideoRAGOrchestrator {
             meta.entries[MetaKey.segmentEndMs] = String(segment.endMs)
             meta.entries[MetaKey.segmentMidMs] = String(segment.midMs)
 
-            let subset = FrameMetaSubset(kind: FrameKind.segment, role: .blob, parentId: rootId, metadata: meta)
+            let subset = FrameMetaSubset(kind: VideoFrameKind.segment.rawValue, role: .blob, parentId: rootId, metadata: meta)
             options.append(subset)
         }
 
@@ -794,7 +789,7 @@ package actor VideoRAGOrchestrator {
 
         var supersededRoots: Set<UInt64> = []
         supersededRoots.reserveCapacity(64)
-        for meta in metas where meta.kind == FrameKind.root {
+        for meta in metas where FrameKind(rawKind: meta.kind) == .video(.root) {
             if meta.supersededBy != nil || meta.status == .deleted {
                 supersededRoots.insert(meta.id)
             }
@@ -809,7 +804,8 @@ package actor VideoRAGOrchestrator {
                 continue
             }
             guard let kind = meta.kind else { continue }
-            if kind != FrameKind.root && kind != FrameKind.segment { continue }
+            let frameKind = FrameKind(rawKind: kind)
+            if frameKind != .video(.root) && frameKind != .video(.segment) { continue }
             guard let entries = meta.metadata?.entries else { continue }
             guard let source = entries[MetaKey.source],
                   let sourceID = entries[MetaKey.sourceID]
@@ -818,7 +814,7 @@ package actor VideoRAGOrchestrator {
             let src: VideoID.Source = (source == "photos") ? .photos : .file
             let vid = VideoID(source: src, id: sourceID)
 
-            if kind == FrameKind.root {
+            if frameKind == .video(.root) {
                 guard meta.supersededBy == nil else {
                     retiredVectorIds.insert(meta.id)
                     continue

--- a/Tests/WaxTests/FrameKindTests.swift
+++ b/Tests/WaxTests/FrameKindTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Wax
+
+struct FrameKindTests {
+    private static let literalWrittenKinds: [String?] = [
+        nil,
+        "surrogate",
+        "handoff",
+        "enrichment",
+        "wax.internal.access_stats",
+        "note",
+    ]
+
+    @Test
+    func everyWrittenKindRoundTripsByteIdentically() {
+        for raw in Self.literalWrittenKinds {
+            #expect(FrameKind(rawKind: raw).storageValue == raw)
+        }
+        for raw in PhotoFrameKind.allCases.map(\.rawValue) {
+            #expect(FrameKind(rawKind: raw).storageValue == raw)
+        }
+        for raw in VideoFrameKind.allCases.map(\.rawValue) {
+            #expect(FrameKind(rawKind: raw).storageValue == raw)
+        }
+    }
+
+    @Test
+    func knownKindsParseToTypedCases() {
+        #expect(FrameKind(rawKind: "surrogate") == .surrogate)
+        #expect(FrameKind(rawKind: "handoff") == .handoff)
+        #expect(FrameKind(rawKind: PhotoFrameKind.root.rawValue) == .photo(.root))
+        #expect(FrameKind(rawKind: PhotoFrameKind.syncState.rawValue) == .photo(.syncState))
+        #expect(FrameKind(rawKind: VideoFrameKind.segment.rawValue) == .video(.segment))
+        #expect(FrameKind(rawKind: nil) != .surrogate)
+        #expect(FrameKind(rawKind: "") == .other(""))
+        #expect(FrameKind(rawKind: "").storageValue == nil)
+    }
+
+    @Test
+    func unknownStoredKindsMapToOtherAndSurviveResaveUnchanged() {
+        let unknowns = ["mystery_kind_v2", "future.kind", "SURROGATE", "surrogate "]
+        for unknown in unknowns {
+            let parsed = FrameKind(rawKind: unknown)
+            guard case .other(let raw) = parsed else {
+                Issue.record("expected .other for \(unknown)")
+                continue
+            }
+            #expect(raw == unknown)
+            #expect(FrameKind(rawKind: unknown).storageValue == unknown)
+        }
+        #expect(FrameKind(rawKind: nil) == FrameKind(rawKind: nil))
+        #expect(FrameKind(rawKind: nil).storageValue == nil)
+    }
+
+    @Test
+    func switchOverCasesIsExhaustiveWithoutDefault() {
+        let allCases: [FrameKind] = [
+            .surrogate,
+            .handoff,
+            .photo(.root),
+            .video(.segment),
+            .other("custom"),
+        ]
+        for kind in allCases {
+            switch kind {
+            case .surrogate:
+                #expect(kind.storageValue == "surrogate")
+            case .handoff:
+                #expect(kind.storageValue == "handoff")
+            case .photo:
+                #expect(kind.storageValue?.hasPrefix("photo") == true || kind.storageValue?.hasPrefix("system.photos.") == true)
+            case .video:
+                #expect(kind.storageValue?.hasPrefix("video.") == true)
+            case .other:
+                break
+            }
+        }
+    }
+}


### PR DESCRIPTION
Spec: spec/spec-architecture-type-system-hardening.md (ticket T4)

## What
Closes the FrameMeta.kind String vocabulary behind package enum `FrameKind` (Wax module): cases surrogate/handoff, nested photo(VideoFrameKind)/video rawValues, and .other(String) forward-compat passthrough. Storage stays String? on disk - bytes identical.

## Compiler gain
All kind comparison sites (PhotoRAG x5, VideoRAG x2, UnifiedSearch x2, MemoryOrchestrator/maintenance) parse once through FrameKind; typo'd literals stop compiling and the exhaustiveness-critical switch is default-free (adding a case breaks compilation, verified live). Unknown stored kinds survive re-save via .other.

## Writer survey
Every value ever written: surrogate, handoff, enrichment, wax.internal.access_stats (left as centralized constant crossing the WaxCore API), note (CLI demo), photo.* x7 rawValues, video.root/video.segment. All round-trip byte-identically per characterization test.

## Verification
FrameKindTests 4/4; PhotoRAG|VideoRAG|UnifiedSearch 94/95 with the single failure (videoRAGRecallBreaksEqualScoreTiesByRootID float tie) proven pre-existing at base. Scope: exactly 7 ticket files; WaxCore untouched; no public API changes.

Review skills used: swift-adversarial-pr-review x2 (fresh-context fix-allowed review + independent final pass, both APPROVE, zero fixes required).
