### PR TITLE
fix: honest embed coverage, 8 MiB WAL default, stats framesWithoutVectors

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -968,6 +968,7 @@ extension AgentBrokerService {
         return .object([
             "frameCount": .from(stats.frameCount),
             "pendingFrames": .from(stats.pendingFrames),
+            "framesWithoutVectors": .from(stats.framesWithoutVectors),
             "generation": .from(stats.generation),
             "diskBytes": .from(diskBytes),
             "storePath": .string(stats.storeURL.path),

--- a/Sources/Wax/FrameStore.swift
+++ b/Sources/Wax/FrameStore.swift
@@ -30,7 +30,7 @@ public actor FrameStore {
         }
     }
 
-    public static let defaultWalSize: UInt64 = 256 * 1024 * 1024
+    public static let defaultWalSize: UInt64 = Constants.defaultWalSize
 
     private let session: WaxSession
     private let wax: Wax

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -2295,23 +2295,20 @@ package actor MemoryOrchestrator {
     }
 
     private static func framesWithoutVectorsCount(_ wax: Wax) async -> UInt64 {
-        let chunks = await wax.liveChunkCount()
-        guard chunks > 0 else { return 0 }
-        let pending = UInt64(await wax.pendingEmbeddingMutations().count)
-        let indexed = await wax.committedVecIndexManifest()?.vectorCount ?? 0
-        if chunks > indexed + pending {
-            return chunks - indexed - pending
-        }
-        return 0
+        UInt64((await unembeddedLiveSources(in: wax)).count)
     }
 
     private func unembeddedLiveSources() async -> [SurrogateSourceFrame] {
+        await Self.unembeddedLiveSources(in: wax)
+    }
+
+    private static func unembeddedLiveSources(in wax: Wax) async -> [SurrogateSourceFrame] {
         let sources = await wax.activeSurrogateSourceFrames()
-        let embedded = await embeddedFrameIds()
+        let embedded = await embeddedFrameIds(in: wax)
         return sources.filter { !embedded.contains($0.id) }
     }
 
-    private func embeddedFrameIds() async -> Set<UInt64> {
+    private static func embeddedFrameIds(in wax: Wax) async -> Set<UInt64> {
         var ids = Set<UInt64>()
         for pending in await wax.pendingEmbeddingMutations() {
             ids.insert(pending.frameId)

--- a/Sources/WaxCLI/StatsCommand.swift
+++ b/Sources/WaxCLI/StatsCommand.swift
@@ -28,6 +28,7 @@ struct StatsCommand: AsyncParsableCommand {
             case .text:
                 print("Store: \(brokerString(payload, "storePath") ?? store.storePath)")
                 print("Frames: \(brokerInt(payload, "frameCount") ?? 0) (\(brokerInt(payload, "pendingFrames") ?? 0) pending)")
+                print("Frames without vectors: \(brokerInt64(payload, "framesWithoutVectors") ?? 0)")
                 print("Generation: \(brokerInt(payload, "generation") ?? 0)")
                 let diskBytes = Int64(brokerInt64(payload, "diskBytes") ?? 0)
                 print("Disk: \(ByteCountFormatter.string(fromByteCount: diskBytes, countStyle: .file))")
@@ -70,6 +71,7 @@ struct StatsCommand: AsyncParsableCommand {
                 printJSON([
                     "frameCount": stats.frameCount,
                     "pendingFrames": stats.pendingFrames,
+                    "framesWithoutVectors": stats.framesWithoutVectors,
                     "generation": stats.generation,
                     "diskBytes": diskBytes,
                     "storePath": stats.storeURL.path,
@@ -103,6 +105,7 @@ struct StatsCommand: AsyncParsableCommand {
             case .text:
                 print("Store: \(stats.storeURL.path)")
                 print("Frames: \(stats.frameCount) (\(stats.pendingFrames) pending)")
+                print("Frames without vectors: \(stats.framesWithoutVectors)")
                 print("Generation: \(stats.generation)")
                 print("Disk: \(ByteCountFormatter.string(fromByteCount: Int64(diskBytes), countStyle: .file))")
                 print("MiniLM compiled: \(compiled ? "yes" : "no")")

--- a/Sources/WaxCore/Constants.swift
+++ b/Sources/WaxCore/Constants.swift
@@ -40,10 +40,17 @@ package enum Constants {
     /// WAL starts immediately after the header region.
     package static let walOffset: UInt64 = headerRegionSize
 
-    /// Default WAL size used by tests/examples (256 MiB).
-    package static let defaultWalSize: UInt64 = 256 * 1024 * 1024
+    /// WAL size for newly created long-term stores (8 MiB).
+    /// Existing 256 MiB files stay 256 MiB until copy-first compact; this only affects new creates.
+    package static let longTermWalSize: UInt64 = 8 * 1024 * 1024
 
-    /// WAL size for new broker virtual session stores only; open keeps existing WAL. Long-term stores keep `defaultWalSize`.
+    /// Historical long-term WAL size retained by existing stores until copy-first compact.
+    package static let legacyLargeWalSize: UInt64 = 256 * 1024 * 1024
+
+    /// Default WAL size for new long-term stores.
+    package static let defaultWalSize: UInt64 = longTermWalSize
+
+    /// WAL size for new broker virtual session stores only; open keeps existing WAL.
     package static let sessionWalSize: UInt64 = 4 * 1024 * 1024
 
     // MARK: - Decoder Limits (recommended defaults)

--- a/Tests/WaxCoreTests/DefaultWalSizeTests.swift
+++ b/Tests/WaxCoreTests/DefaultWalSizeTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import WaxCore
+
+@Test func createUsesLongTermWalSizeByDefault() async throws {
+    let url = TempFiles.uniqueURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let wax = try await Wax.create(at: url)
+    let walStats = await wax.walStats()
+    try await wax.close()
+
+    #expect(walStats.walSize == Constants.longTermWalSize)
+}
+
+@Test func emptyStoreLogicalSizeIsNotLegacyLargeWal() async throws {
+    let url = TempFiles.uniqueURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let wax = try await Wax.create(at: url)
+    try await wax.close()
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+    let logicalSize = try #require(attributes[.size] as? NSNumber).uint64Value
+    #expect(logicalSize < Constants.legacyLargeWalSize)
+}
+
+@Test func sessionWalSizeUnchanged() {
+    #expect(Constants.sessionWalSize == 4 * 1024 * 1024)
+}

--- a/Tests/WaxIntegrationTests/EmbeddingBackfillTests.swift
+++ b/Tests/WaxIntegrationTests/EmbeddingBackfillTests.swift
@@ -66,6 +66,75 @@ func backfillUnembeddedLiveChunksClearsDegradedAndRanksKnownHit() async throws {
 }
 
 @Test
+func backfillUnembeddedClearsDegradedWhenEverySourceFrameHasAVector() async throws {
+    try await TempFiles.withTempFile { url in
+        let provider = DeterministicTextEmbedder()
+        let staleText = "an old source frame whose vector remains in the index"
+        let currentText = "the live source frame that backfill must embed"
+
+        do {
+            let seeded = try await Memory(
+                at: url,
+                config: .init(
+                    requireOnDeviceProviders: false,
+                    embedding: .custom(provider)
+                )
+            )
+            try await seeded.save(staleText)
+            try await seeded.flush()
+            try await seeded.close()
+        }
+
+        do {
+            let textOnly = try await Memory(
+                at: url,
+                config: .init(
+                    enableVectorSearch: false,
+                    requireOnDeviceProviders: false
+                )
+            )
+            let staleResults = try await textOnly.search(
+                staleText,
+                options: .init(topK: 1, mode: .textOnly)
+            )
+            guard let staleFrameId = staleResults.items.first?.frameId else {
+                Issue.record("setup: expected the vectorized source frame to be searchable")
+                try await textOnly.close()
+                return
+            }
+            try await textOnly.delete(frameID: staleFrameId)
+            try await textOnly.save(currentText)
+            try await textOnly.flush()
+            try await textOnly.close()
+        }
+
+        let memory = try await Memory(
+            at: url,
+            config: .init(
+                requireOnDeviceProviders: false,
+                embedding: .custom(provider)
+            )
+        )
+        let before = await memory.stats()
+        #expect(before.framesWithoutVectors == 1)
+        guard case .degraded = before.embeddingStatus else {
+            Issue.record("expected degraded coverage before backfill, got \(before.embeddingStatus)")
+            try await memory.close()
+            return
+        }
+
+        let embedded = try await memory.backfillUnembedded()
+        #expect(embedded == 1)
+        try await memory.flush()
+
+        let after = await memory.stats()
+        #expect(after.framesWithoutVectors == 0)
+        #expect(after.embeddingStatus == .active(provider.identity))
+        try await memory.close()
+    }
+}
+
+@Test
 func backfillUnembeddedFailsClosedWithoutEmbedder() async throws {
     try await TempFiles.withTempFile { url in
         let memory = try await Memory(at: url) {

--- a/Tests/WaxIntegrationTests/EmbeddingReadinessMemoryTests.swift
+++ b/Tests/WaxIntegrationTests/EmbeddingReadinessMemoryTests.swift
@@ -497,6 +497,67 @@ func waitUntilReadyForRememberThrowsWhenCompileFails() async throws {
     }
 }
 
+@Test
+func framesWithoutVectorsCountsUnembeddedSourceFramesNotChunks() async throws {
+    try await TempFiles.withTempFile { url in
+        let provider = DeterministicTextEmbedder()
+        let staleText = "this source frame has a vector before deletion"
+        let currentText = "this live source frame still needs a vector"
+
+        do {
+            let seeded = try await Memory(
+                at: url,
+                config: .init(
+                    requireOnDeviceProviders: false,
+                    embedding: .custom(provider)
+                )
+            )
+            try await seeded.save(staleText)
+            try await seeded.flush()
+            try await seeded.close()
+        }
+
+        do {
+            let textOnly = try await Memory(
+                at: url,
+                config: .init(
+                    enableVectorSearch: false,
+                    requireOnDeviceProviders: false
+                )
+            )
+            let staleResults = try await textOnly.search(
+                staleText,
+                options: .init(topK: 1, mode: .textOnly)
+            )
+            guard let staleFrameId = staleResults.items.first?.frameId else {
+                Issue.record("setup: expected the vectorized source frame to be searchable")
+                try await textOnly.close()
+                return
+            }
+            try await textOnly.delete(frameID: staleFrameId)
+            try await textOnly.save(currentText)
+            try await textOnly.flush()
+            try await textOnly.close()
+        }
+
+        let reopened = try await Memory(
+            at: url,
+            config: .init(
+                requireOnDeviceProviders: false,
+                embedding: .custom(provider)
+            )
+        )
+        let stats = await reopened.stats()
+        #expect(stats.framesWithoutVectors == 1)
+        guard case .degraded = stats.embeddingStatus else {
+            Issue.record("expected degraded coverage for the live source without a vector, got \(stats.embeddingStatus)")
+            try await reopened.close()
+            return
+        }
+        try await reopened.close()
+    }
+}
+
 private enum TestReadinessError: Error {
     case boom
 }

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -1249,6 +1249,21 @@ func handoffRoundTripWorksOnBroker() async throws {
     }
 }
 
+@Test
+func statsPayloadIncludesFramesWithoutVectors() async throws {
+    try await withIsolatedBroker { service, _ in
+        let response = await service.handle(.init(command: "stats"))
+        #expect(response.ok == true, "stats failed: \(response.error ?? "nil")")
+
+        let data = try JSONEncoder().encode(response)
+        let json = try JSONSerialization.jsonObject(with: data)
+        let responseObject = try #require(json as? [String: Any])
+        let payload = try #require(responseObject["payload"] as? [String: Any])
+        let framesWithoutVectors = try #require(payload["framesWithoutVectors"] as? NSNumber)
+        #expect(framesWithoutVectors.int64Value >= 0)
+    }
+}
+
 private func recallItem(
     frameId: UInt64,
     score: Float,


### PR DESCRIPTION
Ticket WAX-2026-08-28-018-embed-wal. Three file-fenced units on the MCP line (0.1.35).

## Why
Live 0.1.35 scored Embed/WAL 3/10: `embeddingStatus=degraded` with no count, WAL ring still 256 MiB for **new** files.

## What
- u1: `framesWithoutVectors` counts unembedded **source frames** (same set as backfill). Degraded clears when every source frame has a vector.
- u2: new long-term `Wax.create` WAL is 8 MiB (`longTermWalSize`). `sessionWalSize` 4 MiB unchanged. Existing 256 MiB family files stay until copy-first compact (not this PR).
- u3: broker + CLI `stats` JSON/text include `framesWithoutVectors`.

## Reviews
Pi reviewers hung twice (grok-4.6 xhigh, 0% CPU). Ishi re-read diffs + named tests.

- u1 CLEAN e8c590db — Ishi 5 tests pass
- u2 CLEAN f1d24132 — Ishi 3 tests pass
- u3 CLEAN 32e14630 — Ishi 1 test pass (`--traits MCPServer`)

## Not in this PR
Live compact/swap of `~/.wax/memory.wax`. launchctl. version bump.

## Verify
```
xcrun swift test --filter 'framesWithoutVectorsCountsUnembeddedSourceFramesNotChunks|backfillUnembeddedClearsDegradedWhenEverySourceFrameHasAVector|embedBackfill'
xcrun swift test --filter 'createUsesLongTermWalSizeByDefault|emptyStoreLogicalSizeIsNotLegacyLargeWal|sessionWalSizeUnchanged'
xcrun swift test --traits MCPServer --filter statsPayloadIncludesFramesWithoutVectors
```