### PR TITLE
refactor(broker): type composite memory references behind MemoryReference

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -77,7 +77,7 @@ extension AgentBrokerService {
             managed: document.metadata[MemoryMetadataKeys.sourceManaged] != "false",
             sourceKind: kind.rawValue,
             frameID: document.frameId,
-            memoryID: Self.makeMemoryReference(.durable, sessionID: nil, frameID: document.frameId),
+            memoryID: MemoryReference.durable(frameID: document.frameId).wireValue,
             hash: Self.stableHash(document.text),
             sessionID: document.metadata[MemoryMetadataKeys.promotedFromSession] ?? document.metadata["session_id"],
             sourceFrameID: document.metadata[MemoryMetadataKeys.promotedFromFrame].flatMap(UInt64.init),
@@ -399,7 +399,7 @@ extension AgentBrokerService {
         guard marker.hash == previousHash else { return false }
 
         if let markerMemoryID = marker.memoryID {
-            let canonicalMemoryID = Self.makeMemoryReference(.durable, sessionID: nil, frameID: document.frameId)
+            let canonicalMemoryID = MemoryReference.durable(frameID: document.frameId).wireValue
             let storedMemoryID = document.metadata[MemoryMetadataKeys.sourceMemoryID]
             guard markerMemoryID == canonicalMemoryID || markerMemoryID == storedMemoryID else { return false }
         }

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -254,9 +254,7 @@ extension AgentBrokerService {
     package static let maxContentBytes = BrokerLimits.maxContentBytes
     static let maxGraphLimit = BrokerLimits.maxGraphLimit
 
-    typealias MemoryHorizon = LayeredRecall.Horizon
     typealias LayeredMemoryHit = LayeredRecall.Hit
-    typealias MemoryReference = LayeredRecall.MemoryReference
 
     struct CompactContextAssembly {
         var short: [LayeredMemoryHit]
@@ -621,10 +619,14 @@ extension AgentBrokerService {
     }
 
     func memoryGet(_ command: BrokerCommand.MemoryGet) async throws -> AgentBrokerValue {
-        let reference = try parseMemoryReference(command.memoryID)
+        guard let reference = MemoryReference(parsing: command.memoryID) else {
+            throw BrokerValidationError.invalid(
+                "memory_id must be in the form '<horizon>:<frame>' or '<horizon>:<session_id>:<frame>'"
+            )
+        }
         let hit = try await layeredMemoryGet(reference: reference)
         return .object([
-            "memory_id": .string(hit.reference),
+            "memory_id": .string(hit.reference.wireValue),
             "horizon": .string(hit.horizon.rawValue),
             "session_id": .from(hit.sessionID?.uuidString),
             "agent_id": .from(hit.agentID),
@@ -1890,7 +1892,7 @@ extension AgentBrokerService {
         case .durable:
             let document = try await requireDocument(frameID: reference.frameID, memory: longTermMemory)
             return LayeredMemoryHit(
-                reference: Self.makeMemoryReference(.durable, sessionID: nil, frameID: reference.frameID),
+                reference: .durable(frameID: reference.frameID),
                 horizon: .durable,
                 sessionID: nil,
                 agentID: nil,
@@ -1911,7 +1913,7 @@ extension AgentBrokerService {
             let loader: (MemoryOrchestrator) async throws -> LayeredMemoryHit = { memory in
                 let document = try await self.requireDocument(frameID: reference.frameID, memory: memory)
                 return LayeredMemoryHit(
-                    reference: Self.makeMemoryReference(reference.horizon, sessionID: sessionID, frameID: reference.frameID),
+                    reference: reference,
                     horizon: reference.horizon,
                     sessionID: sessionID,
                     agentID: manifest.agentID,
@@ -1960,7 +1962,7 @@ extension AgentBrokerService {
             for item in execution.context.items {
                 let canonicalFrameID = try await canonicalDocumentFrameID(for: item.frameId, memory: state.memory)
                 short.append(LayeredMemoryHit(
-                    reference: Self.makeMemoryReference(.working, sessionID: sessionID, frameID: canonicalFrameID),
+                    reference: .working(sessionID: sessionID, frameID: canonicalFrameID),
                     horizon: .working,
                     sessionID: sessionID,
                     agentID: state.manifest.agentID,
@@ -1982,7 +1984,7 @@ extension AgentBrokerService {
                     }
                 for document in documents.prefix(min(4, maxItems)) {
                     short.append(LayeredMemoryHit(
-                        reference: Self.makeMemoryReference(.working, sessionID: sessionID, frameID: document.frameId),
+                        reference: .working(sessionID: sessionID, frameID: document.frameId),
                         horizon: .working,
                         sessionID: sessionID,
                         agentID: state.manifest.agentID,
@@ -2009,7 +2011,7 @@ extension AgentBrokerService {
         for item in longExecution.context.items {
             let canonicalFrameID = try await canonicalDocumentFrameID(for: item.frameId, memory: longTermMemory)
             long.append(LayeredMemoryHit(
-                reference: Self.makeMemoryReference(.durable, sessionID: nil, frameID: canonicalFrameID),
+                reference: .durable(frameID: canonicalFrameID),
                 horizon: .durable,
                 sessionID: nil,
                 agentID: nil,
@@ -2051,7 +2053,7 @@ extension AgentBrokerService {
                 for item in items {
                     let canonicalFrameID = try await self.canonicalDocumentFrameID(for: item.frameId, memory: memory)
                     hits.append(LayeredMemoryHit(
-                        reference: Self.makeMemoryReference(.episodic, sessionID: manifest.sessionID, frameID: canonicalFrameID),
+                        reference: .episodic(sessionID: manifest.sessionID, frameID: canonicalFrameID),
                         horizon: .episodic,
                         sessionID: manifest.sessionID,
                         agentID: manifest.agentID,
@@ -2074,7 +2076,7 @@ extension AgentBrokerService {
         medium = Self.deduplicateLayeredHits(medium).sorted {
             if $0.score != $1.score { return $0.score > $1.score }
             if $0.timestampMs != $1.timestampMs { return $0.timestampMs > $1.timestampMs }
-            return $0.reference < $1.reference
+            return $0.reference.wireValue < $1.reference.wireValue
         }
         long = Self.deduplicateLayeredHits(long)
 
@@ -2148,7 +2150,7 @@ extension AgentBrokerService {
     }
 
     static func deduplicateLayeredHits(_ hits: [LayeredMemoryHit]) -> [LayeredMemoryHit] {
-        var seen = Set<String>()
+        var seen = Set<MemoryReference>()
         var deduped: [LayeredMemoryHit] = []
         deduped.reserveCapacity(hits.count)
         for hit in hits where seen.insert(hit.reference).inserted {
@@ -2703,33 +2705,9 @@ extension AgentBrokerService {
         }
     }
 
-    func parseMemoryReference(_ raw: String) throws -> MemoryReference {
-        let parts = raw.split(separator: ":").map(String.init)
-        guard parts.count >= 2 else {
-            throw BrokerValidationError.invalid("memory_id must be in the form '<horizon>:<frame>' or '<horizon>:<session_id>:<frame>'")
-        }
-        guard let horizon = MemoryHorizon(rawValue: parts[0]) else {
-            throw BrokerValidationError.invalid("memory_id horizon must be one of: working, episodic, durable")
-        }
-        switch horizon {
-        case .durable:
-            guard parts.count == 2, let frameID = UInt64(parts[1]) else {
-                throw BrokerValidationError.invalid("durable memory_id must be 'durable:<frame_id>'")
-            }
-            return MemoryReference(horizon: .durable, sessionID: nil, frameID: frameID)
-        case .working, .episodic:
-            guard parts.count == 3,
-                  let sessionID = UUID(uuidString: parts[1]),
-                  let frameID = UInt64(parts[2]) else {
-                throw BrokerValidationError.invalid("session memory_id must be '\(horizon.rawValue):<session_id>:<frame_id>'")
-            }
-            return MemoryReference(horizon: horizon, sessionID: sessionID, frameID: frameID)
-        }
-    }
-
     func renderLayeredMemoryHit(_ hit: LayeredMemoryHit) -> AgentBrokerValue {
         .object([
-            "memory_id": .string(hit.reference),
+            "memory_id": .string(hit.reference.wireValue),
             "horizon": .string(hit.horizon.rawValue),
             "session_id": .from(hit.sessionID?.uuidString),
             "agent_id": .from(hit.agentID),
@@ -2843,10 +2821,6 @@ extension AgentBrokerService {
             return dayString(fromMs: fallbackMs)
         }
         return trimmed
-    }
-
-    static func makeMemoryReference(_ horizon: MemoryHorizon, sessionID: UUID?, frameID: UInt64) -> String {
-        LayeredRecall.makeMemoryReference(horizon, sessionID: sessionID, frameID: frameID)
     }
 
     static func nowMs() -> Int64 {

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -439,8 +439,18 @@ package enum LayeredRecall {
     }
 
     package static func hit(from item: RAGContext.Item, horizon: Horizon, sessionID: UUID?) -> Hit {
-        Hit(
-            reference: MemoryReference(horizon: horizon, sessionID: sessionID, frameID: item.frameId)!,
+        // Total per wire grammar: durable never carries a session, working/episodic may.
+        let reference: MemoryReference
+        switch horizon {
+        case .durable:
+            reference = .durable(frameID: item.frameId)
+        case .working:
+            reference = .working(sessionID: sessionID, frameID: item.frameId)
+        case .episodic:
+            reference = .episodic(sessionID: sessionID, frameID: item.frameId)
+        }
+        return Hit(
+            reference: reference,
             horizon: horizon,
             sessionID: sessionID,
             frameID: item.frameId,

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -27,7 +27,7 @@ package enum LayeredRecall {
     }
 
     package struct Hit: Sendable, Equatable {
-        package var reference: String
+        package var reference: MemoryReference
         package var horizon: Horizon
         package var sessionID: UUID?
         package var agentID: String?
@@ -44,7 +44,7 @@ package enum LayeredRecall {
         package var sources: [String]
 
         package init(
-            reference: String,
+            reference: MemoryReference,
             horizon: Horizon,
             sessionID: UUID? = nil,
             agentID: String? = nil,
@@ -73,18 +73,6 @@ package enum LayeredRecall {
             self.timestampMs = timestampMs
             self.kind = kind
             self.sources = sources
-        }
-    }
-
-    package struct MemoryReference: Sendable, Equatable {
-        package var horizon: Horizon
-        package var sessionID: UUID?
-        package var frameID: UInt64
-
-        package init(horizon: Horizon, sessionID: UUID?, frameID: UInt64) {
-            self.horizon = horizon
-            self.sessionID = sessionID
-            self.frameID = frameID
         }
     }
 
@@ -262,19 +250,6 @@ package enum LayeredRecall {
             self.endedManifests = endedManifests
             self.searchEndedSession = searchEndedSession
             self.nowMs = nowMs
-        }
-    }
-
-    package static func makeMemoryReference(
-        _ horizon: Horizon,
-        sessionID: UUID?,
-        frameID: UInt64
-    ) -> String {
-        switch horizon {
-        case .durable:
-            return "durable:\(frameID)"
-        case .working, .episodic:
-            return "\(horizon.rawValue):\(sessionID?.uuidString ?? "unknown"):\(frameID)"
         }
     }
 
@@ -465,7 +440,7 @@ package enum LayeredRecall {
 
     package static func hit(from item: RAGContext.Item, horizon: Horizon, sessionID: UUID?) -> Hit {
         Hit(
-            reference: makeMemoryReference(horizon, sessionID: sessionID, frameID: item.frameId),
+            reference: MemoryReference(horizon: horizon, sessionID: sessionID, frameID: item.frameId)!,
             horizon: horizon,
             sessionID: sessionID,
             frameID: item.frameId,
@@ -592,11 +567,7 @@ package enum LayeredRecall {
                     }
                 sessionHits = documents.prefix(retrievalTopK).map { document in
                     Hit(
-                        reference: makeMemoryReference(
-                            .working,
-                            sessionID: working.sessionID,
-                            frameID: document.frameId
-                        ),
+                        reference: .working(sessionID: working.sessionID, frameID: document.frameId),
                         horizon: .working,
                         sessionID: working.sessionID,
                         agentID: working.agentID,
@@ -704,11 +675,7 @@ package enum LayeredRecall {
                 }
                 hits.append(
                     Hit(
-                        reference: makeMemoryReference(
-                            .working,
-                            sessionID: sessionID,
-                            frameID: canonicalFrameID
-                        ),
+                        reference: .working(sessionID: sessionID, frameID: canonicalFrameID),
                         horizon: .working,
                         sessionID: sessionID,
                         agentID: lane.agentID,
@@ -743,7 +710,7 @@ package enum LayeredRecall {
                 }
                 hits.append(
                     Hit(
-                        reference: makeMemoryReference(.durable, sessionID: nil, frameID: canonicalFrameID),
+                        reference: .durable(frameID: canonicalFrameID),
                         horizon: .durable,
                         sessionID: nil,
                         frameID: canonicalFrameID,
@@ -790,11 +757,7 @@ package enum LayeredRecall {
                     explanations.append(contentsOf: laneHit.explanations)
                     hits.append(
                         Hit(
-                            reference: makeMemoryReference(
-                                .episodic,
-                                sessionID: manifest.sessionID,
-                                frameID: canonicalFrameID
-                            ),
+                            reference: .episodic(sessionID: manifest.sessionID, frameID: canonicalFrameID),
                             horizon: .episodic,
                             sessionID: manifest.sessionID,
                             agentID: manifest.agentID,
@@ -821,7 +784,7 @@ package enum LayeredRecall {
             deduped.sorted { lhs, rhs in
                 if lhs.score != rhs.score { return lhs.score > rhs.score }
                 if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
-                return lhs.reference < rhs.reference
+                return lhs.reference.wireValue < rhs.reference.wireValue
             }.prefix(request.topK)
         )
     }

--- a/Sources/Wax/Broker/MemoryReference.swift
+++ b/Sources/Wax/Broker/MemoryReference.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Client-facing composite memory identifier (the broker wire `memory_id`).
+///
+/// Wire grammar: durable frames never carry a session and render as
+/// `durable:<frame>`; working/episodic frames render as
+/// `<horizon>:<session-uuid>:<frame>`, where a missing session renders as the
+/// literal `unknown`. The encoding is bijective: `unknown` parses back to a
+/// nil session.
+package struct MemoryReference: Sendable, Hashable {
+    package let horizon: LayeredRecall.Horizon
+    package let sessionID: UUID?
+    package let frameID: UInt64
+
+    package init?(horizon: LayeredRecall.Horizon, sessionID: UUID?, frameID: UInt64) {
+        guard horizon != .durable || sessionID == nil else { return nil }
+        self.horizon = horizon
+        self.sessionID = sessionID
+        self.frameID = frameID
+    }
+
+    package init?(parsing raw: String) {
+        let parts = raw.split(separator: ":").map(String.init)
+        guard parts.count >= 2, let horizon = LayeredRecall.Horizon(rawValue: parts[0]) else {
+            return nil
+        }
+        switch horizon {
+        case .durable:
+            guard parts.count == 2, let parsedFrameID = UInt64(parts[1]) else { return nil }
+            self.horizon = .durable
+            self.sessionID = nil
+            self.frameID = parsedFrameID
+        case .working, .episodic:
+            guard parts.count == 3, let frameID = UInt64(parts[2]) else {
+                return nil
+            }
+            let sessionID: UUID?
+            if parts[1] == "unknown" {
+                sessionID = nil
+            } else if let parsed = UUID(uuidString: parts[1]) {
+                sessionID = parsed
+            } else {
+                return nil
+            }
+            self.horizon = horizon
+            self.sessionID = sessionID
+            self.frameID = frameID
+        }
+    }
+
+    /// The sole formatter for composite memory IDs; bytes pinned by characterization tests.
+    package var wireValue: String {
+        switch horizon {
+        case .durable:
+            return "durable:\(frameID)"
+        case .working, .episodic:
+            return "\(horizon.rawValue):\(sessionID?.uuidString ?? "unknown"):\(frameID)"
+        }
+    }
+
+    package static func durable(frameID: UInt64) -> MemoryReference {
+        MemoryReference(horizon: .durable, sessionID: nil, frameID: frameID)!
+    }
+
+    package static func working(sessionID: UUID?, frameID: UInt64) -> MemoryReference {
+        MemoryReference(horizon: .working, sessionID: sessionID, frameID: frameID)!
+    }
+
+    package static func episodic(sessionID: UUID?, frameID: UInt64) -> MemoryReference {
+        MemoryReference(horizon: .episodic, sessionID: sessionID, frameID: frameID)!
+    }
+}

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -114,13 +114,61 @@ func layeredRecallFrameFilterInjectsProjectMetadataForScopedRetrieval() {
 }
 
 @Test
-func layeredRecallMakeMemoryReferenceFormatsHorizons() {
+func memoryReferenceWireValuePinsWireBytes() {
+    let sessionID = UUID(uuidString: "DEADBEEF-1234-5678-90AB-CDEF01234567")!
+    #expect(MemoryReference.durable(frameID: 42).wireValue == "durable:42")
+    #expect(MemoryReference.working(sessionID: sessionID, frameID: 7).wireValue == "working:\(sessionID.uuidString):7")
+    #expect(MemoryReference.working(sessionID: nil, frameID: 7).wireValue == "working:unknown:7")
+    #expect(MemoryReference.episodic(sessionID: sessionID, frameID: 9).wireValue == "episodic:\(sessionID.uuidString):9")
+}
+
+@Test
+func memoryReferenceParsingRoundTripsEveryProducedShape() {
     let sessionID = UUID()
-    #expect(LayeredRecall.makeMemoryReference(.durable, sessionID: nil, frameID: 42) == "durable:42")
-    #expect(
-        LayeredRecall.makeMemoryReference(.working, sessionID: sessionID, frameID: 7)
-            == "working:\(sessionID.uuidString):7"
-    )
+    let shapes: [MemoryReference] = [
+        .durable(frameID: 0),
+        .durable(frameID: UInt64.max),
+        .working(sessionID: nil, frameID: 0),
+        .working(sessionID: nil, frameID: UInt64.max),
+        .working(sessionID: sessionID, frameID: 7),
+        .episodic(sessionID: nil, frameID: 9),
+        .episodic(sessionID: sessionID, frameID: 9),
+    ]
+    for shape in shapes {
+        #expect(
+            MemoryReference(parsing: shape.wireValue) == shape,
+            "round-trip failed for '\(shape.wireValue)'"
+        )
+    }
+}
+
+@Test
+func memoryReferenceParsingRejectsMalformedLiterals() {
+    let malformed = [
+        "",
+        ":",
+        "durable",
+        "durable:",
+        "durable:x",
+        "durable:-1",
+        "durable:1:2",
+        "bogus:1",
+        "bogus:some-uuid:1",
+        "working:1",
+        "working:not-a-uuid:1",
+        "working::1",
+        "episodic:1:2:3",
+    ]
+    for raw in malformed {
+        #expect(MemoryReference(parsing: raw) == nil, "expected \(raw) to be rejected")
+    }
+}
+
+@Test
+func memoryReferenceInitRejectsSessionOnDurableLane() {
+    #expect(MemoryReference(horizon: .durable, sessionID: UUID(), frameID: 1) == nil)
+    #expect(MemoryReference(horizon: .durable, sessionID: nil, frameID: 1) != nil)
+    #expect(MemoryReference(horizon: .working, sessionID: nil, frameID: 1) != nil)
 }
 
 private func layeredHit(
@@ -131,7 +179,7 @@ private func layeredHit(
     metadata: [String: String] = [:]
 ) -> LayeredRecall.Hit {
     LayeredRecall.Hit(
-        reference: LayeredRecall.makeMemoryReference(horizon, sessionID: nil, frameID: frameID),
+        reference: MemoryReference(horizon: horizon, sessionID: nil, frameID: frameID)!,
         horizon: horizon,
         frameID: frameID,
         score: score,


### PR DESCRIPTION
Spec: spec/spec-architecture-type-system-hardening.md (ticket T2)

## What
Replaces formatted composite memory-ID strings (makeMemoryReference / parseMemoryReference and aliases) with package-internal `MemoryReference` newtype: horizon + optional session UUID + frame ID, with wireValue/init(parsing:) as the single byte-compatible format edge. Hit.reference retyped String -> MemoryReference; dedupe keys become Set<MemoryReference>.

## Compiler gain
Reference construction can no longer omit/transpose components or typo the format string; malformed IDs fail once at the parse edge instead of per-request deep in handlers. AC-202 proven: zero memory-ID interpolations remain outside MemoryReference.swift.

## Wire compatibility
wireValue character-identical to deleted makeMemoryReference (durable:<frame>; <horizon>:<uuid>:<frame>). One deliberate parse-edge widening: "working:unknown:<frame>" now parses to nil session but remains gated by layeredMemoryGet session_id requirement (typed rejection, same outcome class).

## Notable review fix
First-pass reviewer replaced a latent force-unwrap in LayeredRecall.hit(from:) with an exhaustive total horizon switch (review(t2): 3c8e9b1a1).

## Verification
LayeredRecall|BrokerCommandDecode|BrokerSessionModel under --traits MCPServer,MiniLMEmbeddings: all green incl. 4 new round-trip/wire-pin tests.

Review skills used: swift-adversarial-pr-review x2 (fresh-context fix-allowed + independent final pass, APPROVE).
