### PR TITLE
fix: WAL reclaim on rewrite + embed backfill

### DIFF
--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -18,6 +18,7 @@ Source: `Sources/Wax/Memory.swift`
 - Deprecated aliases: `search(_:strategy:options:)` and `search(_:strategy:options:reranker:)` (generic shims; use the existential form)
 - `public func delete(frameID: UInt64) async throws` — soft-deletes the frame and removes it from enabled text and vector indexes (committed).
 - `public func flush() async throws` — commits pending writes (WAL, FTS, vector index) to durable storage.
+- `public func backfillUnembedded() async throws -> UInt64` — embeds live searchable frames that have no vectors using the attached provider. Idempotent. Throws `WaxError.missingEmbedder` when no provider is attached; never invents vectors. Call `flush()` to commit.
 - `public func close() async throws` — flushes, then closes.
 - `public func stats() async -> Memory.Stats`
 
@@ -55,7 +56,7 @@ Source: `Sources/Wax/RAG/RAGContext.swift`
 
 ### Memory.Stats
 
-`public struct Stats: Sendable, Equatable` with `frameCount`, `pendingFrames`, `vectorSearchEnabled`, `queryEmbedderConfigured`, `queryEmbeddingCircuitOpen`, `embedderIdentity: EmbeddingIdentity?`, `embeddingStatus: EmbeddingStatus`.
+`public struct Stats: Sendable, Equatable` with `frameCount`, `pendingFrames`, `vectorSearchEnabled`, `queryEmbedderConfigured`, `queryEmbeddingCircuitOpen`, `embedderIdentity: EmbeddingIdentity?`, `embeddingStatus: EmbeddingStatus`, `framesWithoutVectors`.
 
 `queryEmbedderConfigured` is derived: `true` only for `active` and `degraded`.
 

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -206,6 +206,16 @@ public actor Memory {
         try await orchestrator.flush()
     }
 
+    /// Embed live searchable frames that have no vectors, using the attached provider.
+    ///
+    /// Idempotent: frames that already have pending or committed vectors are skipped.
+    /// Throws ``WaxError/missingEmbedder`` when no provider is attached — never invents vectors.
+    /// Call ``flush()`` afterward to commit the new vectors.
+    @discardableResult
+    public func backfillUnembedded() async throws -> UInt64 {
+        try await orchestrator.backfillUnembedded()
+    }
+
     /// Close the memory handle and release resources.
     public func close() async throws {
         try await orchestrator.close()
@@ -227,6 +237,8 @@ public actor Memory {
         public var embedderIdentity: EmbeddingIdentity?
         /// Readiness of the embedding provider attached to this store.
         public var embeddingStatus: EmbeddingStatus
+        /// Live searchable frames that currently have no pending or committed vector.
+        public var framesWithoutVectors: UInt64
 
         public init(
             frameCount: UInt64,
@@ -235,7 +247,8 @@ public actor Memory {
             queryEmbedderConfigured: Bool,
             queryEmbeddingCircuitOpen: Bool,
             embedderIdentity: EmbeddingIdentity?,
-            embeddingStatus: EmbeddingStatus = .disabled
+            embeddingStatus: EmbeddingStatus = .disabled,
+            framesWithoutVectors: UInt64 = 0
         ) {
             self.frameCount = frameCount
             self.pendingFrames = pendingFrames
@@ -244,6 +257,7 @@ public actor Memory {
             self.queryEmbeddingCircuitOpen = queryEmbeddingCircuitOpen
             self.embedderIdentity = embedderIdentity
             self.embeddingStatus = embeddingStatus
+            self.framesWithoutVectors = framesWithoutVectors
         }
     }
 
@@ -260,7 +274,8 @@ public actor Memory {
             queryEmbedderConfigured: runtime.embeddingStatus.isQueryEmbedderConfigured,
             queryEmbeddingCircuitOpen: runtime.queryEmbeddingCircuitOpen,
             embedderIdentity: runtime.embeddingStatus.identity,
-            embeddingStatus: runtime.embeddingStatus
+            embeddingStatus: runtime.embeddingStatus,
+            framesWithoutVectors: runtime.framesWithoutVectors
         )
     }
 

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -189,12 +189,21 @@ package extension MemoryOrchestrator {
         let sourceSizes = try Self.fileSizes(at: sourceURL)
         let sourceFrames = await wax.frameMetas()
         let sourceWalSize = (await wax.walStats()).walSize
+        let payloadLiveness = await wax.committedPayloadLivenessBytes()
+        let livePayloadBytes = payloadLiveness.totalPayloadBytes &- payloadLiveness.deadPayloadBytes
+        let payloadBytes = options.dropNonLivePayloads
+            ? livePayloadBytes
+            : payloadLiveness.totalPayloadBytes
+        let destinationWalSize = Self.walSizeForLiveSetRewrite(
+            sourceWalSize: sourceWalSize,
+            payloadBytes: payloadBytes
+        )
         let committedLexManifest = await wax.committedLexIndexManifest()
         let committedVecManifest = await wax.committedVecIndexManifest()
         let committedLexBytes = try await wax.readCommittedLexIndexBytes()
         let committedVecBytes = try await wax.readCommittedVecIndexBytes()
 
-        let rewritten = try await Wax.create(at: destinationURL, walSize: sourceWalSize)
+        let rewritten = try await Wax.create(at: destinationURL, walSize: destinationWalSize)
         var droppedPayloadFrames = 0
         do {
             for frame in sourceFrames {
@@ -561,6 +570,17 @@ package extension MemoryOrchestrator {
             searchText: frame.searchText,
             metadata: frame.metadata
         )
+    }
+
+    /// Destination WAL is payload-derived: never clone a large empty source ring,
+    /// never go below `Constants.sessionWalSize` when the source ring allows it,
+    /// and never exceed the source ring.
+    static func walSizeForLiveSetRewrite(sourceWalSize: UInt64, payloadBytes: UInt64) -> UInt64 {
+        let floor = Constants.sessionWalSize
+        let cap = sourceWalSize
+        let boundedFloor = min(floor, cap)
+        let needed = max(boundedFloor, payloadBytes)
+        return min(cap, needed)
     }
 
     private static func fileSizes(at url: URL) throws -> (logical: UInt64, allocated: UInt64) {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -139,6 +139,7 @@ package actor MemoryOrchestrator {
         package var accessStatsScoringEnabled: Bool
         package var embedderIdentity: EmbeddingIdentity?
         package var embeddingStatus: EmbeddingStatus
+        package var framesWithoutVectors: UInt64
 
         package init(
             frameCount: UInt64,
@@ -153,7 +154,8 @@ package actor MemoryOrchestrator {
             structuredMemoryEnabled: Bool,
             accessStatsScoringEnabled: Bool,
             embedderIdentity: EmbeddingIdentity?,
-            embeddingStatus: EmbeddingStatus = .disabled
+            embeddingStatus: EmbeddingStatus = .disabled,
+            framesWithoutVectors: UInt64 = 0
         ) {
             self.frameCount = frameCount
             self.pendingFrames = pendingFrames
@@ -168,6 +170,7 @@ package actor MemoryOrchestrator {
             self.accessStatsScoringEnabled = accessStatsScoringEnabled
             self.embedderIdentity = embedderIdentity
             self.embeddingStatus = embeddingStatus
+            self.framesWithoutVectors = framesWithoutVectors
         }
     }
 
@@ -909,12 +912,16 @@ package actor MemoryOrchestrator {
     }
 
     private static func vecSegmentContains(frameId: UInt64, bytes: Data) -> Bool {
+        vecSegmentFrameIds(bytes: bytes).contains(frameId)
+    }
+
+    private static func vecSegmentFrameIds(bytes: Data) -> Set<UInt64> {
         guard let payload = try? VectorSerializer.decodeVecSegment(from: bytes) else {
-            return false
+            return []
         }
         switch payload {
         case .metal(_, _, let frameIds):
-            return frameIds.contains(frameId)
+            return Set(frameIds)
         }
     }
 
@@ -1339,7 +1346,8 @@ package actor MemoryOrchestrator {
             structuredMemoryEnabled: config.enableStructuredMemory,
             accessStatsScoringEnabled: config.enableAccessStatsScoring,
             embedderIdentity: embeddingStatus.identity,
-            embeddingStatus: embeddingStatus
+            embeddingStatus: embeddingStatus,
+            framesWithoutVectors: await Self.framesWithoutVectorsCount(wax)
         )
     }
 
@@ -1352,6 +1360,55 @@ package actor MemoryOrchestrator {
         guard config.enableVectorSearch else { return false }
         if case .loading = embeddingStatus { return true }
         return false
+    }
+
+    /// Embed live searchable frames that have no vectors using the attached provider.
+    ///
+    /// Returns the number of frames newly embedded. Already-vectorized frames are
+    /// skipped. Throws ``WaxError/missingEmbedder`` when no provider is attached.
+    @discardableResult
+    package func backfillUnembedded() async throws -> UInt64 {
+        let snapshot = readyEmbedderSnapshot
+        guard config.enableVectorSearch, let embedder = snapshot.provider else {
+            throw WaxError.missingEmbedder
+        }
+
+        let missing = await unembeddedLiveSources()
+        guard !missing.isEmpty else {
+            await refreshEmbeddingCoverage()
+            return 0
+        }
+
+        try await session.ensureVectorEngine(dimensions: embedder.dimensions)
+
+        let batchSize = max(1, config.ingestBatchSize)
+        var embedded: UInt64 = 0
+        var index = 0
+        while index < missing.count {
+            let end = min(index + batchSize, missing.count)
+            let batch = Array(missing[index..<end])
+            let vectors = try await Self.prepareEmbeddingsBatchOptimized(
+                chunks: batch.map(\.searchText),
+                embedder: embedder,
+                capabilities: snapshot.capabilities,
+                cache: embeddingCache,
+                timeout: config.ingestEmbeddingTimeout
+            )
+            try await wax.putEmbeddingBatch(
+                frameIds: batch.map(\.id),
+                vectors: vectors
+            )
+            if let identity = embedder.identity {
+                try await ensureMemoryBindingIfNeeded(
+                    MemoryBindingCompatibility.binding(from: identity)
+                )
+            }
+            embedded += UInt64(batch.count)
+            index = end
+        }
+
+        await refreshEmbeddingCoverage()
+        return embedded
     }
 
     /// Wait until automatic compile has attached, or throw if it failed.
@@ -2234,11 +2291,50 @@ package actor MemoryOrchestrator {
     }
 
     private static func storeHasUnembeddedChunks(_ wax: Wax) async -> Bool {
+        await framesWithoutVectorsCount(wax) > 0
+    }
+
+    private static func framesWithoutVectorsCount(_ wax: Wax) async -> UInt64 {
         let chunks = await wax.liveChunkCount()
-        guard chunks > 0 else { return false }
+        guard chunks > 0 else { return 0 }
         let pending = UInt64(await wax.pendingEmbeddingMutations().count)
         let indexed = await wax.committedVecIndexManifest()?.vectorCount ?? 0
-        return chunks > indexed + pending
+        if chunks > indexed + pending {
+            return chunks - indexed - pending
+        }
+        return 0
+    }
+
+    private func unembeddedLiveSources() async -> [SurrogateSourceFrame] {
+        let sources = await wax.activeSurrogateSourceFrames()
+        let embedded = await embeddedFrameIds()
+        return sources.filter { !embedded.contains($0.id) }
+    }
+
+    private func embeddedFrameIds() async -> Set<UInt64> {
+        var ids = Set<UInt64>()
+        for pending in await wax.pendingEmbeddingMutations() {
+            ids.insert(pending.frameId)
+        }
+        if let staged = await wax.readStagedVecIndexBytes() {
+            ids.formUnion(Self.vecSegmentFrameIds(bytes: staged.bytes))
+        }
+        if let bytes = try? await wax.readCommittedVecIndexBytes() {
+            ids.formUnion(Self.vecSegmentFrameIds(bytes: bytes))
+        }
+        return ids
+    }
+
+    private func refreshEmbeddingCoverage() async {
+        guard case .ready(let provider, let capabilities, _) = embedderLifecycle else {
+            return
+        }
+        let lacksVectors = await Self.storeHasUnembeddedChunks(wax)
+        embedderLifecycle = .ready(
+            provider: provider,
+            capabilities: capabilities,
+            degradedReason: lacksVectors ? "some saved frames have no vectors" : nil
+        )
     }
 
     private func queryEmbeddingResult(

--- a/Tests/WaxIntegrationTests/EmbeddingBackfillTests.swift
+++ b/Tests/WaxIntegrationTests/EmbeddingBackfillTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+import Wax
+
+@Test
+func backfillUnembeddedLiveChunksClearsDegradedAndRanksKnownHit() async throws {
+    try await TempFiles.withTempFile { url in
+        let needle = "unique backfill needle about swift actors"
+        let decoy = "unrelated gardening notes about tomatoes"
+
+        do {
+            let seeded = try await Memory(at: url) {
+                $0.enableVectorSearch = false
+                $0.requireOnDeviceProviders = false
+            }
+            try await seeded.save(needle)
+            try await seeded.save(decoy)
+            try await seeded.flush()
+            try await seeded.close()
+        }
+
+        let provider = DeterministicTextEmbedder()
+        let memory = try await Memory(at: url) {
+            $0.requireOnDeviceProviders = false
+            $0.embedding = .custom(provider)
+        }
+
+        let before = await memory.stats()
+        guard case .degraded = before.embeddingStatus else {
+            Issue.record("expected degraded before backfill, got \(before.embeddingStatus)")
+            try await memory.close()
+            return
+        }
+        #expect(before.framesWithoutVectors > 0)
+        #expect(before.queryEmbedderConfigured)
+
+        let first = try await memory.backfillUnembedded()
+        #expect(first > 0)
+        try await memory.flush()
+
+        let after = await memory.stats()
+        #expect(after.embeddingStatus == .active(provider.identity))
+        #expect(after.framesWithoutVectors == 0)
+
+        let vectorHits = try await memory.search(
+            needle,
+            options: .init(topK: 1, mode: .vectorOnly)
+        )
+        #expect(vectorHits.items.first?.text.contains("swift actors") == true)
+
+        let hybridHits = try await memory.search(
+            needle,
+            options: .init(topK: 1, mode: .hybrid())
+        )
+        #expect(hybridHits.items.first?.text.contains("swift actors") == true)
+
+        let second = try await memory.backfillUnembedded()
+        #expect(second == 0)
+        try await memory.flush()
+        let again = await memory.stats()
+        #expect(again.embeddingStatus == .active(provider.identity))
+        #expect(again.framesWithoutVectors == 0)
+
+        try await memory.close()
+    }
+}
+
+@Test
+func backfillUnembeddedFailsClosedWithoutEmbedder() async throws {
+    try await TempFiles.withTempFile { url in
+        let memory = try await Memory(at: url) {
+            $0.enableVectorSearch = false
+            $0.requireOnDeviceProviders = false
+        }
+        try await memory.save("text-only frame must not invent vectors")
+        try await memory.flush()
+
+        do {
+            _ = try await memory.backfillUnembedded()
+            Issue.record("backfill without an embedder must fail closed")
+        } catch let error as WaxError {
+            guard case .missingEmbedder = error else {
+                Issue.record("expected WaxError.missingEmbedder, got \(error)")
+                try await memory.close()
+                return
+            }
+        }
+
+        let stats = await memory.stats()
+        #expect(stats.embeddingStatus == .disabled)
+        try await memory.close()
+    }
+}

--- a/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
+++ b/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
@@ -94,6 +94,97 @@ func rewriteLiveSetDropsNonLivePayloadsAndPreservesFrameState() async throws {
 }
 
 @Test
+func rewriteLiveSetWalSizeFloorsAtSessionSizeAndCapsAtSourceRing() {
+    let session = Constants.sessionWalSize
+    let defaultRing = Constants.defaultWalSize
+
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: defaultRing,
+            payloadBytes: 107_000
+        ) == session
+    )
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: defaultRing,
+            payloadBytes: session + 1
+        ) == session + 1
+    )
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: defaultRing,
+            payloadBytes: defaultRing + 1
+        ) == defaultRing
+    )
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: session / 2,
+            payloadBytes: 1
+        ) == session / 2
+    )
+}
+
+@Test
+func rewriteLiveSetChoosesWalSizeFromPayloadNotSourceRing() async throws {
+    try await TempFiles.withTempFile { sourceURL in
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: destinationURL) }
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+
+        do {
+            let wax = try await Wax.create(at: sourceURL)
+            for index in 0..<20 {
+                _ = try await wax.put(
+                    Data("small live payload \(index)".utf8),
+                    options: FrameMetaSubset(searchText: "small live payload \(index)")
+                )
+            }
+            try await wax.commit()
+            let sourceWal = await wax.walStats()
+            #expect(sourceWal.walSize == Constants.defaultWalSize)
+            try await wax.close()
+        }
+
+        let sourceSizesBefore = try fileSizes(at: sourceURL)
+        #expect(sourceSizesBefore.logical >= Constants.defaultWalSize)
+
+        let report: LiveSetRewriteReport
+        do {
+            let orchestrator = try await MemoryOrchestrator(at: sourceURL, config: config)
+            report = try await orchestrator.rewriteLiveSet(to: destinationURL)
+            try await orchestrator.close()
+        }
+
+        let sourceSizesAfter = try fileSizes(at: sourceURL)
+        #expect(sourceSizesAfter.logical == sourceSizesBefore.logical)
+
+        let rewrittenWax = try await Wax.open(at: destinationURL)
+        let destWal = await rewrittenWax.walStats()
+        #expect(destWal.walSize == Constants.sessionWalSize)
+        #expect(destWal.walSize >= Constants.sessionWalSize)
+        #expect(destWal.walSize <= Constants.defaultWalSize)
+        #expect(destWal.walSize <= 8 * 1024 * 1024)
+
+        let destFrames = await rewrittenWax.frameMetas()
+        #expect(destFrames.count == 20)
+        #expect(destFrames.filter { $0.status == .active && $0.supersededBy == nil }.count == 20)
+        try await rewrittenWax.verify()
+        try await rewrittenWax.close()
+
+        let destSizes = try fileSizes(at: destinationURL)
+        #expect(destSizes.logical < sourceSizesBefore.logical)
+        #expect(destSizes.logical < 16 * 1024 * 1024)
+        #expect(report.logicalBytesAfter < report.logicalBytesBefore)
+        #expect(report.frameCount == 20)
+        #expect(report.activeFrameCount == 20)
+    }
+}
+
+@Test
 func rewriteLiveSetRespectsDestinationOverwriteGuard() async throws {
     try await TempFiles.withTempFile { sourceURL in
         let destinationURL = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary
Family-honesty Wave 1 for 0.1.34.

- `rewriteLiveSet` sizes dest WAL from payload (floor session 4 MiB, cap source). Stops cloning a 256 MiB empty ring.
- `Memory.backfillUnembedded()` embeds live text-only frames. Idempotent. Fail-closed without a provider. `stats.framesWithoutVectors`.

Tickets: WAX-2026-08-27-011-wal u1, WAX-2026-08-27-012-embed u1.
Base: release/waxmcp-0.1.33. Not performance.

## Test plan
- [x] Ishi: `xcrun swift test --skip-update --filter rewriteLiveSet` — 4 passed
- [x] Ishi: `xcrun swift test --skip-update --filter backfillUnembedded` — 2 passed
- [x] HTTP soak :3010 copy store 90s: ok=35003 rst=0 fds 20→21

Chris authorized merge + cut next waxmcp.

Leftover (not this PR): CLI compact-store / embed-backfill, defaultWalSize 8 MiB, broker JSON framesWithoutVectors, live file swap.