### PR TITLE
fix(cli): raise direct-store lock wait to 30s

### DIFF
--- a/Sources/WaxCLI/StoreSession.swift
+++ b/Sources/WaxCLI/StoreSession.swift
@@ -12,7 +12,8 @@ import WaxVectorSearchArctic
 
 enum StoreSession {
     static let defaultStorePath = "~/.wax/memory.wax"
-    private static let defaultLockTimeoutSeconds = 5.0
+    /// CLI `--direct-store` wait. One budget covers preflight plus open.
+    static let defaultLockTimeoutSeconds = 30.0
 
     /// Whether this binary was compiled with MiniLM embedding support.
     static var miniLMCompiled: Bool {
@@ -44,15 +45,10 @@ enum StoreSession {
         return url
     }
 
-    private static var waxOptions: WaxOptions {
-        var options = WaxOptions()
-        options.lockWaitTimeout = lockWaitTimeout
-        return options
-    }
-
-    private static var lockWaitTimeout: Duration? {
-        let env = ProcessInfo.processInfo.environment
-        guard let raw = env["WAX_LOCK_TIMEOUT_SECS"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+    static func lockWaitTimeout(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Duration? {
+        guard let raw = environment["WAX_LOCK_TIMEOUT_SECS"]?.trimmingCharacters(in: .whitespacesAndNewlines),
               !raw.isEmpty
         else {
             return .milliseconds(Int64(defaultLockTimeoutSeconds * 1000))
@@ -62,6 +58,19 @@ enum StoreSession {
         }
         guard secs > 0 else { return nil }
         return .milliseconds(Int64(secs * 1000))
+    }
+
+    /// Subtract elapsed wait from a finite budget so preflight + open share one timeout.
+    static func remainingLockWait(budget: Duration?, elapsed: Duration) -> Duration? {
+        guard let budget else { return nil }
+        if elapsed >= budget { return .zero }
+        return budget - elapsed
+    }
+
+    private static func waxOptions(lockWaitTimeout: Duration?) -> WaxOptions {
+        var options = WaxOptions()
+        options.lockWaitTimeout = lockWaitTimeout
+        return options
     }
 
     /// Open a memory store with an optional embedder.
@@ -79,7 +88,15 @@ enum StoreSession {
         embedderTuning: CommandLineEmbedderRuntimeTuning = .fromEnvironment(),
         requireVector: Bool = false
     ) async throws -> MemoryOrchestrator {
-        try StoreLockProbe.preflightExclusiveAccess(at: url, timeout: waxOptions.lockWaitTimeout)
+        let lockBudget = lockWaitTimeout()
+        let clock = ContinuousClock()
+        let waitStarted = clock.now
+        try StoreLockProbe.preflightExclusiveAccess(at: url, timeout: lockBudget)
+        let remainingWait = remainingLockWait(
+            budget: lockBudget,
+            elapsed: waitStarted.duration(to: clock.now)
+        )
+        let waxOptions = waxOptions(lockWaitTimeout: remainingWait)
         if requireVector, noEmbedder {
             throw CLIError("Vector search required but --no-embedder was set.")
         }

--- a/Tests/WaxCLITests/StoreSessionLockTimeoutTests.swift
+++ b/Tests/WaxCLITests/StoreSessionLockTimeoutTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import wax_cli
+
+struct StoreSessionLockTimeoutTests {
+    @Test func emptyEnvironmentUsesThirtySecondCLILockWait() {
+        let timeout = StoreSession.lockWaitTimeout(environment: [:])
+        #expect(timeout == .milliseconds(30_000))
+    }
+
+    @Test func lockTimeoutEnvOverrideIsHonored() {
+        let timeout = StoreSession.lockWaitTimeout(
+            environment: ["WAX_LOCK_TIMEOUT_SECS": "10"]
+        )
+        #expect(timeout == .milliseconds(10_000))
+    }
+
+    @Test func remainingLockWaitPreservesSingleBudget() {
+        #expect(
+            StoreSession.remainingLockWait(budget: .milliseconds(30_000), elapsed: .zero)
+                == .milliseconds(30_000)
+        )
+        #expect(
+            StoreSession.remainingLockWait(
+                budget: .milliseconds(30_000),
+                elapsed: .milliseconds(12_000)
+            ) == .milliseconds(18_000)
+        )
+        #expect(
+            StoreSession.remainingLockWait(
+                budget: .milliseconds(30_000),
+                elapsed: .milliseconds(40_000)
+            ) == .zero
+        )
+        #expect(
+            StoreSession.remainingLockWait(budget: nil, elapsed: .milliseconds(5_000)) == nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary
WAX-004 / 006 / 007. CLI exclusive lock wait is 30s (was 5s). Preflight and `Wax.open` share one budget. `WAX_LOCK_TIMEOUT_SECS` still overrides. MCP default stays 2s.

## Proof
```
xcrun swift test --filter StoreSessionLockTimeoutTests
```
3 passed (Ishi re-run).