### PR TITLE
release: waxmcp v0.1.35

### DIFF
--- a/.pi/extensions/wax-agents/package.json
+++ b/.pi/extensions/wax-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-agents",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Wax-specific multi-agent orchestration for pi",
   "dependencies": {
     "typebox": "^1.0.0"

--- a/Resources/hermes/README.md
+++ b/Resources/hermes/README.md
@@ -98,7 +98,7 @@ Add to your Hermes `$HERMES_HOME/config.yaml`:
 mcp_servers:
   wax-memory:
     command: "npx"
-    args: ["-y", "waxmcp@0.1.34", "mcp", "serve"]
+    args: ["-y", "waxmcp@0.1.35", "mcp", "serve"]
     env:
       WAX_MCP_FEATURE_LICENSE: "0"
       WAX_MCP_FEATURE_STRUCTURED_MEMORY: "1"
@@ -115,7 +115,7 @@ mcp_servers:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `command` | `npx` | Launcher for waxmcp |
-| `args` | `["-y", "waxmcp@0.1.34", "mcp", "serve"]` | Arguments passed to waxmcp |
+| `args` | `["-y", "waxmcp@0.1.35", "mcp", "serve"]` | Arguments passed to waxmcp |
 | `env.WAX_MCP_FEATURE_LICENSE` | `"0"` | Disable license checks |
 | `env.WAX_MCP_FEATURE_STRUCTURED_MEMORY` | `"1"` | Enable structured memory tools |
 | `timeout` | `120` | MCP call timeout in seconds |

--- a/Resources/hermes/wax-memory-plugin/plugin.yaml
+++ b/Resources/hermes/wax-memory-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.34
+version: 0.1.35
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
+++ b/Resources/npm/waxmcp/homebrew-wax/Formula/wax.rb
@@ -1,7 +1,7 @@
 class Wax < Formula
   desc "On-device memory and RAG framework with MCP server for Claude Code"
   homepage "https://github.com/christopherkarani/Wax"
-  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.34.tar.gz"
+  url "https://github.com/christopherkarani/Wax/archive/refs/tags/waxmcp-v0.1.35.tar.gz"
   sha256 "4d0b2303dd57588222b1261e94059be2ea6666256373d4d1f9a3ce2b06b75831"
   license "MIT"
 

--- a/Resources/npm/waxmcp/package.json
+++ b/Resources/npm/waxmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxmcp",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "npx launcher for the Wax MCP server",
   "repository": {
     "type": "git",

--- a/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
+++ b/Resources/npm/waxmcp/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: wax-memory
-version: 0.1.34
+version: 0.1.35
 description: "Wax-backed native memory provider for Hermes Agent. Delegates to the Wax MCP broker over HTTP for cross-session persistence, RAG recall, structured memory, and managed Markdown projections."
 pip_dependencies:
   - requests>=2.28

--- a/Resources/openclaw/wax-memory-plugin/package.json
+++ b/Resources/openclaw/wax-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wax/openclaw-wax-memory",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "description": "OpenClaw memory plugin for Wax-backed agent memory.",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "openclaw": ">=2026.3.24-beta.2"
   },
   "dependencies": {
-    "waxmcp": "0.1.34"
+    "waxmcp": "0.1.35"
   },
   "devDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -8,7 +8,7 @@ struct WaxCLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wax-cli",
         abstract: "Wax developer CLI",
-        version: "0.1.34",
+        version: "0.1.35",
         subcommands: [
             RememberCommand.self,
             RecallCommand.self,

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -23,7 +23,7 @@ import WaxVectorSearchArctic
 #endif
 
 enum WaxMCPServerMetadata {
-    static let version = "0.1.34"
+    static let version = "0.1.35"
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
## Summary
- version surfaces 0.1.35 (same 9 files as 0.1.34)
- so SPM tag `0.1.35` includes #166 (ranking, compact-store/embed-backfill, KeepAlive packaging)

## Not in this PR
- npm publish
- Homebrew sha of the new tarball (placeholder until tag exists)
- live :3000 swap

## Verify
`scripts/validate-congruency.sh` → 0.1.35