### PR TITLE
fix(mcp-http): close NIO child channels after HTTP response

### DIFF
--- a/Sources/WaxMCPServer/HTTPApp.swift
+++ b/Sources/WaxMCPServer/HTTPApp.swift
@@ -526,6 +526,9 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         requestState = nil
+        if channelContext === context {
+            channelContext = nil
+        }
         closeIfActive(context)
     }
 
@@ -593,8 +596,7 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             body.writeBytes(bodyData)
             context.write(wrapOutboundOut(.body(.byteBuffer(body))), promise: nil)
         }
-        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
-        closeIfActive(context)
+        flushEndThenClose(context)
     }
 
     private func completeRequest(
@@ -709,8 +711,7 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func writeEnd() {
         guard let context = activeContext() else { return }
-        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
-        closeIfActive(context)
+        flushEndThenClose(context)
     }
 
     private func writeCompleteResponse(
@@ -730,8 +731,7 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             buffer.writeBytes(body)
             context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
         }
-        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
-        closeIfActive(context)
+        flushEndThenClose(context)
     }
 
     private func activeContext() -> ChannelHandlerContext? {
@@ -747,6 +747,13 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     private func closeIfActive(_ context: ChannelHandlerContext) {
         guard context.channel.isActive else { return }
         context.close(promise: nil)
+    }
+
+    private func flushEndThenClose(_ context: ChannelHandlerContext) {
+        context.writeAndFlush(wrapOutboundOut(.end(nil))).whenComplete { _ in
+            guard context.channel.isActive else { return }
+            context.close(promise: nil)
+        }
     }
 }
 #endif

--- a/Sources/WaxMCPServer/HTTPApp.swift
+++ b/Sources/WaxMCPServer/HTTPApp.swift
@@ -78,6 +78,10 @@ actor MCPHTTPApplication {
 
     var endpoint: String { configuration.endpoint }
 
+    func boundPort() -> Int? {
+        channel?.localAddress?.port
+    }
+
     func start() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
@@ -509,6 +513,20 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         if channelContext === context {
             channelContext = nil
         }
+        requestState = nil
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        requestState = nil
+        if channelContext === context {
+            channelContext = nil
+        }
+        context.fireChannelInactive()
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        requestState = nil
+        closeIfActive(context)
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -576,6 +594,7 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             context.write(wrapOutboundOut(.body(.byteBuffer(body))), promise: nil)
         }
         context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        closeIfActive(context)
     }
 
     private func completeRequest(
@@ -639,7 +658,10 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
                     }
                 }
             } catch {
-                // Let the connection drain naturally.
+                await hop(eventLoop) {
+                    self.closeActiveChannel()
+                }
+                return
             }
 
             await hop(eventLoop) {
@@ -669,7 +691,7 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private func writeHeadAndFlush(statusCode: Int, headers: [String: String], version: HTTPVersion) {
-        guard let context = channelContext else { return }
+        guard let context = activeContext() else { return }
         var head = HTTPResponseHead(version: version, status: HTTPResponseStatus(statusCode: statusCode))
         for (name, value) in headers {
             head.headers.add(name: name, value: value)
@@ -679,15 +701,16 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private func writeBodyChunk(_ chunk: Data) {
-        guard let context = channelContext else { return }
+        guard let context = activeContext() else { return }
         var buffer = context.channel.allocator.buffer(capacity: chunk.count)
         buffer.writeBytes(chunk)
         context.writeAndFlush(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
     }
 
     private func writeEnd() {
-        guard let context = channelContext else { return }
+        guard let context = activeContext() else { return }
         context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        closeIfActive(context)
     }
 
     private func writeCompleteResponse(
@@ -696,7 +719,7 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         version: HTTPVersion,
         bodyData: Data?
     ) {
-        guard let context = channelContext else { return }
+        guard let context = activeContext() else { return }
         var head = HTTPResponseHead(version: version, status: HTTPResponseStatus(statusCode: statusCode))
         for (name, value) in headers {
             head.headers.add(name: name, value: value)
@@ -708,6 +731,22 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
         }
         context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        closeIfActive(context)
+    }
+
+    private func activeContext() -> ChannelHandlerContext? {
+        guard let context = channelContext, context.channel.isActive else { return nil }
+        return context
+    }
+
+    private func closeActiveChannel() {
+        guard let context = activeContext() else { return }
+        closeIfActive(context)
+    }
+
+    private func closeIfActive(_ context: ChannelHandlerContext) {
+        guard context.channel.isActive else { return }
+        context.close(promise: nil)
     }
 }
 #endif

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -8,6 +8,7 @@ import Glibc
 
 #if MCPServer
 import MCP
+import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 @testable import wax_mcp
@@ -1505,7 +1506,7 @@ func httpHandlerRejectsOversizedContentLengthBeforeReadingBody() async throws {
     try expectImmediatePayloadTooLargeResponse(on: channel)
     let trailingResponsePart = try channel.readOutbound(as: HTTPServerResponsePart.self)
     #expect(trailingResponsePart == nil)
-    _ = try channel.finish()
+    _ = try channel.finish(acceptAlreadyClosed: true)
 }
 
 @Test
@@ -1529,7 +1530,76 @@ func httpHandlerReturns404AfterRequestEndForUnknownPath() async throws {
         return
     }
     #expect(response.status == HTTPResponseStatus(statusCode: 404))
-    _ = try await channel.finish()
+    _ = try await channel.finish(acceptAlreadyClosed: true)
+}
+
+private final class HTTPChildChannelCloseProbe: ChannelOutboundHandler, @unchecked Sendable {
+    typealias OutboundIn = HTTPServerResponsePart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private let lock = NSLock()
+    private var closed = false
+
+    var didClose: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return closed
+    }
+
+    func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
+        lock.lock()
+        closed = true
+        lock.unlock()
+        context.close(mode: mode, promise: promise)
+    }
+}
+
+@Test
+func httpHandlerClosesChannelAfterCompletedResponse() async throws {
+    let app = MCPHTTPApplication(
+        configuration: .init(maxRequestBodyBytes: 1_048),
+        serverFactory: { _, _ in
+            Issue.record("unknown path should not reach MCP server creation")
+            throw MCP.MCPError.invalidRequest("unexpected server creation")
+        }
+    )
+    let probe = HTTPChildChannelCloseProbe()
+    let channel = await NIOAsyncTestingChannel(handlers: [probe, HTTPHandler(app: app)])
+    try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 1)).get()
+    let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/not-mcp")
+
+    try await channel.writeInbound(HTTPServerRequestPart.head(head))
+    try await channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let responseHeadPart = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+    guard case .head(let response) = responseHeadPart else {
+        Issue.record("expected response head, got \(responseHeadPart)")
+        return
+    }
+    #expect(response.status == HTTPResponseStatus(statusCode: 404))
+    try await Task.sleep(for: .milliseconds(100))
+    await channel.testingEventLoop.run()
+    #expect(probe.didClose, "child channel must close after the HTTP response ends")
+    _ = try await channel.finish(acceptAlreadyClosed: true)
+}
+
+@Test
+func httpHandlerTearsDownOnChannelInactive() async throws {
+    let app = MCPHTTPApplication(
+        configuration: .init(maxRequestBodyBytes: 1_048),
+        serverFactory: { _, _ in
+            Issue.record("inactive teardown should not reach MCP server creation")
+            throw MCP.MCPError.invalidRequest("unexpected server creation")
+        }
+    )
+    let channel = await NIOAsyncTestingChannel(handler: HTTPHandler(app: app))
+    try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 1)).get()
+    let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+
+    try await channel.writeInbound(HTTPServerRequestPart.head(head))
+    try await channel.close().get()
+    try await channel.throwIfErrorCaught()
+    _ = try await channel.finish(acceptAlreadyClosed: true)
 }
 
 @Test
@@ -1551,7 +1621,7 @@ func httpHandlerRejectsStreamingOverflowBeforeRequestEnd() async throws {
     try expectImmediatePayloadTooLargeResponse(on: channel)
     let trailingResponsePart = try channel.readOutbound(as: HTTPServerResponsePart.self)
     #expect(trailingResponsePart == nil)
-    _ = try channel.finish()
+    _ = try channel.finish(acceptAlreadyClosed: true)
 }
 
 private func expectImmediatePayloadTooLargeResponse(on channel: EmbeddedChannel) throws {
@@ -1754,6 +1824,141 @@ func httpSessionCleanupTaskStopsWithApplicationStop() async throws {
     await app.stop()
     try await startTask.value
     #expect(!(await app.hasActiveSessionCleanupTask()))
+}
+
+@Test
+func httpApplicationSurvivesOneHundredSequentialRequests() async throws {
+    let app = MCPHTTPApplication(
+        configuration: .init(host: "127.0.0.1", port: 0, endpoint: "/mcp"),
+        serverFactory: { _, _ in
+            Issue.record("missing session header should not create an MCP server")
+            throw MCP.MCPError.invalidRequest("unexpected server creation")
+        }
+    )
+    let startTask = Task { try await app.start() }
+    var port: Int?
+    for _ in 0..<200 {
+        if let bound = await app.boundPort(), bound > 0 {
+            port = bound
+            break
+        }
+        try await Task.sleep(for: .milliseconds(5))
+    }
+    let boundPort = try #require(port)
+    #expect(boundPort != 3000)
+
+    do {
+        let body = Data("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}".utf8)
+        for _ in 0..<100 {
+            let status = try postMCPOverTCP(
+                host: "127.0.0.1",
+                port: boundPort,
+                path: "/mcp",
+                body: body
+            )
+            #expect(status == 400)
+        }
+    } catch {
+        await app.stop()
+        _ = try? await startTask.value
+        throw error
+    }
+
+    await app.stop()
+    try await startTask.value
+}
+
+private enum POSIXHTTPClientError: Error {
+    case socket
+    case connect
+    case write
+    case read
+    case invalidStatus
+}
+
+/// Raw TCP POST. URLSession.shared.data hangs against this close-after-response
+/// server (NSURLConnectionLoader ignores timeoutInterval).
+private func postMCPOverTCP(host: String, port: Int, path: String, body: Data) throws -> Int {
+    let fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+    guard fd >= 0 else { throw POSIXHTTPClientError.socket }
+    defer {
+        #if canImport(Darwin)
+        _ = Darwin.close(fd)
+        #else
+        _ = Glibc.close(fd)
+        #endif
+    }
+
+    #if canImport(Darwin)
+    var noSigPipe = 1
+    _ = setsockopt(
+        fd,
+        SOL_SOCKET,
+        SO_NOSIGPIPE,
+        &noSigPipe,
+        socklen_t(MemoryLayout.size(ofValue: noSigPipe))
+    )
+    #endif
+
+    var timeout = timeval(tv_sec: 3, tv_usec: 0)
+    _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+    _ = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+    var addr = sockaddr_in()
+    #if canImport(Darwin)
+    addr.sin_len = __uint8_t(MemoryLayout<sockaddr_in>.size)
+    #endif
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_port = in_port_t(UInt16(port).bigEndian)
+    let parsed = host.withCString { inet_pton(AF_INET, $0, &addr.sin_addr) }
+    guard parsed == 1 else { throw POSIXHTTPClientError.connect }
+
+    let connected: Int32 = withUnsafePointer(to: &addr) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+    guard connected == 0 else { throw POSIXHTTPClientError.connect }
+
+    var request = Data()
+    request.append(contentsOf: Array("POST \(path) HTTP/1.1\r\n".utf8))
+    request.append(contentsOf: Array("Host: \(host):\(port)\r\n".utf8))
+    request.append(contentsOf: Array("Content-Type: application/json\r\n".utf8))
+    request.append(contentsOf: Array("Content-Length: \(body.count)\r\n".utf8))
+    request.append(contentsOf: Array("Connection: close\r\n\r\n".utf8))
+    request.append(body)
+
+    try request.withUnsafeBytes { rawBuffer in
+        guard let base = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+            throw POSIXHTTPClientError.write
+        }
+        var sent = 0
+        while sent < rawBuffer.count {
+            let n = send(fd, base + sent, rawBuffer.count - sent, 0)
+            guard n > 0 else { throw POSIXHTTPClientError.write }
+            sent += n
+        }
+    }
+
+    var collected = Data()
+    var chunk = [UInt8](repeating: 0, count: 1024)
+    while collected.count < 4096 {
+        let n = recv(fd, &chunk, chunk.count, 0)
+        if n == 0 { break }
+        guard n > 0 else { throw POSIXHTTPClientError.read }
+        collected.append(contentsOf: chunk[0..<n])
+        guard let lineEnd = collected.range(of: Data("\r\n".utf8)) else { continue }
+        let line = collected.subdata(in: collected.startIndex..<lineEnd.lowerBound)
+        guard let text = String(data: line, encoding: .utf8) else {
+            throw POSIXHTTPClientError.invalidStatus
+        }
+        let parts = text.split(separator: " ")
+        guard parts.count >= 2, let status = Int(parts[1]) else {
+            throw POSIXHTTPClientError.invalidStatus
+        }
+        return status
+    }
+    throw POSIXHTTPClientError.invalidStatus
 }
 
 @Test

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -1539,6 +1539,8 @@ private final class HTTPChildChannelCloseProbe: ChannelOutboundHandler, @uncheck
 
     private let lock = NSLock()
     private var closed = false
+    private var holdEndWrites = false
+    private var heldEnd: (context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?)?
 
     var didClose: Bool {
         lock.lock()
@@ -1546,11 +1548,52 @@ private final class HTTPChildChannelCloseProbe: ChannelOutboundHandler, @uncheck
         return closed
     }
 
+    func holdEndUntilReleased() {
+        lock.lock()
+        holdEndWrites = true
+        lock.unlock()
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let part = unwrapOutboundIn(data)
+        if case .end = part {
+            lock.lock()
+            let shouldHold = holdEndWrites && heldEnd == nil
+            if shouldHold {
+                heldEnd = (context, data, promise)
+                lock.unlock()
+                return
+            }
+            lock.unlock()
+        }
+        context.write(data, promise: promise)
+    }
+
+    func releaseHeldEnd() {
+        lock.lock()
+        let held = heldEnd
+        heldEnd = nil
+        holdEndWrites = false
+        lock.unlock()
+        guard let held else { return }
+        held.context.write(held.data, promise: held.promise)
+        held.context.flush()
+    }
+
     func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
         lock.lock()
         closed = true
         lock.unlock()
         context.close(mode: mode, promise: promise)
+    }
+
+    func pollDidClose(on loop: NIOAsyncTestingEventLoop, iterations: Int = 10) async -> Bool {
+        if didClose { return true }
+        for _ in 0..<iterations {
+            await loop.run()
+            if didClose { return true }
+        }
+        return didClose
     }
 }
 
@@ -1577,9 +1620,71 @@ func httpHandlerClosesChannelAfterCompletedResponse() async throws {
         return
     }
     #expect(response.status == HTTPResponseStatus(statusCode: 404))
-    try await Task.sleep(for: .milliseconds(100))
+    let nextPart = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+    if case .body = nextPart {
+        let endPart = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+        guard case .end = endPart else {
+            Issue.record("expected response end after body, got \(endPart)")
+            return
+        }
+    } else {
+        guard case .end = nextPart else {
+            Issue.record("expected response end, got \(nextPart)")
+            return
+        }
+    }
+    #expect(
+        await probe.pollDidClose(on: channel.testingEventLoop),
+        "child channel must close after the HTTP response ends"
+    )
+    _ = try await channel.finish(acceptAlreadyClosed: true)
+}
+
+@Test
+func httpHandlerClosesChannelOnlyAfterEndFlushCompletes() async throws {
+    let app = MCPHTTPApplication(
+        configuration: .init(maxRequestBodyBytes: 1_048),
+        serverFactory: { _, _ in
+            Issue.record("unknown path should not reach MCP server creation")
+            throw MCP.MCPError.invalidRequest("unexpected server creation")
+        }
+    )
+    let probe = HTTPChildChannelCloseProbe()
+    probe.holdEndUntilReleased()
+    let channel = await NIOAsyncTestingChannel(handlers: [probe, HTTPHandler(app: app)])
+    try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 1)).get()
+    let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/not-mcp")
+
+    try await channel.writeInbound(HTTPServerRequestPart.head(head))
+    try await channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let responseHeadPart = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+    guard case .head(let response) = responseHeadPart else {
+        Issue.record("expected response head, got \(responseHeadPart)")
+        return
+    }
+    #expect(response.status == HTTPResponseStatus(statusCode: 404))
+    if let maybeBody = try await channel.readOutbound(as: HTTPServerResponsePart.self) {
+        guard case .body = maybeBody else {
+            Issue.record("expected optional body before held .end, got \(maybeBody)")
+            return
+        }
+    }
     await channel.testingEventLoop.run()
-    #expect(probe.didClose, "child channel must close after the HTTP response ends")
+    #expect(!probe.didClose, "close must wait until writeAndFlush(.end) completes")
+
+    try await channel.testingEventLoop.executeInContext {
+        probe.releaseHeldEnd()
+    }
+    let endPart = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+    guard case .end = endPart else {
+        Issue.record("expected response end after releasing held write, got \(endPart)")
+        return
+    }
+    #expect(
+        await probe.pollDidClose(on: channel.testingEventLoop),
+        "child channel must close after the HTTP .end flush completes"
+    )
     _ = try await channel.finish(acceptAlreadyClosed: true)
 }
 
@@ -1597,8 +1702,38 @@ func httpHandlerTearsDownOnChannelInactive() async throws {
     let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
 
     try await channel.writeInbound(HTTPServerRequestPart.head(head))
+    let outboundBeforeClose = try await channel.readOutbound(as: HTTPServerResponsePart.self)
+    #expect(outboundBeforeClose == nil)
     try await channel.close().get()
     try await channel.throwIfErrorCaught()
+    let outboundAfterClose = try await channel.readOutbound(as: HTTPServerResponsePart.self)
+    #expect(outboundAfterClose == nil, "inactive teardown must not emit HTTP response parts")
+    try await channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let outboundAfterLateEnd = try await channel.readOutbound(as: HTTPServerResponsePart.self)
+    #expect(outboundAfterLateEnd == nil, "inbound .end after inactive must be ignored")
+    _ = try await channel.finish(acceptAlreadyClosed: true)
+}
+
+@Test
+func httpHandlerTearsDownOnErrorCaught() async throws {
+    enum ProbeError: Error { case boom }
+    let app = MCPHTTPApplication(
+        configuration: .init(maxRequestBodyBytes: 1_048),
+        serverFactory: { _, _ in
+            Issue.record("error teardown should not reach MCP server creation")
+            throw MCP.MCPError.invalidRequest("unexpected server creation")
+        }
+    )
+    let channel = await NIOAsyncTestingChannel(handler: HTTPHandler(app: app))
+    try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 1)).get()
+    let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+
+    try await channel.writeInbound(HTTPServerRequestPart.head(head))
+    channel.pipeline.fireErrorCaught(ProbeError.boom)
+    await channel.testingEventLoop.run()
+    try await channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let outboundAfterError = try await channel.readOutbound(as: HTTPServerResponsePart.self)
+    #expect(outboundAfterError == nil, "errorCaught must drop in-flight request state")
     _ = try await channel.finish(acceptAlreadyClosed: true)
 }
 
@@ -1837,17 +1972,17 @@ func httpApplicationSurvivesOneHundredSequentialRequests() async throws {
     )
     let startTask = Task { try await app.start() }
     var port: Int?
-    for _ in 0..<200 {
-        if let bound = await app.boundPort(), bound > 0 {
-            port = bound
-            break
-        }
-        try await Task.sleep(for: .milliseconds(5))
-    }
-    let boundPort = try #require(port)
-    #expect(boundPort != 3000)
-
     do {
+        for _ in 0..<200 {
+            if let bound = await app.boundPort(), bound > 0 {
+                port = bound
+                break
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let boundPort = try #require(port)
+        #expect(boundPort != 3000)
+
         let body = Data("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}".utf8)
         for _ in 0..<100 {
             let status = try postMCPOverTCP(
@@ -1858,14 +1993,13 @@ func httpApplicationSurvivesOneHundredSequentialRequests() async throws {
             )
             #expect(status == 400)
         }
+        await app.stop()
+        try await startTask.value
     } catch {
         await app.stop()
         _ = try? await startTask.value
         throw error
     }
-
-    await app.stop()
-    try await startTask.value
 }
 
 private enum POSIXHTTPClientError: Error {


### PR DESCRIPTION
## Summary
Fixes WAX-2026-08-25-001 / 008 (HTTP RST / empty reply on :3000).

`HTTPHandler` now tears down child channels after `writeAndFlush(.end)` completes, and on `channelInactive` / `errorCaught`. Close waits for the flush future so NIO does not `failAll` a still-pending `.end` (that path recreated RST on large bodies).

## Test proof (Ishi, 2026-08-27)
```
xcrun swift test --traits MCPServer --filter 'httpHandlerClosesChannelOnlyAfterEndFlushCompletes|httpHandlerClosesChannelAfterCompletedResponse|httpHandlerTearsDownOnChannelInactive|httpHandlerTearsDownOnErrorCaught'
```
4 passed, 0.012s.

Did not bind :3000. Did not restart live pid 73749.

## Notes
- Base: `release/waxmcp-0.1.32` (not `performance`)
- Live RST remains until this binary is rebuilt and the daemon restarted
- Linear tickets not created: no Linear MCP / LINEAR_API_KEY on this machine