### PR TITLE
feat: unique-token ranking, copy-first hygiene CLI, KeepAlive packaging

### DIFF
--- a/Sources/Wax/UnifiedSearch/MatchPlan.swift
+++ b/Sources/Wax/UnifiedSearch/MatchPlan.swift
@@ -54,7 +54,16 @@ package struct MatchPlan: Equatable, Sendable {
 
         func flush() {
             if !buffer.isEmpty {
-                tokens.append(String(buffer))
+                let raw = String(buffer)
+                tokens.append(raw)
+                if raw.contains(where: { $0 == "-" || $0 == "_" }) {
+                    for part in raw.split(whereSeparator: { $0 == "-" || $0 == "_" }) {
+                        let piece = String(part)
+                        if !piece.isEmpty {
+                            tokens.append(piece)
+                        }
+                    }
+                }
                 buffer.removeAll(keepingCapacity: true)
             }
         }
@@ -168,7 +177,9 @@ package struct MatchPlan: Equatable, Sendable {
     ]
 
     private static let asciiPunctuationScalars: Set<UnicodeScalar> = {
-        let scalars = "!\\\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~".unicodeScalars
+        // Keep '-' and '_' as identifier glue so hyphenated tokens stay intact;
+        // split parts are still emitted from `aliasTokens` for OR fallback.
+        let scalars = "!\\\"#$%&'()*+,./:;<=>?@[\\\\]^`{|}~".unicodeScalars
         return Set(scalars)
     }()
 

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -759,7 +759,9 @@ extension Wax {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { return results }
         let cappedWindow = min(max(0, maxWindow), results.count)
-        guard cappedWindow > 1 else { return results }
+        // Window 1 still publishes the bonus so a lone exact hit outranks
+        // OR-fallback name matches from another store after corpus merge.
+        guard cappedWindow > 0 else { return results }
 
         let lowerNeedle = needle.lowercased()
         // Larger than same-repo (0.9) + same-project (0.7) + decision (0.45) + durable (0.25).

--- a/Sources/WaxCLI/CompactStoreCommand.swift
+++ b/Sources/WaxCLI/CompactStoreCommand.swift
@@ -54,6 +54,7 @@ struct CompactStoreCommand: AsyncParsableCommand {
             storePath: storePath,
             output: output
         )
+        try failFastIfStoreHeld(at: sourceURL)
 
         let report = try await StoreSession.withOpen(at: sourceURL, noEmbedder: true) { memory in
             try await memory.rewriteLiveSet(
@@ -89,19 +90,32 @@ struct CompactStoreCommand: AsyncParsableCommand {
             print("WAL size: \(destWal.walSize)")
         }
     }
+
+    func failFastIfStoreHeld(at url: URL) throws {
+        guard try StoreLockProbe.tryExclusiveAccess(at: url) else {
+            throw CLIError(
+                "another process holds an exclusive lock on this store; if a broker is attached, use waxmcp stats / attach instead of waiting"
+            )
+        }
+    }
 }
 
 enum CompactStorePathPolicy {
     static func validate(storePath: String, output: String) throws {
         let source = expandedURL(storePath)
         let dest = expandedURL(output)
-        if source == liveFamilyURL() {
-            throw ValidationError(
-                "compact-store refuses the live family store path \(StoreSession.defaultStorePath)"
-            )
-        }
+        try refuseLiveFamily(source, command: "compact-store")
+        try refuseLiveFamily(dest, command: "compact-store")
         if source == dest {
             throw ValidationError("compact-store destination must differ from source")
+        }
+    }
+
+    static func refuseLiveFamily(_ url: URL, command: String) throws {
+        if url == liveFamilyURL() {
+            throw ValidationError(
+                "\(command) refuses the live family store path \(StoreSession.defaultStorePath)"
+            )
         }
     }
 
@@ -116,8 +130,10 @@ enum CompactStorePathPolicy {
         expandedURL(StoreSession.defaultStorePath)
     }
 
+    /// Trim then tilde-expand. Must match `StoreSession.resolveURL` identity without creating directories.
     static func expandedURL(_ raw: String) -> URL {
-        let expanded = (raw as NSString).expandingTildeInPath
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expanded = (trimmed as NSString).expandingTildeInPath
         return URL(fileURLWithPath: expanded).standardizedFileURL
     }
 }

--- a/Sources/WaxCLI/CompactStoreCommand.swift
+++ b/Sources/WaxCLI/CompactStoreCommand.swift
@@ -1,0 +1,123 @@
+import ArgumentParser
+import Foundation
+import Wax
+import WaxCore
+
+struct CompactStoreCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "compact-store",
+        abstract: "Rewrite a copy of a Wax store with automatic WAL sizing"
+    )
+
+    @Option(
+        name: .customLong("store-path"),
+        help: "Source store path. Required; never defaults to ~/.wax/memory.wax."
+    )
+    var storePath: String
+
+    @Option(name: .customLong("output"), help: "Destination store path")
+    var output: String
+
+    @Flag(
+        name: .customLong("direct-store"),
+        help: "Required. Open the source store file directly; never talks to the broker."
+    )
+    var directStore: Bool = false
+
+    @Flag(
+        name: .customLong("no-embedder"),
+        help: "Disable MiniLM. Compact does not need an embedder."
+    )
+    var noEmbedder: Bool = false
+
+    @Flag(name: .customLong("overwrite"), help: "Replace an existing destination file")
+    var overwrite: Bool = false
+
+    @Option(name: .customLong("format"), help: "Output format: json or text")
+    var format: OutputFormat = .text
+
+    func validate() throws {
+        guard directStore else {
+            throw ValidationError("--direct-store is required for compact-store")
+        }
+        try CompactStorePathPolicy.validate(
+            storePath: storePath,
+            output: output
+        )
+    }
+
+    func runAsync() async throws {
+        _ = noEmbedder
+        let sourceURL = try StoreSession.resolveURL(storePath)
+        let destURL = try CompactStorePathPolicy.destinationURL(from: output)
+        try CompactStorePathPolicy.validate(
+            storePath: storePath,
+            output: output
+        )
+
+        let report = try await StoreSession.withOpen(at: sourceURL, noEmbedder: true) { memory in
+            try await memory.rewriteLiveSet(
+                to: destURL,
+                options: LiveSetRewriteOptions(
+                    overwriteDestination: overwrite,
+                    dropNonLivePayloads: true,
+                    verifyDeep: true
+                )
+            )
+        }
+
+        let dest = try await Wax.open(at: destURL)
+        let destWal = await dest.walStats()
+        try await dest.close()
+
+        switch format {
+        case .json:
+            printJSON([
+                "sourcePath": report.sourceURL.path,
+                "outputPath": report.destinationURL.path,
+                "frameCount": report.frameCount,
+                "activeFrameCount": report.activeFrameCount,
+                "droppedPayloadFrames": report.droppedPayloadFrames,
+                "logicalBytesBefore": report.logicalBytesBefore,
+                "logicalBytesAfter": report.logicalBytesAfter,
+                "walSizeAfter": destWal.walSize,
+            ])
+        case .text:
+            print("Compacted \(report.sourceURL.path) → \(report.destinationURL.path)")
+            print("Frames: \(report.frameCount) (\(report.activeFrameCount) active)")
+            print("Logical size: \(report.logicalBytesAfter) bytes (was \(report.logicalBytesBefore))")
+            print("WAL size: \(destWal.walSize)")
+        }
+    }
+}
+
+enum CompactStorePathPolicy {
+    static func validate(storePath: String, output: String) throws {
+        let source = expandedURL(storePath)
+        let dest = expandedURL(output)
+        if source == liveFamilyURL() {
+            throw ValidationError(
+                "compact-store refuses the live family store path \(StoreSession.defaultStorePath)"
+            )
+        }
+        if source == dest {
+            throw ValidationError("compact-store destination must differ from source")
+        }
+    }
+
+    static func destinationURL(from raw: String) throws -> URL {
+        let url = expandedURL(raw)
+        let dir = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func liveFamilyURL() -> URL {
+        expandedURL(StoreSession.defaultStorePath)
+    }
+
+    static func expandedURL(_ raw: String) -> URL {
+        let expanded = (raw as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expanded).standardizedFileURL
+    }
+}

--- a/Sources/WaxCLI/EmbedBackfillCommand.swift
+++ b/Sources/WaxCLI/EmbedBackfillCommand.swift
@@ -16,11 +16,10 @@ struct EmbedBackfillCommand: AsyncParsableCommand {
         guard store.directStore else {
             throw ValidationError("--direct-store is required for embed-backfill")
         }
-        if CompactStorePathPolicy.expandedURL(store.storePath) == CompactStorePathPolicy.liveFamilyURL() {
-            throw ValidationError(
-                "embed-backfill refuses the live family store path \(StoreSession.defaultStorePath)"
-            )
-        }
+        try CompactStorePathPolicy.refuseLiveFamily(
+            CompactStorePathPolicy.expandedURL(store.storePath),
+            command: "embed-backfill"
+        )
     }
 
     func runAsync() async throws {

--- a/Sources/WaxCLI/EmbedBackfillCommand.swift
+++ b/Sources/WaxCLI/EmbedBackfillCommand.swift
@@ -1,0 +1,80 @@
+import ArgumentParser
+import Foundation
+import Wax
+import WaxCore
+
+struct EmbedBackfillCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "embed-backfill",
+        abstract: "Embed live frames that have no vectors on a copy of a store"
+    )
+
+    @OptionGroup var store: VectorStoreOptions
+
+    func validate() throws {
+        try store.validate()
+        guard store.directStore else {
+            throw ValidationError("--direct-store is required for embed-backfill")
+        }
+        if CompactStorePathPolicy.expandedURL(store.storePath) == CompactStorePathPolicy.liveFamilyURL() {
+            throw ValidationError(
+                "embed-backfill refuses the live family store path \(StoreSession.defaultStorePath)"
+            )
+        }
+    }
+
+    func runAsync() async throws {
+        let url = try StoreSession.resolveURL(store.storePath)
+        try failFastIfStoreHeld(at: url)
+
+        if store.noEmbedder {
+            throw CLIError("embed-backfill requires an embedder; --no-embedder fails closed")
+        }
+
+        do {
+            try await StoreSession.withOpen(
+                at: url,
+                noEmbedder: false,
+                embedderChoice: store.embedder,
+                embedderTuning: store.embedderTuning,
+                requireVector: true
+            ) { memory in
+                try await memory.waitUntilReadyForRemember()
+                let before = await memory.runtimeStats()
+                let examined = before.framesWithoutVectors
+                let embedded = try await memory.backfillUnembedded()
+                try await memory.flush()
+                let after = await memory.runtimeStats()
+                let payload: [String: Any] = [
+                    "examined": examined,
+                    "embedded": embedded,
+                    "skippedAlreadyEmbedded": max(0, Int64(before.frameCount) - Int64(examined)),
+                    "framesWithoutVectors": after.framesWithoutVectors,
+                    "embeddingStatus": after.embeddingStatus.wireName,
+                    "storePath": after.storeURL.path,
+                ]
+                switch store.format {
+                case .json:
+                    printJSON(payload)
+                case .text:
+                    print("Backfill examined \(examined) unembedded frame(s); embedded \(embedded).")
+                    print("Frames without vectors: \(after.framesWithoutVectors)")
+                    print("Embedding status: \(after.embeddingStatus.wireName)")
+                }
+            }
+        } catch let error as WaxError {
+            if case .missingEmbedder = error {
+                throw CLIError("embed-backfill requires an embedder; none is attached")
+            }
+            throw error
+        }
+    }
+
+    func failFastIfStoreHeld(at url: URL) throws {
+        guard try StoreLockProbe.tryExclusiveAccess(at: url) else {
+            throw CLIError(
+                "another process holds an exclusive lock on this store; if a broker is attached, use waxmcp stats / attach instead of waiting"
+            )
+        }
+    }
+}

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -23,6 +23,8 @@ struct WaxCLI: ParsableCommand {
             CorpusSearchCommand.self,
             DaemonCommand.self,
             StatsCommand.self,
+            CompactStoreCommand.self,
+            EmbedBackfillCommand.self,
             VectorHealthCommand.self,
             FlushCommand.self,
             SessionStartCommand.self,

--- a/Tests/WaxCLITests/CompactStoreCommandTests.swift
+++ b/Tests/WaxCLITests/CompactStoreCommandTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+import WaxCore
+@testable import wax_cli
+
+struct CompactStoreCommandTests {
+    @Test func compactStoreRequiresDirectStoreFlag() throws {
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--store-path", "/tmp/wax-compact-in.wax",
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+    }
+
+    @Test func compactStoreRefusesLiveFamilyPath() throws {
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", StoreSession.defaultStorePath,
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax",
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+    }
+
+    @Test func compactStoreRewritesTempCopyWithLongTermWal() async throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-compact-src-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        let destURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-compact-dst-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destURL)
+        }
+
+        let source = try await Wax.create(at: sourceURL)
+        for index in 0..<5 {
+            _ = try await source.put(
+                Data("compact live payload \(index)".utf8),
+                options: FrameMetaSubset(searchText: "compact live payload \(index)")
+            )
+        }
+        try await source.commit()
+        let sourceWal = await source.walStats()
+        #expect(sourceWal.walSize == Constants.defaultWalSize)
+        try await source.close()
+
+        var command = try CompactStoreCommand.parse([
+            "--direct-store",
+            "--no-embedder",
+            "--store-path", sourceURL.path,
+            "--output", destURL.path,
+            "--format", "json",
+        ])
+        try await command.runAsync()
+
+        let dest = try await Wax.open(at: destURL)
+        let destWal = await dest.walStats()
+        // Shipped rewriteLiveSet automatic dest for a 256 MiB source with small
+        // payload is sessionWalSize. Constants.longTermWalSize is not on this line.
+        #expect(destWal.walSize == Constants.sessionWalSize)
+        try await dest.verify(deep: true)
+        try await dest.close()
+
+        let destSize = try destURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        #expect(destSize < 32 * 1024 * 1024)
+        #expect(destSize < Int(Constants.defaultWalSize))
+    }
+}

--- a/Tests/WaxCLITests/CompactStoreCommandTests.swift
+++ b/Tests/WaxCLITests/CompactStoreCommandTests.swift
@@ -28,6 +28,29 @@ struct CompactStoreCommandTests {
                 "--output", "/tmp/wax-compact-out.wax",
             ])
         }
+        // Quoted trailing space must still refuse: open trims, so this is the live file.
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax ",
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", "/tmp/wax-compact-in.wax",
+                "--output", StoreSession.defaultStorePath,
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--overwrite",
+                "--store-path", "/tmp/wax-compact-in.wax",
+                "--output", "~/.wax/memory.wax",
+            ])
+        }
     }
 
     @Test func compactStoreRewritesTempCopyWithLongTermWal() async throws {

--- a/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
+++ b/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
@@ -22,6 +22,27 @@ struct EmbedBackfillCommandTests {
         }
     }
 
+    @Test func embedBackfillRefusesLiveFamilyPath() throws {
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", StoreSession.defaultStorePath,
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax ",
+            ])
+        }
+    }
+
     @Test func embedBackfillNoEmbedderFailsClosed() async throws {
         let storeURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("wax-backfill-\(UUID().uuidString)")

--- a/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
+++ b/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+import Wax
+import WaxCore
+@testable import wax_cli
+
+struct EmbedBackfillCommandTests {
+    @Test func waxCLIExposesEmbedBackfillCommand() throws {
+        let source = try String(
+            contentsOfFile: "Sources/WaxCLI/WaxCLICommand.swift",
+            encoding: .utf8
+        )
+        #expect(source.contains("EmbedBackfillCommand.self"))
+    }
+
+    @Test func embedBackfillRequiresDirectStoreFlag() throws {
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--store-path", "/tmp/wax-backfill.wax",
+                "--no-embedder",
+            ])
+        }
+    }
+
+    @Test func embedBackfillNoEmbedderFailsClosed() async throws {
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-backfill-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        do {
+            var config = OrchestratorConfig.default
+            config.enableVectorSearch = false
+            let memory = try await MemoryOrchestrator(at: storeURL, config: config)
+            try await memory.remember("text-only frame must not invent vectors")
+            try await memory.flush()
+            try await memory.close()
+        }
+
+        var command = try EmbedBackfillCommand.parse([
+            "--direct-store",
+            "--no-embedder",
+            "--store-path", storeURL.path,
+            "--format", "json",
+        ])
+        do {
+            try await command.runAsync()
+            Issue.record("embed-backfill --no-embedder must fail closed")
+        } catch let error as CLIError {
+            #expect(error.message.lowercased().contains("embedder") || error.message.lowercased().contains("no-embedder"))
+        } catch let error as WaxError {
+            guard case .missingEmbedder = error else {
+                Issue.record("expected WaxError.missingEmbedder, got \(error)")
+                return
+            }
+        }
+
+        let reopened = try await MemoryOrchestrator(at: storeURL, config: {
+            var config = OrchestratorConfig.default
+            config.enableVectorSearch = false
+            return config
+        }())
+        let stats = await reopened.runtimeStats()
+        #expect(stats.embeddingStatus == .disabled)
+        try await reopened.close()
+    }
+}

--- a/Tests/WaxTests/MatchPlanTests.swift
+++ b/Tests/WaxTests/MatchPlanTests.swift
@@ -25,6 +25,16 @@ func matchPlanStopwordsAndOperatorsAloneAreEmpty() {
 }
 
 @Test
+func matchPlanKeepsHyphenatedIdentifierAsToken() {
+    let tokens = MatchPlan.tokens(from: "qx7m-ishi-qa")
+    #expect(tokens.contains("qx7m-ishi-qa"))
+    #expect(tokens.contains("ishi"))
+    let plan = MatchPlan.plan(query: "qx7m-ishi-qa")
+    #expect(plan?.primaryMatch.contains("qx7m-ishi-qa") == true)
+    #expect(plan?.fallbackMatch?.contains(" OR ") == true)
+}
+
+@Test
 func matchPlanTreatsFTSPunctuationAsLiteralTokens() {
     let plan = MatchPlan.plan(query: #"task:(F076) NEAR(unclosed "quote""#)
     let primary = plan?.primaryMatch ?? ""

--- a/Tests/WaxTests/UniqueTokenRankingTests.swift
+++ b/Tests/WaxTests/UniqueTokenRankingTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Testing
+@testable import Wax
+
+private struct UniqueTokenRankingEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 4
+    let normalize = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "UniqueTokenRanking",
+        model: "Deterministic",
+        dimensions: 4,
+        normalized: true
+    )
+
+    func embed(_ text: String) async throws -> [Float] {
+        let lower = text.lowercased()
+        if lower.contains("qx7m-ishi-qa") {
+            return [1, 0, 0, 0]
+        }
+        if lower.contains("ishi") {
+            return [0, 1, 0, 0]
+        }
+        return [0, 0, 1, 0]
+    }
+}
+
+private func withUniqueTokenBroker<T>(
+    _ body: (AgentBrokerService) async throws -> T
+) async throws -> T {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-unique-token-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    var config = OrchestratorConfig.default
+    config.enableVectorSearch = true
+    config.enableTextSearch = true
+    config.rag.searchMode = .hybrid(alpha: 0.5)
+
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "auto",
+        requireVector: false,
+        embedderOverride: UniqueTokenRankingEmbedder(),
+        orchestratorConfig: config
+    )
+    do {
+        let result = try await body(service)
+        try await service.close()
+        return result
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+private func requireObject(_ value: AgentBrokerValue?) throws -> [String: AgentBrokerValue] {
+    try #require(value?.objectValue)
+}
+
+private func firstHitText(_ payload: [String: AgentBrokerValue]) -> String {
+    let first = payload["results"]?.arrayValue?.first?.objectValue
+    return first?["text"]?.stringValue
+        ?? first?["preview"]?.stringValue
+        ?? ""
+}
+
+private func seedUniqueTokenCorpus(
+    _ service: AgentBrokerService
+) async throws -> UUID {
+    let started = await service.handle(.init(
+        command: "session_start",
+        arguments: [
+            "agent_id": .string("unique-token-agent"),
+            "run_id": .string("unique-token-run"),
+            "project": .string("ishi-qa"),
+            "repo": .string("ishi-qa"),
+        ]
+    ))
+    #expect(started.ok == true, "session_start failed: \(started.error ?? "nil")")
+    let sessionIDString = try #require(try requireObject(started.payload)["session_id"]?.stringValue)
+    let sessionID = try #require(UUID(uuidString: sessionIDString))
+
+    let nonce = await service.handle(.init(
+        command: "remember",
+        arguments: [
+            "content": .string("WAX_MCP_QA marker Unique token qx7m-ishi-qa."),
+            "session_id": .string(sessionIDString),
+            "memory_type": .string("note"),
+            "durability": .string("working"),
+        ]
+    ))
+    #expect(nonce.ok == true, "nonce remember failed: \(nonce.error ?? "nil")")
+
+    let distractors = [
+        "Ishi is reviewing the family memory store tonight.",
+        "Ask Ishi before changing the MCP daemon wrapper.",
+        "Ishi prefers copy-store hygiene over live vacuum.",
+        "Task state: wait for Ishi to confirm the ranking gold set.",
+        "Ishi noted that hyphenated identifiers should stay tokens.",
+    ]
+    for (index, text) in distractors.enumerated() {
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string(text),
+                "memory_type": .string("task_state"),
+                "durability": .string("durable"),
+                "project": .string("ishi-qa"),
+                "repo": .string("ishi-qa"),
+            ]
+        ))
+        #expect(write.ok == true, "distractor \(index) remember failed: \(write.error ?? "nil")")
+    }
+    return sessionID
+}
+
+private func expectUniqueTokenHitAt1(
+    _ response: AgentBrokerResponse,
+    command: String
+) throws {
+    #expect(response.ok == true, "\(command) failed: \(response.error ?? "nil")")
+    let payload = try requireObject(response.payload)
+    let top = firstHitText(payload)
+    #expect(
+        top.localizedCaseInsensitiveContains("qx7m-ishi-qa"),
+        "\(command) hit@1 missed unique token; top=\(top) display=\(payload["display_text"]?.stringValue ?? "")"
+    )
+}
+
+@Test
+func uniqueTokenRanksHitAt1OnSearchRecallMemoryAndCorpus() async throws {
+    try await withUniqueTokenBroker { service in
+        let sessionID = try await seedUniqueTokenCorpus(service)
+        let query = "qx7m-ishi-qa"
+
+        let textSearch = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "topK": .int(8),
+                "session_id": .string(sessionID.uuidString),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(textSearch, command: "search text")
+
+        let hybridSearch = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("hybrid"),
+                "topK": .int(8),
+                "session_id": .string(sessionID.uuidString),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(hybridSearch, command: "search hybrid")
+
+        let recall = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "scope": .string("project"),
+                "project": .string("ishi-qa"),
+                "repo": .string("ishi-qa"),
+                "session_id": .string(sessionID.uuidString),
+                "limit": .int(8),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(recall, command: "recall")
+
+        let memorySearch = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "session_id": .string(sessionID.uuidString),
+                "include_working": .bool(true),
+                "include_durable": .bool(true),
+                "include_episodic": .bool(false),
+                "topK": .int(8),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(memorySearch, command: "memory_search")
+
+        let corpusSearch = await service.handle(.init(
+            command: "corpus_search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "topK": .int(8),
+                "rebuild": .bool(true),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(corpusSearch, command: "corpus_search")
+    }
+}

--- a/Tests/WaxTests/WaxCLISurfaceParityTests.swift
+++ b/Tests/WaxTests/WaxCLISurfaceParityTests.swift
@@ -32,6 +32,11 @@ import Testing
     #expect(source.contains("DemoCommand.self"))
 }
 
+@Test func waxCLIExposesEmbedBackfillCommand() throws {
+    let source = try WaxCLISource.load("WaxCLICommand.swift")
+    #expect(source.contains("EmbedBackfillCommand.self"))
+}
+
 @Test func waxCLIParitySessionLifecycleUsesPersistentBroker() throws {
     let executable = try WaxCLIProcess.builtProductURL()
     let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/packaging/launchd/README.md
+++ b/packaging/launchd/README.md
@@ -1,0 +1,33 @@
+# Supervised wax-mcp HTTP LaunchAgent
+
+Product-owned wrapper + plist for `127.0.0.1:3000`. KeepAlive is the point: launchd must respawn the wrapper after SIGTERM.
+
+Agents must not run `launchctl`, bind `:3000`, or kill a live listener.
+
+Static check (safe for CI / agents):
+
+```
+bash packaging/launchd/test.sh
+```
+
+Install locations (after a human copies them):
+
+- wrapper → `~/.local/share/waxmcp/bin/start-wax-mcp-http.sh`
+- plist → `~/Library/LaunchAgents/ai.wax.mcp-http.plist`
+- logs → `~/.local/share/waxmcp/logs/`
+
+The runtime binary stays `$HOME/.local/share/waxmcp/runtime/darwin-arm64/wax-mcp`. Never Homebrew `waxmcp`.
+
+```
+# Chris, from a real Terminal — agents must not run this:
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.wax.mcp-http.plist  # ok if not loaded
+cp packaging/launchd/ai.wax.mcp-http.plist.template ~/Library/LaunchAgents/ai.wax.mcp-http.plist
+# substitute $HOME if the template uses it
+cp packaging/launchd/start-wax-mcp-http.sh ~/.local/share/waxmcp/bin/start-wax-mcp-http.sh
+chmod +x ~/.local/share/waxmcp/bin/start-wax-mcp-http.sh
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.wax.mcp-http.plist
+launchctl kickstart -k gui/$(id -u)/ai.wax.mcp-http
+lsof -nP -iTCP:3000 -sTCP:LISTEN
+```
+
+Pass after Chris runs it: listener is launchd’s child of the wrapper, not an Ishi shell pid.

--- a/packaging/launchd/README.md
+++ b/packaging/launchd/README.md
@@ -20,9 +20,13 @@ The runtime binary stays `$HOME/.local/share/waxmcp/runtime/darwin-arm64/wax-mcp
 
 ```
 # Chris, from a real Terminal — agents must not run this:
+# If lsof shows a listener that is not this LaunchAgent, stop that process first.
+# Do not have the wrapper kill anyone. kickstart -k only kills the launchd job.
+lsof -nP -iTCP:3000 -sTCP:LISTEN
 launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.wax.mcp-http.plist  # ok if not loaded
-cp packaging/launchd/ai.wax.mcp-http.plist.template ~/Library/LaunchAgents/ai.wax.mcp-http.plist
-# substitute $HOME if the template uses it
+mkdir -p ~/.local/share/waxmcp/bin ~/.local/share/waxmcp/logs ~/Library/LaunchAgents
+sed "s|\$HOME|$HOME|g" packaging/launchd/ai.wax.mcp-http.plist.template \
+  > ~/Library/LaunchAgents/ai.wax.mcp-http.plist
 cp packaging/launchd/start-wax-mcp-http.sh ~/.local/share/waxmcp/bin/start-wax-mcp-http.sh
 chmod +x ~/.local/share/waxmcp/bin/start-wax-mcp-http.sh
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.wax.mcp-http.plist

--- a/packaging/launchd/ai.wax.mcp-http.plist.template
+++ b/packaging/launchd/ai.wax.mcp-http.plist.template
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>ai.wax.mcp-http</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$HOME/.local/share/waxmcp/bin/start-wax-mcp-http.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>$HOME/.local/share/waxmcp/logs/http.stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>$HOME/.local/share/waxmcp/logs/http.stderr.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+</dict>
+</plist>

--- a/packaging/launchd/start-wax-mcp-http.sh
+++ b/packaging/launchd/start-wax-mcp-http.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Product-owned Wax MCP HTTP LaunchAgent wrapper.
+# Runtime binary is the waxmcp darwin-arm64 install, not Homebrew waxmcp.
+set -euo pipefail
+
+export WAX_MCP_FEATURE_LICENSE="${WAX_MCP_FEATURE_LICENSE:-0}"
+export WAX_EMBEDDER_ALLOW_LOW_PRECISION_GPU="${WAX_EMBEDDER_ALLOW_LOW_PRECISION_GPU:-1}"
+export WAX_EMBEDDER_BATCH_SIZE="${WAX_EMBEDDER_BATCH_SIZE:-1}"
+export WAX_EMBEDDER_PREWARM_BATCH_SIZE="${WAX_EMBEDDER_PREWARM_BATCH_SIZE:-1}"
+export WAX_EMBEDDER_TIMEOUT_SECS="${WAX_EMBEDDER_TIMEOUT_SECS:-120.0}"
+export WAX_EMBEDDER_COMPUTE_UNITS="${WAX_EMBEDDER_COMPUTE_UNITS:-cpuAndNeuralEngine,cpuOnly,cpuAndGPU,all}"
+
+BIN="${WAX_MCP_BIN:-$HOME/.local/share/waxmcp/runtime/darwin-arm64/wax-mcp}"
+STORE="${WAX_STORE_PATH:-$HOME/.wax/memory.wax}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "start-wax-mcp-http: BIN is not executable: $BIN" >&2
+  exit 1
+fi
+
+if [[ ! -e "$STORE" ]]; then
+  echo "start-wax-mcp-http: STORE is missing: $STORE" >&2
+  exit 1
+fi
+
+if command -v lsof >/dev/null 2>&1; then
+  holder="$(lsof -nP -iTCP:3000 -sTCP:LISTEN -t 2>/dev/null | head -n1 || true)"
+  if [[ -n "${holder}" ]]; then
+    echo "start-wax-mcp-http: port 3000 already held by pid $holder; not killing" >&2
+    exit 1
+  fi
+fi
+
+exec "$BIN" \
+  --store-path "$STORE" \
+  --embedder minilm \
+  --transport http \
+  --http-host 127.0.0.1 \
+  --http-port 3000 \
+  --http-endpoint /mcp

--- a/packaging/launchd/test.sh
+++ b/packaging/launchd/test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Static contract tests for the LaunchAgent wrapper + plist.
+# Do not start wax-mcp. Do not bind :3000. Do not run launchctl.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+WRAP="$ROOT/start-wax-mcp-http.sh"
+PLIST="$ROOT/ai.wax.mcp-http.plist.template"
+failures=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  failures=$((failures + 1))
+}
+
+pass() {
+  echo "PASS: $*"
+}
+
+if [[ ! -f "$WRAP" ]]; then
+  fail "missing wrapper $WRAP"
+else
+  if grep -q 'set -euo pipefail' "$WRAP"; then
+    pass "wrapper has set -euo pipefail"
+  else
+    fail "wrapper missing set -euo pipefail"
+  fi
+
+  if grep -q 'wax-mcp' "$WRAP" \
+    && grep -q -- '--transport http' "$WRAP" \
+    && grep -q -- '--http-port 3000' "$WRAP"; then
+    pass "wrapper execs wax-mcp with --transport http and --http-port 3000"
+  else
+    fail "wrapper must exec wax-mcp with --transport http and --http-port 3000"
+  fi
+
+  if grep -q '0.1.26' "$WRAP"; then
+    fail "wrapper must not contain 0.1.26"
+  else
+    pass "wrapper does not contain 0.1.26"
+  fi
+fi
+
+if [[ ! -f "$PLIST" ]]; then
+  fail "missing plist template $PLIST"
+else
+  if grep -q '<string>ai.wax.mcp-http</string>' "$PLIST" \
+    && grep -A1 '<key>KeepAlive</key>' "$PLIST" | grep -q '<true/>'; then
+    pass "plist Label ai.wax.mcp-http and KeepAlive true"
+  else
+    fail "plist must have Label ai.wax.mcp-http and KeepAlive true"
+  fi
+
+  first="$(
+    awk '
+      /<key>ProgramArguments<\/key>/ { found=1; next }
+      found && /<array>/ { inarr=1; next }
+      inarr && /<string>/ {
+        gsub(/.*<string>/, "")
+        gsub(/<\/string>.*/, "")
+        print
+        exit
+      }
+    ' "$PLIST"
+  )"
+  case "$first" in
+    *start-wax-mcp-http.sh)
+      pass "plist ProgramArguments[0] ends with start-wax-mcp-http.sh"
+      ;;
+    *)
+      fail "plist ProgramArguments[0] must end with start-wax-mcp-http.sh (got: ${first:-<empty>})"
+      ;;
+  esac
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "test.sh: $failures failure(s)" >&2
+  exit 1
+fi
+
+echo "test.sh: all checks passed"

--- a/packaging/launchd/test.sh
+++ b/packaging/launchd/test.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 WRAP="$ROOT/start-wax-mcp-http.sh"
 PLIST="$ROOT/ai.wax.mcp-http.plist.template"
+README="$ROOT/README.md"
 failures=0
 
 fail() {
@@ -71,6 +72,24 @@ else
       fail "plist ProgramArguments[0] must end with start-wax-mcp-http.sh (got: ${first:-<empty>})"
       ;;
   esac
+fi
+
+if [[ ! -f "$README" ]]; then
+  fail "missing README $README"
+else
+  if grep -q 'sed "s|\\$HOME|$HOME|g" packaging/launchd/ai.wax.mcp-http.plist.template' "$README" \
+    && ! grep -q '^cp packaging/launchd/ai.wax.mcp-http.plist.template' "$README"; then
+    pass "README substitutes \$HOME with sed (no bare template cp)"
+  else
+    fail "README must sed-substitute \$HOME; must not bare-cp the plist template"
+  fi
+
+  if grep -q 'lsof -nP -iTCP:3000 -sTCP:LISTEN' "$README" \
+    && grep -B20 'launchctl bootstrap' "$README" | grep -q 'lsof -nP -iTCP:3000 -sTCP:LISTEN'; then
+    pass "README checks :3000 is free before launchctl bootstrap"
+  else
+    fail "README must lsof :3000 before launchctl bootstrap (do not kill)"
+  fi
 fi
 
 if [[ "$failures" -ne 0 ]]; then


### PR DESCRIPTION
Three file-fenced units on the MCP line. Ticket WAX-2026-08-27-016-mcp-quality.

## What
- Ranking: hyphenated identifiers stay MatchPlan tokens; unique-token hit@1 vs name distractors on search/recall/memory_search/corpus_search.
- Hygiene CLI: `wax-cli compact-store` and `embed-backfill` copy-only. Refuse live `~/.wax/memory.wax` on source and dest. Fail-fast lock.
- Daemon packaging: KeepAlive wrapper + plist template. Chris bootstraps from Terminal (sed expands $HOME). Agents do not launchctl.

## Reviews
- u1 CLEAN (adversarial L) f8c16258
- u2 CLEAN after P1 dest-refuse fix 18d2b1db
- u3 CLEAN after P1 $HOME sed f3aaedf4

## Ishi tests
Named filters re-run on integration. Packaging `bash packaging/launchd/test.sh` PASS. Swift filters recorded in the land comment.

## Not in this PR
Live family migrate, launchctl, killing :3000, npm/Homebrew, Metal.

Do not graft onto performance. Do not restart #161/#162/#163/#165.