### PR TITLE
refactor(cli): decode broker responses into typed rows and collapse dual renderers

### DIFF
--- a/Sources/Wax/Broker/BrokerClientResults.swift
+++ b/Sources/Wax/Broker/BrokerClientResults.swift
@@ -1,0 +1,352 @@
+import Foundation
+
+package struct BrokerPayloadDecodeError: Error, LocalizedError, Equatable, Sendable {
+    package enum Reason: Equatable, Sendable {
+        case payloadNotAnObject
+        case missingKey(String)
+        case invalidValue(key: String, expected: String)
+    }
+
+    package let reason: Reason
+
+    package init(reason: Reason) {
+        self.reason = reason
+    }
+
+    package var errorDescription: String? {
+        switch reason {
+        case .payloadNotAnObject:
+            return "Broker returned an unexpected payload"
+        case .missingKey(let key):
+            return "Broker response payload is missing key '\(key)'"
+        case .invalidValue(let key, let expected):
+            return "Broker response payload key '\(key)' is not \(expected)"
+        }
+    }
+}
+
+package struct BrokerCommandFailedError: Error, LocalizedError, Equatable, Sendable {
+    package let message: String
+
+    package init(message: String) {
+        self.message = message
+    }
+
+    package var errorDescription: String? { message }
+}
+
+package struct BrokerRecallRow: Sendable, Equatable {
+    package let rank: Int
+    package let kind: String?
+    package let frameId: UInt64
+    package let score: Double
+    package let text: String
+
+    package init(rank: Int, kind: String?, frameId: UInt64, score: Double, text: String) {
+        self.rank = rank
+        self.kind = kind
+        self.frameId = frameId
+        self.score = score
+        self.text = text
+    }
+
+    package init(_ payload: [String: AgentBrokerValue]) throws {
+        try self.init(
+            rank: decodeInt(requiredValue(payload, "rank"), key: "rank"),
+            kind: decodeOptionalString(payload["kind"], key: "kind"),
+            frameId: decodeUInt64(requiredValue(payload, "frameId"), key: "frameId"),
+            score: decodeDouble(requiredValue(payload, "score"), key: "score"),
+            text: decodeString(requiredValue(payload, "text"), key: "text")
+        )
+    }
+}
+
+package struct BrokerRecallResult: Sendable, Equatable {
+    package let query: String
+    package let totalTokens: Int
+    package let items: [BrokerRecallRow]
+
+    package init(_ payload: [String: AgentBrokerValue]) throws {
+        query = try decodeString(requiredValue(payload, "query"), key: "query")
+        totalTokens = try decodeInt(requiredValue(payload, "total_tokens"), key: "total_tokens")
+        items = try decodedObjectArray(requiredValue(payload, "results"), key: "results")
+            .map(BrokerRecallRow.init)
+    }
+}
+
+package struct BrokerSearchRow: Sendable, Equatable {
+    package let rank: Int
+    package let frameId: UInt64
+    package let score: Double
+    package let sources: [String]
+    package let preview: String
+
+    package init(
+        rank: Int,
+        frameId: UInt64,
+        score: Double,
+        sources: [String],
+        preview: String
+    ) {
+        self.rank = rank
+        self.frameId = frameId
+        self.score = score
+        self.sources = sources
+        self.preview = preview
+    }
+
+    package init(_ payload: [String: AgentBrokerValue]) throws {
+        try self.init(
+            rank: decodeInt(requiredValue(payload, "rank"), key: "rank"),
+            frameId: decodeUInt64(requiredValue(payload, "frameId"), key: "frameId"),
+            score: decodeDouble(requiredValue(payload, "score"), key: "score"),
+            sources: decodedStringArray(requiredValue(payload, "sources"), key: "sources"),
+            preview: decodeString(requiredValue(payload, "preview"), key: "preview")
+        )
+    }
+}
+
+package struct BrokerSearchResult: Sendable, Equatable {
+    package let items: [BrokerSearchRow]
+
+    package init(_ payload: [String: AgentBrokerValue]) throws {
+        items = try decodedObjectArray(requiredValue(payload, "results"), key: "results")
+            .map(BrokerSearchRow.init)
+    }
+}
+
+package struct BrokerRememberResult: Sendable, Equatable {
+    package let framesAdded: Int
+    package let frameCount: Int
+    package let pendingFrames: Int
+
+    package init(framesAdded: Int, frameCount: Int, pendingFrames: Int) {
+        self.framesAdded = framesAdded
+        self.frameCount = frameCount
+        self.pendingFrames = pendingFrames
+    }
+
+    package init(_ payload: [String: AgentBrokerValue]) throws {
+        framesAdded = try decodeInt(requiredValue(payload, "framesAdded"), key: "framesAdded")
+        frameCount = try decodeInt(requiredValue(payload, "frameCount"), key: "frameCount")
+        pendingFrames = try decodeInt(requiredValue(payload, "pendingFrames"), key: "pendingFrames")
+    }
+}
+
+package struct BrokerStatsSummary: Sendable, Equatable {
+    package let storePath: String?
+    package let frameCount: Int
+    package let pendingFrames: Int
+    package let generation: Int
+    package let diskBytes: Int64
+    package let vectorSearchEnabled: Bool
+    package let embeddingStatus: String?
+
+    package init(_ payload: [String: AgentBrokerValue]) throws {
+        storePath = try decodeOptionalString(payload["storePath"], key: "storePath")
+        frameCount = try decodeInt(requiredValue(payload, "frameCount"), key: "frameCount")
+        pendingFrames = try decodeInt(requiredValue(payload, "pendingFrames"), key: "pendingFrames")
+        generation = try decodeInt(requiredValue(payload, "generation"), key: "generation")
+        diskBytes = try decodeInt64(requiredValue(payload, "diskBytes"), key: "diskBytes")
+        vectorSearchEnabled = try decodeBool(requiredValue(payload, "vectorSearchEnabled"), key: "vectorSearchEnabled")
+        embeddingStatus = try decodeOptionalString(payload["embeddingStatus"], key: "embeddingStatus")
+    }
+}
+
+package struct BrokerStatsResponse: Sendable, Equatable {
+    package let summary: BrokerStatsSummary
+    package let payload: [String: AgentBrokerValue]
+
+    package init(_ payload: [String: AgentBrokerValue]) throws {
+        summary = try BrokerStatsSummary(payload)
+        self.payload = payload
+    }
+}
+
+private func requiredValue(
+    _ payload: [String: AgentBrokerValue],
+    _ key: String
+) throws -> AgentBrokerValue {
+    guard let value = payload[key] else {
+        throw BrokerPayloadDecodeError(reason: .missingKey(key))
+    }
+    return value
+}
+
+private func decodeString(_ value: AgentBrokerValue, key: String) throws -> String {
+    guard let string = value.stringValue else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "a string"))
+    }
+    return string
+}
+
+private func decodeOptionalString(_ value: AgentBrokerValue?, key: String) throws -> String? {
+    guard let value else { return nil }
+    if case .null = value { return nil }
+    return try decodeString(value, key: key)
+}
+
+private func decodeInt(_ value: AgentBrokerValue, key: String) throws -> Int {
+    guard let raw = value.intValue, let integer = Int(exactly: raw) else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "an integer"))
+    }
+    return integer
+}
+
+private func decodeInt64(_ value: AgentBrokerValue, key: String) throws -> Int64 {
+    guard let raw = value.intValue else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "an integer"))
+    }
+    return raw
+}
+
+private func decodeUInt64(_ value: AgentBrokerValue, key: String) throws -> UInt64 {
+    guard let raw = value.intValue, let unsigned = UInt64(exactly: raw) else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "a non-negative integer"))
+    }
+    return unsigned
+}
+
+private func decodeDouble(_ value: AgentBrokerValue, key: String) throws -> Double {
+    guard let double = value.doubleValue else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "a number"))
+    }
+    return double
+}
+
+private func decodeBool(_ value: AgentBrokerValue, key: String) throws -> Bool {
+    guard let bool = value.boolValue else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "a boolean"))
+    }
+    return bool
+}
+
+private func decodedObjectArray(
+    _ value: AgentBrokerValue,
+    key: String
+) throws -> [[String: AgentBrokerValue]] {
+    guard let elements = value.arrayValue else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "an array"))
+    }
+    return try elements.map { element in
+        guard let object = element.objectValue else {
+            throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "objects"))
+        }
+        return object
+    }
+}
+
+private func decodedStringArray(_ value: AgentBrokerValue, key: String) throws -> [String] {
+    guard let elements = value.arrayValue else {
+        throw BrokerPayloadDecodeError(reason: .invalidValue(key: key, expected: "an array"))
+    }
+    return try elements.enumerated().map { index, element in
+        guard let string = element.stringValue else {
+            throw BrokerPayloadDecodeError(
+                reason: .invalidValue(key: "\(key)[\(index)]", expected: "a string")
+            )
+        }
+        return string
+    }
+}
+
+fileprivate extension AgentBrokerClient {
+    static func performCommand(
+        _ request: AgentBrokerRequest,
+        configuration: AgentBrokerConfiguration,
+        shutdownIfStarted: Bool
+    ) async throws -> [String: AgentBrokerValue] {
+        let response = try await perform(
+            request: request,
+            configuration: configuration,
+            shutdownIfStarted: shutdownIfStarted
+        )
+        guard response.ok else {
+            throw BrokerCommandFailedError(message: response.error ?? "Broker command failed")
+        }
+        guard let payload = response.payload, let object = payload.objectValue else {
+            throw BrokerPayloadDecodeError(reason: .payloadNotAnObject)
+        }
+        return object
+    }
+}
+
+package extension AgentBrokerClient {
+    static func performRecall(
+        query: String,
+        limit: Int,
+        configuration: AgentBrokerConfiguration,
+        shutdownIfStarted: Bool = true
+    ) async throws -> BrokerRecallResult {
+        try BrokerRecallResult(
+            try await performCommand(
+                AgentBrokerRequest(
+                    command: "recall",
+                    arguments: [
+                        "query": .string(query),
+                        "limit": .from(limit),
+                    ]
+                ),
+                configuration: configuration,
+                shutdownIfStarted: shutdownIfStarted
+            )
+        )
+    }
+
+    static func performSearch(
+        query: String,
+        mode: String,
+        topK: Int,
+        configuration: AgentBrokerConfiguration,
+        shutdownIfStarted: Bool = true
+    ) async throws -> BrokerSearchResult {
+        try BrokerSearchResult(
+            try await performCommand(
+                AgentBrokerRequest(
+                    command: "search",
+                    arguments: [
+                        "query": .string(query),
+                        "mode": .string(mode),
+                        "topK": .from(topK),
+                    ]
+                ),
+                configuration: configuration,
+                shutdownIfStarted: shutdownIfStarted
+            )
+        )
+    }
+
+    static func performRemember(
+        content: String,
+        metadata: [String: String],
+        configuration: AgentBrokerConfiguration,
+        shutdownIfStarted: Bool = true
+    ) async throws -> BrokerRememberResult {
+        try BrokerRememberResult(
+            try await performCommand(
+                AgentBrokerRequest(
+                    command: "remember",
+                    arguments: [
+                        "content": .string(content),
+                        "metadata": .object(metadata.mapValues(AgentBrokerValue.string)),
+                    ]
+                ),
+                configuration: configuration,
+                shutdownIfStarted: shutdownIfStarted
+            )
+        )
+    }
+
+    static func performStats(
+        configuration: AgentBrokerConfiguration,
+        shutdownIfStarted: Bool = true
+    ) async throws -> BrokerStatsResponse {
+        try BrokerStatsResponse(
+            try await performCommand(
+                AgentBrokerRequest(command: "stats", arguments: [:]),
+                configuration: configuration,
+                shutdownIfStarted: shutdownIfStarted
+            )
+        )
+    }
+}

--- a/Sources/WaxCLI/RecallCommand.swift
+++ b/Sources/WaxCLI/RecallCommand.swift
@@ -22,51 +22,19 @@ struct RecallCommand: AsyncParsableCommand {
         }
 
         if AgentBrokerPolicy.shouldUseBroker(store: store) {
-            let response = try await AgentBrokerCLI.perform(
-                command: "recall",
-                arguments: [
-                    "query": .string(query),
-                    "limit": .from(limit),
-                ],
+            let configuration = try AgentBrokerCLI.configuration(
                 storePath: store.storePath,
                 embedderChoice: store.embedder.rawValue,
                 noEmbedder: store.noEmbedder,
                 requireVector: store.requireVector,
                 embedderTuning: store.embedderTuning
             )
-            let payload = try brokerPayloadObject(response)
-            let daemonQuery = brokerString(payload, "query") ?? query
-            let totalTokens = brokerInt(payload, "total_tokens") ?? 0
-            let items = brokerArray(payload, "results")
-
-            switch store.format {
-            case .json:
-                let encodedItems: [[String: Any]] = items.compactMap { item in
-                    guard let object = item.objectValue else { return nil }
-                    return [
-                        "rank": brokerInt(object, "rank") ?? 0,
-                        "kind": brokerString(object, "kind") ?? "",
-                        "frameId": brokerInt64(object, "frameId") ?? 0,
-                        "score": object["score"]?.doubleValue ?? 0,
-                        "text": brokerString(object, "text") ?? "",
-                    ]
-                }
-                printJSON([
-                    "query": daemonQuery,
-                    "totalTokens": totalTokens,
-                    "count": encodedItems.count,
-                    "items": encodedItems,
-                ])
-            case .text:
-                print("Query: \(daemonQuery)")
-                print("Total tokens: \(totalTokens)")
-                for item in items {
-                    guard let object = item.objectValue else { continue }
-                    print(
-                        "\(brokerInt(object, "rank") ?? 0). [\(brokerString(object, "kind") ?? "unknown")] frame=\(brokerInt64(object, "frameId") ?? 0) score=\(String(format: "%.4f", object["score"]?.doubleValue ?? 0)) \(brokerString(object, "text") ?? "")"
-                    )
-                }
-            }
+            let result = try await AgentBrokerClient.performRecall(
+                query: query,
+                limit: limit,
+                configuration: configuration
+            )
+            render(format: store.format, query: result.query, totalTokens: result.totalTokens, rows: result.items)
             return
         }
 
@@ -79,33 +47,43 @@ struct RecallCommand: AsyncParsableCommand {
             requireVector: store.requireVector
         ) { memory in
             let context = try await memory.recall(query: query, frameFilter: nil)
-            let selected = context.items.prefix(limit)
+            let rows = context.items.prefix(limit).enumerated().map { index, item in
+                BrokerRecallRow(
+                    rank: index + 1,
+                    kind: "\(item.kind)",
+                    frameId: item.frameId,
+                    score: Double(item.score),
+                    text: item.text
+                )
+            }
+            render(format: store.format, query: context.query, totalTokens: context.totalTokens, rows: rows)
+        }
+    }
 
-            switch store.format {
-            case .json:
-                let items: [[String: Any]] = selected.enumerated().map { index, item in
+    private func render(format: OutputFormat, query: String, totalTokens: Int, rows: [BrokerRecallRow]) {
+        switch format {
+        case .json:
+            printJSON([
+                "query": query,
+                "totalTokens": totalTokens,
+                "count": rows.count,
+                "items": rows.map { row in
                     [
-                        "rank": index + 1,
-                        "kind": "\(item.kind)",
-                        "frameId": item.frameId,
-                        "score": Double(item.score),
-                        "text": item.text,
-                    ]
-                }
-                printJSON([
-                    "query": context.query,
-                    "totalTokens": context.totalTokens,
-                    "count": items.count,
-                    "items": items,
-                ])
-            case .text:
-                print("Query: \(context.query)")
-                print("Total tokens: \(context.totalTokens)")
-                for (index, item) in selected.enumerated() {
-                    print(
-                        "\(index + 1). [\(item.kind)] frame=\(item.frameId) score=\(String(format: "%.4f", item.score)) \(item.text)"
-                    )
-                }
+                        "rank": row.rank,
+                        "kind": row.kind ?? "",
+                        "frameId": row.frameId,
+                        "score": row.score,
+                        "text": row.text,
+                    ] as [String: Any]
+                },
+            ])
+        case .text:
+            print("Query: \(query)")
+            print("Total tokens: \(totalTokens)")
+            for row in rows {
+                print(
+                    "\(row.rank). [\(row.kind ?? "unknown")] frame=\(row.frameId) score=\(String(format: "%.4f", row.score)) \(row.text)"
+                )
             }
         }
     }

--- a/Sources/WaxCLI/RememberCommand.swift
+++ b/Sources/WaxCLI/RememberCommand.swift
@@ -42,33 +42,19 @@ struct RememberCommand: AsyncParsableCommand {
         }
 
         if AgentBrokerPolicy.shouldUseBroker(store: store) {
-            let response = try await AgentBrokerCLI.perform(
-                command: "remember",
-                arguments: [
-                    "content": .string(trimmed),
-                    "metadata": .object(meta.mapValues(AgentBrokerValue.string)),
-                ],
+            let configuration = try AgentBrokerCLI.configuration(
                 storePath: store.storePath,
                 embedderChoice: store.embedder.rawValue,
                 noEmbedder: store.noEmbedder,
                 requireVector: store.requireVector,
                 embedderTuning: store.embedderTuning
             )
-            let payload = try brokerPayloadObject(response)
-            let frameCount = brokerInt(payload, "frameCount") ?? 0
-            let pendingFrames = brokerInt(payload, "pendingFrames") ?? 0
-            let framesAdded = brokerInt(payload, "framesAdded") ?? 0
-            switch store.format {
-            case .json:
-                printJSON([
-                    "status": "ok",
-                    "framesAdded": framesAdded,
-                    "frameCount": frameCount,
-                    "pendingFrames": pendingFrames,
-                ])
-            case .text:
-                print("Remembered. \(framesAdded) frame(s) added (\(frameCount) total, \(pendingFrames) pending).")
-            }
+            let result = try await AgentBrokerClient.performRemember(
+                content: trimmed,
+                metadata: meta,
+                configuration: configuration
+            )
+            render(format: store.format, result: result)
             return
         }
 
@@ -93,17 +79,28 @@ struct RememberCommand: AsyncParsableCommand {
             let totalAfter = after.frameCount + after.pendingFrames
             let added = totalAfter >= totalBefore ? (totalAfter - totalBefore) : 0
 
-            switch store.format {
-            case .json:
-                printJSON([
-                    "status": "ok",
-                    "framesAdded": added,
-                    "frameCount": after.frameCount,
-                    "pendingFrames": after.pendingFrames,
-                ])
-            case .text:
-                print("Remembered. \(added) frame(s) added (\(after.frameCount) total, \(after.pendingFrames) pending).")
-            }
+            render(
+                format: store.format,
+                result: BrokerRememberResult(
+                    framesAdded: Int(added),
+                    frameCount: Int(after.frameCount),
+                    pendingFrames: Int(after.pendingFrames)
+                )
+            )
+        }
+    }
+
+    private func render(format: OutputFormat, result: BrokerRememberResult) {
+        switch format {
+        case .json:
+            printJSON([
+                "status": "ok",
+                "framesAdded": result.framesAdded,
+                "frameCount": result.frameCount,
+                "pendingFrames": result.pendingFrames,
+            ])
+        case .text:
+            print("Remembered. \(result.framesAdded) frame(s) added (\(result.frameCount) total, \(result.pendingFrames) pending).")
         }
     }
 }

--- a/Sources/WaxCLI/SearchCommand.swift
+++ b/Sources/WaxCLI/SearchCommand.swift
@@ -42,51 +42,20 @@ struct SearchCommand: AsyncParsableCommand {
         }
 
         if AgentBrokerPolicy.shouldUseBroker(store: store) {
-            let response = try await AgentBrokerCLI.perform(
-                command: "search",
-                arguments: [
-                    "query": .string(query),
-                    "mode": .string(modeLower),
-                    "topK": .from(topK),
-                ],
+            let configuration = try AgentBrokerCLI.configuration(
                 storePath: store.storePath,
                 embedderChoice: store.embedder.rawValue,
                 noEmbedder: store.noEmbedder,
                 requireVector: requireVector,
                 embedderTuning: store.embedderTuning
             )
-            let payload = try brokerPayloadObject(response)
-            let items = brokerArray(payload, "results")
-            let count = items.count
-
-            switch store.format {
-            case .json:
-                let encodedItems: [[String: Any]] = items.compactMap { item in
-                    guard let object = item.objectValue else { return nil }
-                    return [
-                        "rank": brokerInt(object, "rank") ?? 0,
-                        "frameId": brokerInt64(object, "frameId") ?? 0,
-                        "score": object["score"]?.doubleValue ?? 0,
-                        "sources": brokerArray(object, "sources").compactMap(\.stringValue),
-                        "preview": brokerString(object, "preview") ?? "",
-                    ]
-                }
-                printJSON([
-                    "count": count,
-                    "items": encodedItems,
-                ])
-            case .text:
-                if items.isEmpty {
-                    print("No results.")
-                } else {
-                    for item in items {
-                        guard let object = item.objectValue else { continue }
-                        print(
-                            "\(brokerInt(object, "rank") ?? 0). frame=\(brokerInt64(object, "frameId") ?? 0) score=\(String(format: "%.4f", object["score"]?.doubleValue ?? 0)) sources=[\(brokerArray(object, "sources").compactMap(\.stringValue).joined(separator: ","))] \(brokerString(object, "preview") ?? "")"
-                        )
-                    }
-                }
-            }
+            let result = try await AgentBrokerClient.performSearch(
+                query: query,
+                mode: modeLower,
+                topK: topK,
+                configuration: configuration
+            )
+            render(format: store.format, rows: result.items)
             return
         }
 
@@ -99,33 +68,42 @@ struct SearchCommand: AsyncParsableCommand {
             requireVector: requireVector
         ) { memory in
             let hits = try await memory.search(query: query, mode: searchMode, topK: topK, frameFilter: nil)
+            let rows = hits.enumerated().map { index, hit in
+                BrokerSearchRow(
+                    rank: index + 1,
+                    frameId: hit.frameId,
+                    score: Double(hit.score),
+                    sources: hit.sources.map(\.rawValue),
+                    preview: hit.previewText ?? ""
+                )
+            }
+            render(format: store.format, rows: rows)
+        }
+    }
 
-            switch store.format {
-            case .json:
-                let items: [[String: Any]] = hits.enumerated().map { index, hit in
+    private func render(format: OutputFormat, rows: [BrokerSearchRow]) {
+        switch format {
+        case .json:
+            printJSON([
+                "count": rows.count,
+                "items": rows.map { row in
                     [
-                        "rank": index + 1,
-                        "frameId": hit.frameId,
-                        "score": Double(hit.score),
-                        "sources": hit.sources.map { $0.rawValue },
-                        "preview": hit.previewText ?? "",
-                    ]
-                }
-                printJSON([
-                    "count": items.count,
-                    "items": items,
-                ])
-            case .text:
-                if hits.isEmpty {
-                    print("No results.")
-                } else {
-                    for (index, hit) in hits.enumerated() {
-                        let sources = hit.sources.map { $0.rawValue }.joined(separator: ",")
-                        let preview = hit.previewText ?? ""
-                        print(
-                            "\(index + 1). frame=\(hit.frameId) score=\(String(format: "%.4f", hit.score)) sources=[\(sources)] \(preview)"
-                        )
-                    }
+                        "rank": row.rank,
+                        "frameId": row.frameId,
+                        "score": row.score,
+                        "sources": row.sources,
+                        "preview": row.preview,
+                    ] as [String: Any]
+                },
+            ])
+        case .text:
+            if rows.isEmpty {
+                print("No results.")
+            } else {
+                for row in rows {
+                    print(
+                        "\(row.rank). frame=\(row.frameId) score=\(String(format: "%.4f", row.score)) sources=[\(row.sources.joined(separator: ","))] \(row.preview)"
+                    )
                 }
             }
         }

--- a/Sources/WaxCLI/StatsCommand.swift
+++ b/Sources/WaxCLI/StatsCommand.swift
@@ -12,29 +12,19 @@ struct StatsCommand: AsyncParsableCommand {
 
     func runAsync() async throws {
         if AgentBrokerPolicy.shouldUseBroker(store: store) {
-            let response = try await AgentBrokerCLI.perform(
-                command: "stats",
-                arguments: [:],
+            let configuration = try AgentBrokerCLI.configuration(
                 storePath: store.storePath,
                 embedderChoice: store.embedder.rawValue,
                 noEmbedder: store.noEmbedder,
                 requireVector: store.requireVector,
                 embedderTuning: store.embedderTuning
             )
-            let payload = try brokerPayloadObject(response)
+            let response = try await AgentBrokerClient.performStats(configuration: configuration)
             switch store.format {
             case .json:
-                printJSON(payload.toJSONObject())
+                printJSON(response.payload.toJSONObject())
             case .text:
-                print("Store: \(brokerString(payload, "storePath") ?? store.storePath)")
-                print("Frames: \(brokerInt(payload, "frameCount") ?? 0) (\(brokerInt(payload, "pendingFrames") ?? 0) pending)")
-                print("Generation: \(brokerInt(payload, "generation") ?? 0)")
-                let diskBytes = Int64(brokerInt64(payload, "diskBytes") ?? 0)
-                print("Disk: \(ByteCountFormatter.string(fromByteCount: diskBytes, countStyle: .file))")
-                print("Vector search: \((brokerBool(payload, "vectorSearchEnabled") ?? false) ? "enabled" : "disabled")")
-                if let status = brokerString(payload, "embeddingStatus") {
-                    print("Embedding status: \(status)")
-                }
+                renderBrokerSummary(response.summary, fallbackStorePath: store.storePath)
             }
             return
         }
@@ -118,6 +108,16 @@ struct StatsCommand: AsyncParsableCommand {
                 }
                 print("WAL: \(stats.wal.pendingBytes) bytes pending, seq \(stats.wal.committedSeq)-\(stats.wal.lastSeq)")
             }
+        }
+    }
+    private func renderBrokerSummary(_ summary: BrokerStatsSummary, fallbackStorePath: String) {
+        print("Store: \(summary.storePath ?? fallbackStorePath)")
+        print("Frames: \(summary.frameCount) (\(summary.pendingFrames) pending)")
+        print("Generation: \(summary.generation)")
+        print("Disk: \(ByteCountFormatter.string(fromByteCount: summary.diskBytes, countStyle: .file))")
+        print("Vector search: \(summary.vectorSearchEnabled ? "enabled" : "disabled")")
+        if let status = summary.embeddingStatus {
+            print("Embedding status: \(status)")
         }
     }
 }

--- a/Tests/WaxTests/BrokerClientResultsDecodeTests.swift
+++ b/Tests/WaxTests/BrokerClientResultsDecodeTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+import Wax
+
+@Suite struct BrokerClientResultsDecodeTests {
+    private func recallRowPayload(
+        rank: AgentBrokerValue = .from(1),
+        kind: AgentBrokerValue? = .string("snippet"),
+        frameId: AgentBrokerValue = .from(UInt64(42)),
+        score: AgentBrokerValue = .double(0.5),
+        text: AgentBrokerValue = .string("hello world")
+    ) -> [String: AgentBrokerValue] {
+        var payload: [String: AgentBrokerValue] = [
+            "rank": rank,
+            "frameId": frameId,
+            "score": score,
+            "text": text,
+        ]
+        if let kind {
+            payload["kind"] = kind
+        }
+        return payload
+    }
+
+    @Test func recallRowDecodesAllFields() throws {
+        let row = try BrokerRecallRow(recallRowPayload())
+        #expect(row.rank == 1)
+        #expect(row.kind == "snippet")
+        #expect(row.frameId == 42)
+        #expect(row.score == 0.5)
+        #expect(row.text == "hello world")
+    }
+
+    @Test func recallRowMissingKeyThrowsNamedError() throws {
+        var payload = recallRowPayload()
+        payload["text"] = nil
+
+        #expect(throws: BrokerPayloadDecodeError(reason: .missingKey("text"))) {
+            try BrokerRecallRow(payload)
+        }
+    }
+
+    @Test func recallRowMissingKindDecodesAsNilKind() throws {
+        let row = try BrokerRecallRow(recallRowPayload(kind: nil))
+        #expect(row.kind == nil)
+    }
+
+    @Test func recallRowWrongTypedScoreThrowsNamedError() throws {
+        let payload = recallRowPayload(score: .string("fast"))
+
+        #expect(throws: BrokerPayloadDecodeError(reason: .invalidValue(key: "score", expected: "a number"))) {
+            try BrokerRecallRow(payload)
+        }
+    }
+
+    @Test func recallResultDecodesEnvelopeAndRows() throws {
+        let payload: [String: AgentBrokerValue] = [
+            "query": .string("rollback steps"),
+            "total_tokens": .from(6),
+            "results": .array([
+                .object(recallRowPayload()),
+                .object(recallRowPayload(rank: .from(2), frameId: .from(UInt64(7)), text: .string("second"))),
+            ]),
+        ]
+
+        let result = try BrokerRecallResult(payload)
+        #expect(result.query == "rollback steps")
+        #expect(result.totalTokens == 6)
+        #expect(result.items.count == 2)
+        #expect(result.items[1].rank == 2)
+        #expect(result.items[1].text == "second")
+    }
+
+    @Test func searchRowDecodesSourcesAndPreview() throws {
+        let payload: [String: AgentBrokerValue] = [
+            "rank": .from(3),
+            "frameId": .from(UInt64(9)),
+            "score": .double(1.25),
+            "sources": .array([.string("text"), .string("vector")]),
+            "preview": .string("preview text"),
+        ]
+
+        let row = try BrokerSearchRow(payload)
+        #expect(row.rank == 3)
+        #expect(row.frameId == 9)
+        #expect(row.score == 1.25)
+        #expect(row.sources == ["text", "vector"])
+        #expect(row.preview == "preview text")
+    }
+
+    @Test func searchRowMissingSourcesThrowsNamedError() throws {
+        let payload: [String: AgentBrokerValue] = [
+            "rank": .from(1),
+            "frameId": .from(UInt64(9)),
+            "score": .double(1.0),
+            "preview": .string("preview"),
+        ]
+
+        #expect(throws: BrokerPayloadDecodeError(reason: .missingKey("sources"))) {
+            try BrokerSearchRow(payload)
+        }
+    }
+
+    @Test func searchResultDecodesResultsArray() throws {
+        let payload: [String: AgentBrokerValue] = [
+            "results": .array([
+                .object([
+                    "rank": .from(1),
+                    "frameId": .from(UInt64(4)),
+                    "score": .double(0.75),
+                    "sources": .array([.string("timeline")]),
+                    "preview": .string("p"),
+                ]),
+            ]),
+        ]
+
+        let result = try BrokerSearchResult(payload)
+        #expect(result.items.map(\.preview) == ["p"])
+    }
+
+    @Test func rememberResultDecodesCounts() throws {
+        let payload: [String: AgentBrokerValue] = [
+            "status": .string("ok"),
+            "framesAdded": .from(2),
+            "frameCount": .from(11),
+            "pendingFrames": .from(0),
+        ]
+
+        let result = try BrokerRememberResult(payload)
+        #expect(result.framesAdded == 2)
+        #expect(result.frameCount == 11)
+        #expect(result.pendingFrames == 0)
+    }
+
+    @Test func statsSummaryDecodesFieldsAndToleratesAbsentOptionals() throws {
+        let payload: [String: AgentBrokerValue] = [
+            "storePath": .string("/tmp/memory.wax"),
+            "frameCount": .from(3),
+            "pendingFrames": .from(1),
+            "generation": .from(5),
+            "diskBytes": .from(Int64(268_852_990)),
+            "vectorSearchEnabled": .bool(false),
+        ]
+
+        let summary = try BrokerStatsSummary(payload)
+        #expect(summary.storePath == "/tmp/memory.wax")
+        #expect(summary.frameCount == 3)
+        #expect(summary.pendingFrames == 1)
+        #expect(summary.generation == 5)
+        #expect(summary.diskBytes == 268_852_990)
+        #expect(summary.vectorSearchEnabled == false)
+        #expect(summary.embeddingStatus == nil)
+    }
+
+    @Test func statsSummaryMissingFrameCountThrowsNamedError() throws {
+        let payload: [String: AgentBrokerValue] = [
+            "storePath": .string("/tmp/memory.wax"),
+            "pendingFrames": .from(1),
+            "generation": .from(5),
+            "diskBytes": .from(Int64(10)),
+            "vectorSearchEnabled": .bool(false),
+        ]
+
+        #expect(throws: BrokerPayloadDecodeError(reason: .missingKey("frameCount"))) {
+            try BrokerStatsSummary(payload)
+        }
+    }
+}

--- a/Tests/WaxTests/BrokerClientResultsDecodeTests.swift
+++ b/Tests/WaxTests/BrokerClientResultsDecodeTests.swift
@@ -45,6 +45,19 @@ import Wax
         #expect(row.kind == nil)
     }
 
+    @Test func recallRowNullKindDecodesAsNilKind() throws {
+        let row = try BrokerRecallRow(recallRowPayload(kind: .null))
+        #expect(row.kind == nil)
+    }
+
+    @Test func recallRowNonStringKindThrowsNamedError() {
+        let payload = recallRowPayload(kind: .from(7))
+
+        #expect(throws: BrokerPayloadDecodeError(reason: .invalidValue(key: "kind", expected: "a string"))) {
+            try BrokerRecallRow(payload)
+        }
+    }
+
     @Test func recallRowWrongTypedScoreThrowsNamedError() throws {
         let payload = recallRowPayload(score: .string("fast"))
 


### PR DESCRIPTION
Spec: spec/spec-architecture-type-system-hardening.md (ticket T3)

## What
Broker responses for gated CLI commands are decoded into typed package structs (`BrokerRecallRow/Result`, `BrokerSearchRow/Result`, `BrokerRememberResult`, `BrokerStatsSummary/Response` + named `BrokerPayloadDecodeError`) with typed `AgentBrokerClient.performRecall/Search/Remember/Stats`. RecallCommand, SearchCommand, RememberCommand collapse to ONE renderer each shared by broker and direct paths; StatsCommand's human path is typed while JSON stays raw passthrough (the two paths emit different JSON today - byte parity forbids unifying).

## Compiler gain
Payload-key typos move from silent runtime nils to compile-checked field access plus thrown named decode errors at one parse site. AC-303: zero stringly `broker*` helper callers remain inside gated commands.

## Compatibility
CLI output byte-identical across 68 pre-implementer scenarios plus 17 reviewer-verified pairs (stdout/stderr/exit codes, only tmp store-root masked). Wire requests unchanged.

## Review fixes
review(t3): 70d719813 pins kind null-tolerance and wrong-type decoder contract tests.

Review skills used: swift-pr-review x2 (fresh-context fix-allowed + independent final pass, both MERGEABLE).
