### PR TITLE
fix(broker): treat blank session_id as omitted

### DIFF
--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -718,7 +718,7 @@ extension BrokerCommand.CorpusSearch {
 
 extension BrokerCommand {
     package static func parseOptionalSessionID(_ args: BrokerArguments) throws -> UUID? {
-        guard let raw = try args.optionalString("session_id") else { return nil }
+        guard let raw = normalizedOrNil(try args.optionalString("session_id")) else { return nil }
         guard let value = UUID(uuidString: raw) else {
             throw BrokerValidationError.invalid("session_id must be a valid UUID")
         }

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -83,6 +83,7 @@ enum WaxMCPTools {
             if let oversize = contentLimitError(name: params.name, arguments: forwarded) {
                 return oversize
             }
+            omitBlankSessionIDIfNeeded(arguments: &forwarded)
             injectClientCWDIfNeeded(name: params.name, arguments: &forwarded)
             injectClientSessionIfNeeded(name: params.name, arguments: &forwarded, sessionHint: sessionHint)
             let verbosity = try responseVerbosity(from: forwarded) ?? "compact"
@@ -182,6 +183,13 @@ private extension WaxMCPTools {
             throw ToolValidationError.invalid("verbosity must be one of: compact, verbose")
         }
         return trimmed
+    }
+
+    static func omitBlankSessionIDIfNeeded(arguments: inout [String: Value]) {
+        guard case .string(let raw)? = arguments["session_id"] else { return }
+        if raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            arguments.removeValue(forKey: "session_id")
+        }
     }
 
     static func injectClientCWDIfNeeded(name: String, arguments: inout [String: Value]) {

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -957,6 +957,32 @@ func handleRejectsInvalidSessionIDUUID() async throws {
     }
 }
 
+@Test(arguments: [Optional<String>.none, Optional(""), Optional("   ")])
+func handleTreatsBlankSessionIDAsOmittedUnscopedPath(rawSessionID: String?) async throws {
+    try await withIsolatedBroker { service, _ in
+        let marker = "BLANK_SESSION_ID_UNSCOPED_\(UUID().uuidString)"
+        var rememberArgs: [String: AgentBrokerValue] = ["content": .string(marker)]
+        var searchArgs: [String: AgentBrokerValue] = [
+            "query": .string(marker),
+            "mode": .string("text"),
+            "topK": .int(10),
+        ]
+        if let rawSessionID {
+            rememberArgs["session_id"] = .string(rawSessionID)
+            searchArgs["session_id"] = .string(rawSessionID)
+        }
+
+        let remembered = await service.handle(.init(command: "remember", arguments: rememberArgs))
+        #expect(remembered.ok == true)
+
+        let searched = await service.handle(.init(command: "search", arguments: searchArgs))
+        #expect(searched.ok == true)
+        #expect((searched.error ?? "").contains("session_id must be a valid UUID") == false)
+        let texts = resultTexts(try requireObject(searched.payload))
+        #expect(texts.contains { $0.contains(marker) })
+    }
+}
+
 @Test
 func sessionStartDoesNotImplicitlyScopeUnscopedWrites() async throws {
     try await withIsolatedBroker { service, _ in

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -3544,6 +3544,22 @@ func invalidSessionIDIsRejected() async throws {
     }
 }
 
+@Test(arguments: [Optional<String>.none, Optional(""), Optional("   ")])
+func blankSessionIDIsTreatedAsOmittedOnMCPSearch(rawSessionID: String?) async throws {
+    try await withAgentBrokerService { service, _ in
+        var arguments: [String: Value] = ["query": "x", "mode": "text"]
+        if let rawSessionID {
+            arguments["session_id"] = .string(rawSessionID)
+        }
+        let result = await WaxMCPTools.handleCall(
+            params: .init(name: "search", arguments: arguments),
+            broker: service
+        )
+        #expect(result.isError != true)
+        #expect(firstText(in: result).contains("session_id must be a valid UUID") == false)
+    }
+}
+
 @Test
 func recallJSONResourceIncludesStructuredResults() async throws {
     try await withAgentBrokerService { service, _ in

--- a/Tests/WaxTests/BrokerCommandDecodeTests.swift
+++ b/Tests/WaxTests/BrokerCommandDecodeTests.swift
@@ -496,6 +496,56 @@ struct BrokerCommandDecodeTests {
         }
     }
 
+    @Test(arguments: [Optional<String>.none, Optional(""), Optional("   ")])
+    func omittedOrBlankSessionIDDecodesAsUnscoped(rawSessionID: String?) throws {
+        var searchArgs: [String: AgentBrokerValue] = [
+            "query": .string("needle"),
+            "mode": .string("text"),
+        ]
+        var recallArgs: [String: AgentBrokerValue] = ["query": .string("needle")]
+        var rememberArgs: [String: AgentBrokerValue] = ["content": .string("durable note")]
+        if let rawSessionID {
+            searchArgs["session_id"] = .string(rawSessionID)
+            recallArgs["session_id"] = .string(rawSessionID)
+            rememberArgs["session_id"] = .string(rawSessionID)
+        }
+
+        let search = try BrokerCommand.decode(command: "search", arguments: searchArgs)
+        guard case .search(let searchPayload) = search else {
+            Issue.record("expected search")
+            return
+        }
+        #expect(searchPayload.filters.sessionId == nil)
+
+        let recall = try BrokerCommand.decode(command: "recall", arguments: recallArgs)
+        guard case .recall(let recallPayload) = recall else {
+            Issue.record("expected recall")
+            return
+        }
+        #expect(recallPayload.filters.sessionId == nil)
+
+        let remember = try BrokerCommand.decode(command: "remember", arguments: rememberArgs)
+        guard case .remember(let rememberPayload) = remember else {
+            Issue.record("expected remember")
+            return
+        }
+        #expect(rememberPayload.sessionID == nil)
+    }
+
+    @Test
+    func invalidNonEmptySessionIDStillRejectedAtDecode() {
+        #expect(throws: BrokerValidationError.invalid("session_id must be a valid UUID")) {
+            _ = try BrokerCommand.decode(
+                command: "search",
+                arguments: [
+                    "query": .string("x"),
+                    "mode": .string("text"),
+                    "session_id": .string("not-a-uuid"),
+                ]
+            )
+        }
+    }
+
     @Test
     func entityResolveRejectsOutOfRangeLimit() {
         #expect(throws: BrokerValidationError.self) {


### PR DESCRIPTION
## Summary
WAX-003. Hermes wrappers send `session_id=\"\"`. Broker treated any present string as a UUID and threw. Trimmed-empty is now omitted (unscoped). Invalid non-empty still rejects.

## Proof
```
xcrun swift test --filter 'omittedOrBlankSessionIDDecodesAsUnscoped|invalidNonEmptySessionIDStillRejectedAtDecode'
```
2 passed (blank / whitespace / missing + reject `not-a-uuid`).