### PR TITLE
fix: reconcile released memory reliability work onto main

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,36 @@ Then send JSON-line commands:
 > [!NOTE]
 > Vector search requires the embedder. If it's unavailable, hybrid/vector commands fail loudly instead of silently falling back to text-only mode.
 
+### Repair a store safely
+
+The offline maintenance commands always require an explicit source, destination,
+and direct-file opt-in. They take a locked, byte-verified copy of the source,
+perform the work in a staging file, deep-verify it, and atomically publish the
+destination. The source is not modified. A destination that already exists must
+be a regular, unlocked file and requires `--overwrite`; symlink and live-store
+aliases are rejected.
+
+```bash
+# Compact a degraded or legacy store without touching the source.
+wax-cli compact-store \
+  --direct-store \
+  --no-embedder \
+  --store-path /path/to/source.wax \
+  --output /path/to/compacted.wax
+
+# Backfill missing vectors on a verified copy (requires an embedder build).
+wax-cli embed-backfill \
+  --direct-store \
+  --store-path /path/to/source.wax \
+  --output /path/to/backfilled.wax
+```
+
+Use `--overwrite` only when replacing an existing destination is intentional.
+Do not point either command at `~/.wax/memory.wax` or another broker-managed
+live-store path; stop attached writers first and use `--format json` when the
+result is consumed by automation. The commands report `sourceUnchanged` and
+`deepVerified` on successful JSON output.
+
 ---
 
 ## Agent Quick Start

--- a/Resources/WaxDemo/Sources/WaxDemo/main.swift
+++ b/Resources/WaxDemo/Sources/WaxDemo/main.swift
@@ -215,7 +215,7 @@ private func runFrameStore(storeURL: URL) async throws {
     let payloadText = "FrameStore stress payload \(UUID().uuidString)"
     let payload = Data(payloadText.utf8)
 
-    // Use a modest WAL so stress runs stay light; production default is 256 MiB.
+    // Use a modest WAL so stress runs stay light; production default is 8 MiB.
     let store = try await FrameStore.create(at: storeURL, walSize: 4 * 1024 * 1024)
     let frameID = try await store.put(payload, kind: "note", metadata: ["demo": "framestore"])
     print("PUT_ID \(frameID)")

--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -18,6 +18,7 @@ Source: `Sources/Wax/Memory.swift`
 - Deprecated aliases: `search(_:strategy:options:)` and `search(_:strategy:options:reranker:)` (generic shims; use the existential form)
 - `public func delete(frameID: UInt64) async throws` — soft-deletes the frame and removes it from enabled text and vector indexes (committed).
 - `public func flush() async throws` — commits pending writes (WAL, FTS, vector index) to durable storage.
+- `public func backfillUnembedded() async throws -> UInt64` — embeds live searchable frames that have no vectors using the attached provider. Idempotent. Throws `WaxError.missingEmbedder` when no provider is attached; never invents vectors. Call `flush()` to commit.
 - `public func close() async throws` — flushes, then closes.
 - `public func stats() async -> Memory.Stats`
 
@@ -55,7 +56,7 @@ Source: `Sources/Wax/RAG/RAGContext.swift`
 
 ### Memory.Stats
 
-`public struct Stats: Sendable, Equatable` with `frameCount`, `pendingFrames`, `vectorSearchEnabled`, `queryEmbedderConfigured`, `queryEmbeddingCircuitOpen`, `embedderIdentity: EmbeddingIdentity?`, `embeddingStatus: EmbeddingStatus`.
+`public struct Stats: Sendable, Equatable` with `frameCount`, `pendingFrames`, `vectorSearchEnabled`, `queryEmbedderConfigured`, `queryEmbeddingCircuitOpen`, `embedderIdentity: EmbeddingIdentity?`, `embeddingStatus: EmbeddingStatus`, `framesWithoutVectors`.
 
 `queryEmbedderConfigured` is derived: `true` only for `active` and `degraded`.
 

--- a/Resources/website/docs/core/file-format.md
+++ b/Resources/website/docs/core/file-format.md
@@ -15,7 +15,7 @@ Offset          Region              Size
 ──────          ──────              ────
 0 KiB           Header Page A       4 KiB
 4 KiB           Header Page B       4 KiB
-8 KiB           WAL Ring Buffer     Configurable (default 256 MiB)
+8 KiB           WAL Ring Buffer     Configurable (default 8 MiB)
 WAL + 8 KiB     Frame Payloads      Variable
 After Payloads  TOC                 Variable
 After TOC       Footer              64 bytes
@@ -121,7 +121,7 @@ Frame payloads support four encoding strategies via `CanonicalEncoding`:
 | Header region (A+B) | 8 KiB |
 | Footer size | 64 bytes |
 | WAL record header | 48 bytes |
-| Default WAL size | 256 MiB |
+| Default WAL size | 8 MiB |
 | Max string bytes | 16 MiB |
 | Max blob bytes | 256 MiB |
 | Max array count | 10,000,000 |

--- a/Resources/website/docs/core/store-maintenance.md
+++ b/Resources/website/docs/core/store-maintenance.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 2
+title: "Store maintenance"
+sidebar_label: "Store maintenance"
+---
+
+# Store maintenance
+
+`wax-cli` provides two offline repair commands for a store with stale or
+missing vectors. Both commands are copy-first: they snapshot the source under
+an advisory read lock, work in a sibling staging file, run deep verification,
+and atomically publish the requested output. A successful operation leaves the
+source file unchanged.
+
+## Compact a store
+
+Compaction rewrites committed frames and drops payloads that are no longer
+live. It also sizes the destination WAL from encoded frame metadata and payload
+requirements.
+
+```bash
+wax-cli compact-store \
+  --direct-store \
+  --no-embedder \
+  --store-path /path/to/source.wax \
+  --output /path/to/compacted.wax
+```
+
+`--direct-store`, `--store-path`, and `--output` are required. Add
+`--overwrite` to replace an existing destination. Existing destinations must
+be regular, unlocked files; directories, symlinks, hard-link aliases, and the
+broker-managed live store are refused.
+
+## Backfill missing vectors
+
+Backfill embeds live searchable frames that have no vector on a verified copy.
+It is idempotent and requires a build with an embedding provider (for example,
+the `MiniLMEmbeddings` trait).
+
+```bash
+wax-cli embed-backfill \
+  --direct-store \
+  --store-path /path/to/source.wax \
+  --output /path/to/backfilled.wax
+```
+
+The command also requires `--direct-store` and `--output`; `--no-embedder`
+fails closed. Use `--overwrite` only for an intentional replacement. JSON
+output includes the examined/embedded counts, remaining `framesWithoutVectors`,
+`sourceUnchanged`, and `deepVerified` fields:
+
+```bash
+wax-cli embed-backfill --direct-store \
+  --store-path /path/to/source.wax \
+  --output /path/to/backfilled.wax --format json
+```
+
+These commands are operator tools, not a substitute for the broker's normal
+shared live-store flow. Stop attached writers before repair; the advisory lock
+probe cannot prevent an unrelated process from swapping a pathname after the
+probe, so Wax rechecks path type and file identity immediately before
+promotion and fails closed during rollback if the destination has changed.

--- a/Resources/website/docs/core/wal-crash-recovery.md
+++ b/Resources/website/docs/core/wal-crash-recovery.md
@@ -16,7 +16,7 @@ The WAL (Write-Ahead Log) is a fixed-size circular ring buffer that records all 
 
 ## Ring Buffer Architecture
 
-The WAL occupies a contiguous region starting at file offset 8 KiB. Its default size is 256 MiB, configurable at creation time. The ring buffer uses two pointers:
+The WAL occupies a contiguous region starting at file offset 8 KiB. Its default size is 8 MiB, configurable at creation time. The ring buffer uses two pointers:
 
 - **Write position** — where the next record will be written
 - **Checkpoint position** — the boundary of committed records

--- a/Resources/website/sidebars.js
+++ b/Resources/website/sidebars.js
@@ -25,6 +25,7 @@ const sidebars = {
         "media/photo-rag",
         "media/video-rag",
         "core/getting-started",
+        "core/store-maintenance",
         "core/file-format",
         "core/wal-crash-recovery",
         "core/structured-memory",

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -951,6 +951,7 @@ extension AgentBrokerService {
         return .object([
             "frameCount": .from(stats.frameCount),
             "pendingFrames": .from(stats.pendingFrames),
+            "framesWithoutVectors": .from(stats.framesWithoutVectors),
             "generation": .from(stats.generation),
             "diskBytes": .from(diskBytes),
             "storePath": .string(stats.storeURL.path),

--- a/Sources/Wax/FrameStore.swift
+++ b/Sources/Wax/FrameStore.swift
@@ -30,7 +30,7 @@ public actor FrameStore {
         }
     }
 
-    public static let defaultWalSize: UInt64 = 256 * 1024 * 1024
+    public static let defaultWalSize: UInt64 = Constants.defaultWalSize
 
     private let session: WaxSession
     private let wax: Wax

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -209,6 +209,16 @@ public actor Memory {
         try await orchestrator.flush()
     }
 
+    /// Embed live searchable frames that have no vectors, using the attached provider.
+    ///
+    /// Idempotent: frames that already have pending or committed vectors are skipped.
+    /// Throws ``WaxError/missingEmbedder`` when no provider is attached — never invents vectors.
+    /// Call ``flush()`` afterward to commit the new vectors.
+    @discardableResult
+    public func backfillUnembedded() async throws -> UInt64 {
+        try await orchestrator.backfillUnembedded()
+    }
+
     /// Close the memory handle and release resources.
     public func close() async throws {
         try await orchestrator.close()
@@ -230,6 +240,8 @@ public actor Memory {
         public var embedderIdentity: EmbeddingIdentity?
         /// Readiness of the embedding provider attached to this store.
         public var embeddingStatus: EmbeddingStatus
+        /// Live searchable frames that currently have no pending or committed vector.
+        public var framesWithoutVectors: UInt64
 
         public init(
             frameCount: UInt64,
@@ -238,7 +250,8 @@ public actor Memory {
             queryEmbedderConfigured: Bool,
             queryEmbeddingCircuitOpen: Bool,
             embedderIdentity: EmbeddingIdentity?,
-            embeddingStatus: EmbeddingStatus = .disabled
+            embeddingStatus: EmbeddingStatus = .disabled,
+            framesWithoutVectors: UInt64 = 0
         ) {
             self.frameCount = frameCount
             self.pendingFrames = pendingFrames
@@ -247,6 +260,7 @@ public actor Memory {
             self.queryEmbeddingCircuitOpen = queryEmbeddingCircuitOpen
             self.embedderIdentity = embedderIdentity
             self.embeddingStatus = embeddingStatus
+            self.framesWithoutVectors = framesWithoutVectors
         }
     }
 
@@ -263,7 +277,8 @@ public actor Memory {
             queryEmbedderConfigured: runtime.embeddingStatus.isQueryEmbedderConfigured,
             queryEmbeddingCircuitOpen: runtime.queryEmbeddingCircuitOpen,
             embedderIdentity: runtime.embeddingStatus.identity,
-            embeddingStatus: runtime.embeddingStatus
+            embeddingStatus: runtime.embeddingStatus,
+            framesWithoutVectors: runtime.framesWithoutVectors
         )
     }
 

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -752,6 +752,7 @@ package extension MemoryOrchestrator {
         let destinationURL: URL
         let backupURL: URL?
         let publishedIdentity: FileIdentity?
+        let backupIdentity: FileIdentity?
     }
 
     private static func rewriteStagingURL(for destinationURL: URL) -> URL {
@@ -812,14 +813,17 @@ package extension MemoryOrchestrator {
                 destinationURL,
                 withItemAt: stagingURL,
                 backupItemName: backupName,
-                options: []
+                // Retain the prior live set until finalization has verified
+                // the published inode; rollback relies on this copy.
+                options: [.withoutDeletingBackupItem]
             )
             let backupURL = destinationURL.deletingLastPathComponent()
                 .appendingPathComponent(backupName)
             return RewritePromotion(
                 destinationURL: destinationURL,
                 backupURL: backupURL,
-                publishedIdentity: fileIdentity(at: destinationURL)
+                publishedIdentity: fileIdentity(at: destinationURL),
+                backupIdentity: fileIdentity(at: backupURL)
             )
         }
 
@@ -827,7 +831,8 @@ package extension MemoryOrchestrator {
         return RewritePromotion(
             destinationURL: destinationURL,
             backupURL: nil,
-            publishedIdentity: fileIdentity(at: destinationURL)
+            publishedIdentity: fileIdentity(at: destinationURL),
+            backupIdentity: nil
         )
     }
 
@@ -837,7 +842,60 @@ package extension MemoryOrchestrator {
         // recursively remove a changed directory or symlink; leave it and
         // surface the rollback failure for operator recovery instead.
         let fileManager = FileManager.default
-        if fileManager.fileExists(atPath: promotion.destinationURL.path) {
+        if let backupURL = promotion.backupURL {
+            // Validate and pin the rollback source before touching the
+            // published destination. If it disappeared or changed, retain the
+            // published output for operator recovery.
+            guard fileManager.fileExists(atPath: backupURL.path),
+                  !isSymbolicLink(at: backupURL),
+                  isRegularFile(at: backupURL),
+                  let expected = promotion.backupIdentity,
+                  fileIdentity(at: backupURL) == expected else {
+                throw WaxError.io(
+                    "rewriteLiveSet rollback retained published output because the backup changed or disappeared"
+                )
+            }
+
+            if fileManager.fileExists(atPath: promotion.destinationURL.path) {
+                guard !isSymbolicLink(at: promotion.destinationURL),
+                      let expected = promotion.publishedIdentity,
+                      fileIdentity(at: promotion.destinationURL) == expected else {
+                    throw WaxError.io(
+                        "rewriteLiveSet rollback refused to remove a destination path changed after promotion"
+                    )
+                }
+            }
+
+            let quarantine = promotion.destinationURL.deletingLastPathComponent()
+                .appendingPathComponent(".\(promotion.destinationURL.lastPathComponent)-rollback-\(UUID().uuidString)")
+            guard !fileManager.fileExists(atPath: quarantine.path) else {
+                throw WaxError.io("rewriteLiveSet rollback quarantine path already exists")
+            }
+            do {
+                if fileManager.fileExists(atPath: promotion.destinationURL.path) {
+                    try fileManager.moveItem(at: promotion.destinationURL, to: quarantine)
+                }
+                guard fileManager.fileExists(atPath: backupURL.path),
+                      !isSymbolicLink(at: backupURL),
+                      isRegularFile(at: backupURL),
+                      fileIdentity(at: backupURL) == expected else {
+                    throw WaxError.io(
+                        "rewriteLiveSet rollback retained published output because the backup changed during restore"
+                    )
+                }
+                try fileManager.moveItem(at: backupURL, to: promotion.destinationURL)
+                try? fileManager.removeItem(at: quarantine)
+            } catch {
+                // Restore the published inode when the backup race is
+                // detected after quarantine. Never overwrite a path another
+                // process recreated while rollback was in flight.
+                if fileManager.fileExists(atPath: quarantine.path),
+                   !fileManager.fileExists(atPath: promotion.destinationURL.path) {
+                    try? fileManager.moveItem(at: quarantine, to: promotion.destinationURL)
+                }
+                throw error
+            }
+        } else if fileManager.fileExists(atPath: promotion.destinationURL.path) {
             guard !isSymbolicLink(at: promotion.destinationURL),
                   let expected = promotion.publishedIdentity,
                   fileIdentity(at: promotion.destinationURL) == expected else {
@@ -847,22 +905,16 @@ package extension MemoryOrchestrator {
             }
             try fileManager.removeItem(at: promotion.destinationURL)
         }
-        if let backupURL = promotion.backupURL,
-           fileManager.fileExists(atPath: backupURL.path) {
-            guard !isSymbolicLink(at: backupURL), isRegularFile(at: backupURL) else {
-                throw WaxError.io("rewriteLiveSet rollback backup is no longer a regular file")
-            }
-            guard !fileManager.fileExists(atPath: promotion.destinationURL.path) else {
-                throw WaxError.io("rewriteLiveSet rollback destination reappeared before backup restore")
-            }
-            try fileManager.moveItem(at: backupURL, to: promotion.destinationURL)
-        }
     }
 
     private static func finalizeRewritePromotion(_ promotion: RewritePromotion) throws {
         guard let backupURL = promotion.backupURL else { return }
         let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: backupURL.path) else { return }
+        guard fileManager.fileExists(atPath: backupURL.path) else {
+            throw WaxError.io(
+                "rewriteLiveSet promotion backup disappeared; published output was retained"
+            )
+        }
 
         // Keep the rollback copy until the published destination is still the
         // inode that passed verification. If another writer replaced the
@@ -875,8 +927,12 @@ package extension MemoryOrchestrator {
                 "rewriteLiveSet promotion destination changed before backup cleanup"
             )
         }
-        guard isRegularFile(at: backupURL) else {
-            throw WaxError.io("rewriteLiveSet promotion backup is no longer a regular file")
+        guard isRegularFile(at: backupURL),
+              let expected = promotion.backupIdentity,
+              fileIdentity(at: backupURL) == expected else {
+            throw WaxError.io(
+                "rewriteLiveSet promotion backup changed before cleanup; published output was retained"
+            )
         }
         try fileManager.removeItem(at: backupURL)
     }
@@ -1021,8 +1077,17 @@ package extension MemoryOrchestrator {
         )
 
         let backupURL = sourceURL.deletingLastPathComponent().appendingPathComponent(backupName)
-        if FileManager.default.fileExists(atPath: backupURL.path) {
-            try? FileManager.default.removeItem(at: backupURL)
+        let promotion = RewritePromotion(
+            destinationURL: sourceURL,
+            backupURL: backupURL,
+            publishedIdentity: fileIdentity(at: sourceURL),
+            backupIdentity: fileIdentity(at: backupURL)
+        )
+        do {
+            try Self.finalizeRewritePromotion(promotion)
+        } catch {
+            try? Self.rollbackRewritePromotion(promotion)
+            throw error
         }
 
         if let footerSlice = try FooterScanner.findLastValidFooter(in: sourceURL) {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -1073,7 +1073,9 @@ package extension MemoryOrchestrator {
             sourceURL,
             withItemAt: candidateURL,
             backupItemName: backupName,
-            options: []
+            // Keep the prior live store until finalization verifies the
+            // published candidate; rollback relies on this copy.
+            options: [.withoutDeletingBackupItem]
         )
 
         let backupURL = sourceURL.deletingLastPathComponent().appendingPathComponent(backupName)

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -189,12 +189,21 @@ package extension MemoryOrchestrator {
         let sourceSizes = try Self.fileSizes(at: sourceURL)
         let sourceFrames = await wax.frameMetas()
         let sourceWalSize = (await wax.walStats()).walSize
+        let payloadLiveness = await wax.committedPayloadLivenessBytes()
+        let livePayloadBytes = payloadLiveness.totalPayloadBytes &- payloadLiveness.deadPayloadBytes
+        let payloadBytes = options.dropNonLivePayloads
+            ? livePayloadBytes
+            : payloadLiveness.totalPayloadBytes
+        let destinationWalSize = Self.walSizeForLiveSetRewrite(
+            sourceWalSize: sourceWalSize,
+            payloadBytes: payloadBytes
+        )
         let committedLexManifest = await wax.committedLexIndexManifest()
         let committedVecManifest = await wax.committedVecIndexManifest()
         let committedLexBytes = try await wax.readCommittedLexIndexBytes()
         let committedVecBytes = try await wax.readCommittedVecIndexBytes()
 
-        let rewritten = try await Wax.create(at: destinationURL, walSize: sourceWalSize)
+        let rewritten = try await Wax.create(at: destinationURL, walSize: destinationWalSize)
         var droppedPayloadFrames = 0
         do {
             for frame in sourceFrames {
@@ -561,6 +570,17 @@ package extension MemoryOrchestrator {
             searchText: frame.searchText,
             metadata: frame.metadata
         )
+    }
+
+    /// Destination WAL is payload-derived: never clone a large empty source ring,
+    /// never go below `Constants.sessionWalSize` when the source ring allows it,
+    /// and never exceed the source ring.
+    static func walSizeForLiveSetRewrite(sourceWalSize: UInt64, payloadBytes: UInt64) -> UInt64 {
+        let floor = Constants.sessionWalSize
+        let cap = sourceWalSize
+        let boundedFloor = min(floor, cap)
+        let needed = max(boundedFloor, payloadBytes)
+        return min(cap, needed)
     }
 
     private static func fileSizes(at url: URL) throws -> (logical: UInt64, allocated: UInt64) {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -170,21 +170,56 @@ package extension MemoryOrchestrator {
         let clock = ContinuousClock()
         let started = clock.now
 
-        try await session.commit()
+        let sourceInputURL = (await wax.fileURL()).standardizedFileURL
+        let destinationInputURL = destinationURL.standardizedFileURL
+        guard !Self.isSymbolicLink(at: sourceInputURL),
+              !Self.isSymbolicLink(at: destinationInputURL)
+        else {
+            throw WaxError.io("rewriteLiveSet refuses symlink source or destination")
+        }
 
-        let sourceURL = (await wax.fileURL()).standardizedFileURL
-        let destinationURL = destinationURL.standardizedFileURL
+        let sourceURL = sourceInputURL.resolvingSymlinksInPath().standardizedFileURL
+        let destinationURL = destinationInputURL.resolvingSymlinksInPath().standardizedFileURL
         guard sourceURL != destinationURL else {
             throw WaxError.io("rewriteLiveSet destination must differ from source")
+        }
+        guard !Self.sameFileIdentity(sourceURL, destinationURL) else {
+            throw WaxError.io("rewriteLiveSet destination aliases source")
         }
 
         let fileManager = FileManager.default
         if fileManager.fileExists(atPath: destinationURL.path) {
+            guard let attributes = try? fileManager.attributesOfItem(atPath: destinationURL.path),
+                  let type = attributes[.type] as? FileAttributeType,
+                  type == .typeRegular
+            else {
+                throw WaxError.io("rewriteLiveSet destination must be a regular file")
+            }
             guard options.overwriteDestination else {
                 throw WaxError.io("rewriteLiveSet destination already exists")
             }
-            try fileManager.removeItem(at: destinationURL)
+            guard try StoreLockProbe.tryExclusiveAccess(at: destinationURL) else {
+                throw WaxError.lockUnavailable(
+                    "rewriteLiveSet destination is locked by another process: \(destinationURL.path)"
+                )
+            }
         }
+
+        try await session.commit()
+
+        // Build beside the requested destination. Creating directly at an
+        // overwrite path would truncate the previous output before the new
+        // store has passed verification, and it leaves a promotion race if a
+        // destination is created after preflight.
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let stagingURL = Self.rewriteStagingURL(for: destinationURL)
+        guard !fileManager.fileExists(atPath: stagingURL.path) else {
+            throw WaxError.io("rewriteLiveSet staging path already exists")
+        }
+        defer { try? fileManager.removeItem(at: stagingURL) }
 
         let sourceSizes = try Self.fileSizes(at: sourceURL)
         let sourceFrames = await wax.frameMetas()
@@ -194,17 +229,34 @@ package extension MemoryOrchestrator {
         let payloadBytes = options.dropNonLivePayloads
             ? livePayloadBytes
             : payloadLiveness.totalPayloadBytes
+        let frameWalBytes = try Self.rewriteFrameWalBytes(
+            frames: sourceFrames,
+            dropNonLivePayloads: options.dropNonLivePayloads
+        )
         let destinationWalSize = Self.walSizeForLiveSetRewrite(
             sourceWalSize: sourceWalSize,
-            payloadBytes: payloadBytes
+            payloadBytes: payloadBytes,
+            largestFrameWalBytes: frameWalBytes.largest,
+            totalFrameWalBytes: frameWalBytes.total
         )
+        guard frameWalBytes.largest <= destinationWalSize else {
+            throw WaxError.capacityExceeded(
+                limit: destinationWalSize,
+                requested: frameWalBytes.largest
+            )
+        }
         let committedLexManifest = await wax.committedLexIndexManifest()
         let committedVecManifest = await wax.committedVecIndexManifest()
         let committedLexBytes = try await wax.readCommittedLexIndexBytes()
         let committedVecBytes = try await wax.readCommittedVecIndexBytes()
 
-        let rewritten = try await Wax.create(at: destinationURL, walSize: destinationWalSize)
+        let rewritten = try await Wax.create(at: stagingURL, walSize: destinationWalSize)
         var droppedPayloadFrames = 0
+        let shouldBatchFrameWrites = frameWalBytes.total > destinationWalSize
+        let batchCommitThreshold = max(
+            UInt64(Constants.walRecordHeaderSize),
+            destinationWalSize / 2
+        )
         do {
             for frame in sourceFrames {
                 let isLiveFrame = frame.status == .active && frame.supersededBy == nil
@@ -229,6 +281,15 @@ package extension MemoryOrchestrator {
                     throw WaxError.invalidToc(
                         reason: "rewriteLiveSet frame id mismatch: expected \(frame.id), got \(rewrittenId)"
                     )
+                }
+
+                // Metadata-rich frames can make the aggregate rewrite larger
+                // than one WAL ring. Commit bounded batches before staging
+                // index manifests; the final commit then only publishes the
+                // index manifests and any small tail batch.
+                if shouldBatchFrameWrites,
+                   (await rewritten.walStats()).pendingBytes >= batchCommitThreshold {
+                    try await rewritten.commit()
                 }
             }
 
@@ -256,8 +317,26 @@ package extension MemoryOrchestrator {
             try await rewritten.close()
         } catch {
             try? await rewritten.close()
-            try? fileManager.removeItem(at: destinationURL)
             throw error
+        }
+
+        var promotion: RewritePromotion?
+        do {
+            promotion = try Self.promoteRewriteOutput(
+                from: stagingURL,
+                to: destinationURL,
+                source: sourceURL,
+                overwrite: options.overwriteDestination
+            )
+            try await Self.verifyRewriteOutput(at: destinationURL, deep: options.verifyDeep)
+        } catch {
+            if let promotion {
+                try? Self.rollbackRewritePromotion(promotion)
+            }
+            throw error
+        }
+        if let backup = promotion?.backupURL {
+            try? fileManager.removeItem(at: backup)
         }
 
         let destinationSizes = try Self.fileSizes(at: destinationURL)
@@ -572,15 +651,159 @@ package extension MemoryOrchestrator {
         )
     }
 
-    /// Destination WAL is payload-derived: never clone a large empty source ring,
-    /// never go below `Constants.sessionWalSize` when the source ring allows it,
-    /// and never exceed the source ring.
-    static func walSizeForLiveSetRewrite(sourceWalSize: UInt64, payloadBytes: UInt64) -> UInt64 {
+    /// Destination WAL is payload- and frame-metadata-derived: never clone a
+    /// large empty source ring, never go below `Constants.sessionWalSize` when
+    /// the source ring allows it, and never exceed the source ring.
+    static func walSizeForLiveSetRewrite(
+        sourceWalSize: UInt64,
+        payloadBytes: UInt64,
+        largestFrameWalBytes: UInt64 = 0,
+        totalFrameWalBytes: UInt64 = 0
+    ) -> UInt64 {
         let floor = Constants.sessionWalSize
         let cap = sourceWalSize
         let boundedFloor = min(floor, cap)
-        let needed = max(boundedFloor, payloadBytes)
+        let needed = max(
+            boundedFloor,
+            max(payloadBytes, max(largestFrameWalBytes, totalFrameWalBytes))
+        )
         return min(cap, needed)
+    }
+
+    /// A put-frame WAL entry contains the complete frame metadata, not only
+    /// the payload bytes stored outside the ring. Estimate both the largest
+    /// entry (the hard per-entry capacity requirement) and aggregate entries
+    /// (the useful one-commit capacity requirement) before creating the
+    /// destination. The aggregate includes one conservative wrap/header unit
+    /// per frame; if it exceeds the source ring, Wax commits in batches.
+    private static func rewriteFrameWalBytes(
+        frames: [FrameMeta],
+        dropNonLivePayloads: Bool
+    ) throws -> (largest: UInt64, total: UInt64) {
+        let zeroChecksum = Data(repeating: 0, count: 32)
+        var largest: UInt64 = 0
+        var total: UInt64 = 0
+
+        for frame in frames {
+            let isLiveFrame = frame.status == .active && frame.supersededBy == nil
+            let payloadLength = dropNonLivePayloads && !isLiveFrame ? 0 : frame.payloadLength
+            let canonicalEncoding = dropNonLivePayloads && !isLiveFrame
+                ? CanonicalEncoding.plain
+                : frame.canonicalEncoding
+            let canonicalLength = dropNonLivePayloads && !isLiveFrame
+                ? 0
+                : (frame.canonicalLength ?? frame.payloadLength)
+            let put = PutFrame(
+                frameId: frame.id,
+                timestampMs: frame.timestamp,
+                options: subsetForRewrite(from: frame),
+                payloadOffset: 0,
+                payloadLength: payloadLength,
+                canonicalEncoding: canonicalEncoding,
+                canonicalLength: canonicalLength,
+                canonicalChecksum: zeroChecksum,
+                storedChecksum: zeroChecksum
+            )
+            let recordBytes = try WALSizing.putFrameRecordBytes(put)
+            largest = max(largest, recordBytes)
+            let (nextTotal, overflowed) = total.addingReportingOverflow(recordBytes)
+            total = overflowed ? UInt64.max : nextTotal
+        }
+
+        let perFrameOverhead = UInt64(frames.count)
+            .multipliedReportingOverflow(by: Constants.walRecordHeaderSize)
+        let (conservativeTotal, overflowed) = total.addingReportingOverflow(perFrameOverhead.partialValue)
+        return (
+            largest: largest,
+            total: overflowed || perFrameOverhead.overflow ? UInt64.max : conservativeTotal
+        )
+    }
+
+    private struct RewritePromotion {
+        let destinationURL: URL
+        let backupURL: URL?
+    }
+
+    private static func rewriteStagingURL(for destinationURL: URL) -> URL {
+        let baseName = destinationURL.deletingPathExtension().lastPathComponent
+        let extensionName = destinationURL.pathExtension.isEmpty ? "wax" : destinationURL.pathExtension
+        return destinationURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(baseName)-rewrite-\(UUID().uuidString)")
+            .appendingPathExtension(extensionName)
+    }
+
+    private static func promoteRewriteOutput(
+        from stagingURL: URL,
+        to destinationURL: URL,
+        source sourceURL: URL,
+        overwrite: Bool
+    ) throws -> RewritePromotion {
+        let fileManager = FileManager.default
+        guard !isSymbolicLink(at: stagingURL), !isSymbolicLink(at: destinationURL) else {
+            throw WaxError.io("rewriteLiveSet refuses symlink staging or destination")
+        }
+        guard let stagingAttributes = try? fileManager.attributesOfItem(atPath: stagingURL.path),
+              let stagingType = stagingAttributes[.type] as? FileAttributeType,
+              stagingType == .typeRegular
+        else {
+            throw WaxError.io("rewriteLiveSet staging output must be a regular file")
+        }
+        guard fileManager.fileExists(atPath: stagingURL.path) else {
+            throw WaxError.io("rewriteLiveSet staging output is missing")
+        }
+        guard !sameFileIdentity(sourceURL, destinationURL) else {
+            throw WaxError.io("rewriteLiveSet destination aliases source")
+        }
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            guard let attributes = try? fileManager.attributesOfItem(atPath: destinationURL.path),
+                  let type = attributes[.type] as? FileAttributeType,
+                  type == .typeRegular
+            else {
+                throw WaxError.io("rewriteLiveSet destination must be a regular file")
+            }
+            guard overwrite else {
+                throw WaxError.io("rewriteLiveSet destination appeared during rewrite")
+            }
+            guard try StoreLockProbe.tryExclusiveAccess(at: destinationURL) else {
+                throw WaxError.lockUnavailable(
+                    "rewriteLiveSet destination is locked by another process: \(destinationURL.path)"
+                )
+            }
+            let backupName = ".\(destinationURL.lastPathComponent)-previous-\(UUID().uuidString)"
+            _ = try fileManager.replaceItemAt(
+                destinationURL,
+                withItemAt: stagingURL,
+                backupItemName: backupName,
+                options: []
+            )
+            let backupURL = destinationURL.deletingLastPathComponent()
+                .appendingPathComponent(backupName)
+            return RewritePromotion(destinationURL: destinationURL, backupURL: backupURL)
+        }
+
+        try fileManager.moveItem(at: stagingURL, to: destinationURL)
+        return RewritePromotion(destinationURL: destinationURL, backupURL: nil)
+    }
+
+    private static func rollbackRewritePromotion(_ promotion: RewritePromotion) throws {
+        let fileManager = FileManager.default
+        try? fileManager.removeItem(at: promotion.destinationURL)
+        if let backupURL = promotion.backupURL,
+           fileManager.fileExists(atPath: backupURL.path) {
+            try fileManager.moveItem(at: backupURL, to: promotion.destinationURL)
+        }
+    }
+
+    private static func verifyRewriteOutput(at url: URL, deep: Bool) async throws {
+        let store = try await Wax.open(at: url)
+        do {
+            try await store.verify(deep: deep)
+            try await store.close()
+        } catch {
+            try? await store.close()
+            throw error
+        }
     }
 
     private static func fileSizes(at url: URL) throws -> (logical: UInt64, allocated: UInt64) {
@@ -589,6 +812,27 @@ package extension MemoryOrchestrator {
         let allocatedValue = values.totalFileAllocatedSize ?? values.fileAllocatedSize ?? values.fileSize ?? 0
         let allocated = UInt64(max(0, allocatedValue))
         return (logical: logical, allocated: allocated)
+    }
+
+    private static func isSymbolicLink(at url: URL) -> Bool {
+        (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil
+    }
+
+    private static func sameFileIdentity(_ lhs: URL, _ rhs: URL) -> Bool {
+        guard let left = try? FileManager.default.attributesOfItem(atPath: lhs.path),
+              let right = try? FileManager.default.attributesOfItem(atPath: rhs.path),
+              let leftInode = (left[.systemFileNumber] as? NSNumber)?.uint64Value,
+              let rightInode = (right[.systemFileNumber] as? NSNumber)?.uint64Value,
+              leftInode == rightInode
+        else {
+            return false
+        }
+        guard let leftDevice = (left[.systemNumber] as? NSNumber)?.uint64Value,
+              let rightDevice = (right[.systemNumber] as? NSNumber)?.uint64Value
+        else {
+            return true
+        }
+        return leftDevice == rightDevice
     }
 
     private static func pruneScheduledRewriteCandidates(
@@ -630,9 +874,32 @@ package extension MemoryOrchestrator {
         let sourceURL = sourceURL.standardizedFileURL
         guard candidateURL != sourceURL else { return }
         guard FileManager.default.fileExists(atPath: candidateURL.path) else { return }
+        guard !isSymbolicLink(at: sourceURL), !isSymbolicLink(at: candidateURL) else {
+            throw WaxError.io("live-set promotion refuses symlink source or candidate")
+        }
+        let fileManager = FileManager.default
+        guard let sourceAttributes = try? fileManager.attributesOfItem(atPath: sourceURL.path),
+              let sourceType = sourceAttributes[.type] as? FileAttributeType,
+              sourceType == .typeRegular,
+              let candidateAttributes = try? fileManager.attributesOfItem(atPath: candidateURL.path),
+              let candidateType = candidateAttributes[.type] as? FileAttributeType,
+              candidateType == .typeRegular
+        else {
+            throw WaxError.io("live-set promotion requires regular source and candidate files")
+        }
+        guard try StoreLockProbe.tryExclusiveAccess(at: sourceURL) else {
+            throw WaxError.lockUnavailable(
+                "live-set promotion source is locked by another process: \(sourceURL.path)"
+            )
+        }
+        guard try StoreLockProbe.tryExclusiveAccess(at: candidateURL) else {
+            throw WaxError.lockUnavailable(
+                "live-set promotion candidate is locked by another process: \(candidateURL.path)"
+            )
+        }
 
         let backupName = "\(sourceURL.lastPathComponent).pre-liveset-\(UUID().uuidString)"
-        _ = try FileManager.default.replaceItemAt(
+        _ = try fileManager.replaceItemAt(
             sourceURL,
             withItemAt: candidateURL,
             backupItemName: backupName,

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -249,8 +249,12 @@ package extension MemoryOrchestrator {
         let committedVecManifest = await wax.committedVecIndexManifest()
         let committedLexBytes = try await wax.readCommittedLexIndexBytes()
         let committedVecBytes = try await wax.readCommittedVecIndexBytes()
+        let sourceMemoryBinding = await wax.memoryBinding()
 
         let rewritten = try await Wax.create(at: stagingURL, walSize: destinationWalSize)
+        if let sourceMemoryBinding {
+            try await rewritten.setMemoryBindingIfMissing(sourceMemoryBinding)
+        }
         var droppedPayloadFrames = 0
         let shouldBatchFrameWrites = frameWalBytes.total > destinationWalSize
         let batchCommitThreshold = max(
@@ -722,6 +726,7 @@ package extension MemoryOrchestrator {
     private struct RewritePromotion {
         let destinationURL: URL
         let backupURL: URL?
+        let publishedIdentity: FileIdentity?
     }
 
     private static func rewriteStagingURL(for destinationURL: URL) -> URL {
@@ -754,6 +759,9 @@ package extension MemoryOrchestrator {
         guard !sameFileIdentity(sourceURL, destinationURL) else {
             throw WaxError.io("rewriteLiveSet destination aliases source")
         }
+        guard isRegularFile(at: stagingURL), !isSymbolicLink(at: stagingURL) else {
+            throw WaxError.io("rewriteLiveSet staging output changed before promotion")
+        }
 
         if fileManager.fileExists(atPath: destinationURL.path) {
             guard let attributes = try? fileManager.attributesOfItem(atPath: destinationURL.path),
@@ -770,6 +778,10 @@ package extension MemoryOrchestrator {
                     "rewriteLiveSet destination is locked by another process: \(destinationURL.path)"
                 )
             }
+            guard isRegularFile(at: destinationURL),
+                  !isSymbolicLink(at: destinationURL) else {
+                throw WaxError.io("rewriteLiveSet destination changed before promotion")
+            }
             let backupName = ".\(destinationURL.lastPathComponent)-previous-\(UUID().uuidString)"
             _ = try fileManager.replaceItemAt(
                 destinationURL,
@@ -779,18 +791,45 @@ package extension MemoryOrchestrator {
             )
             let backupURL = destinationURL.deletingLastPathComponent()
                 .appendingPathComponent(backupName)
-            return RewritePromotion(destinationURL: destinationURL, backupURL: backupURL)
+            return RewritePromotion(
+                destinationURL: destinationURL,
+                backupURL: backupURL,
+                publishedIdentity: fileIdentity(at: destinationURL)
+            )
         }
 
         try fileManager.moveItem(at: stagingURL, to: destinationURL)
-        return RewritePromotion(destinationURL: destinationURL, backupURL: nil)
+        return RewritePromotion(
+            destinationURL: destinationURL,
+            backupURL: nil,
+            publishedIdentity: fileIdentity(at: destinationURL)
+        )
     }
 
     private static func rollbackRewritePromotion(_ promotion: RewritePromotion) throws {
+        // The advisory lock probe used before replace cannot prevent an
+        // unrelated process from swapping this pathname afterward. Never
+        // recursively remove a changed directory or symlink; leave it and
+        // surface the rollback failure for operator recovery instead.
         let fileManager = FileManager.default
-        try? fileManager.removeItem(at: promotion.destinationURL)
+        if fileManager.fileExists(atPath: promotion.destinationURL.path) {
+            guard !isSymbolicLink(at: promotion.destinationURL),
+                  let expected = promotion.publishedIdentity,
+                  fileIdentity(at: promotion.destinationURL) == expected else {
+                throw WaxError.io(
+                    "rewriteLiveSet rollback refused to remove a destination path changed after promotion"
+                )
+            }
+            try fileManager.removeItem(at: promotion.destinationURL)
+        }
         if let backupURL = promotion.backupURL,
            fileManager.fileExists(atPath: backupURL.path) {
+            guard !isSymbolicLink(at: backupURL), isRegularFile(at: backupURL) else {
+                throw WaxError.io("rewriteLiveSet rollback backup is no longer a regular file")
+            }
+            guard !fileManager.fileExists(atPath: promotion.destinationURL.path) else {
+                throw WaxError.io("rewriteLiveSet rollback destination reappeared before backup restore")
+            }
             try fileManager.moveItem(at: backupURL, to: promotion.destinationURL)
         }
     }
@@ -816,6 +855,34 @@ package extension MemoryOrchestrator {
 
     private static func isSymbolicLink(at url: URL) -> Bool {
         (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil
+    }
+
+    private static func isRegularFile(at url: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path),
+              !isSymbolicLink(at: url),
+              let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let type = attributes[.type] as? FileAttributeType
+        else {
+            return false
+        }
+        return type == .typeRegular
+    }
+
+    private struct FileIdentity: Equatable {
+        let device: UInt64?
+        let inode: UInt64?
+    }
+
+    private static func fileIdentity(at url: URL) -> FileIdentity? {
+        guard isRegularFile(at: url),
+              let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        else {
+            return nil
+        }
+        return FileIdentity(
+            device: (attributes[.systemNumber] as? NSNumber)?.uint64Value,
+            inode: (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+        )
     }
 
     private static func sameFileIdentity(_ lhs: URL, _ rhs: URL) -> Bool {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator+Maintenance.swift
@@ -262,7 +262,20 @@ package extension MemoryOrchestrator {
             destinationWalSize / 2
         )
         do {
-            for frame in sourceFrames {
+            for (index, frame) in sourceFrames.enumerated() {
+                if shouldBatchFrameWrites {
+                    let pendingBytes = (await rewritten.walStats()).pendingBytes
+                    let nextPayloadSize = frameWalBytes.payloadSizes[index]
+                    if pendingBytes > 0,
+                       !(await rewritten.canAppendWALPayload(payloadSize: nextPayloadSize)) {
+                        // Preflight the complete WAL record (including wrap
+                        // padding) before appending it. A post-write
+                        // threshold check is too late for a large metadata
+                        // record that follows a partially full batch.
+                        try await rewritten.commit()
+                    }
+                }
+
                 let isLiveFrame = frame.status == .active && frame.supersededBy == nil
                 let content: Data
                 let compression: CanonicalEncoding
@@ -333,14 +346,14 @@ package extension MemoryOrchestrator {
                 overwrite: options.overwriteDestination
             )
             try await Self.verifyRewriteOutput(at: destinationURL, deep: options.verifyDeep)
+            if let promotion {
+                try Self.finalizeRewritePromotion(promotion)
+            }
         } catch {
             if let promotion {
                 try? Self.rollbackRewritePromotion(promotion)
             }
             throw error
-        }
-        if let backup = promotion?.backupURL {
-            try? fileManager.removeItem(at: backup)
         }
 
         let destinationSizes = try Self.fileSizes(at: destinationURL)
@@ -683,10 +696,12 @@ package extension MemoryOrchestrator {
     private static func rewriteFrameWalBytes(
         frames: [FrameMeta],
         dropNonLivePayloads: Bool
-    ) throws -> (largest: UInt64, total: UInt64) {
+    ) throws -> (largest: UInt64, total: UInt64, payloadSizes: [Int]) {
         let zeroChecksum = Data(repeating: 0, count: 32)
         var largest: UInt64 = 0
         var total: UInt64 = 0
+        var payloadSizes: [Int] = []
+        payloadSizes.reserveCapacity(frames.count)
 
         for frame in frames {
             let isLiveFrame = frame.status == .active && frame.supersededBy == nil
@@ -709,6 +724,15 @@ package extension MemoryOrchestrator {
                 storedChecksum: zeroChecksum
             )
             let recordBytes = try WALSizing.putFrameRecordBytes(put)
+            let walHeaderSize = UInt64(Constants.walRecordHeaderSize)
+            guard recordBytes >= walHeaderSize,
+                  recordBytes - walHeaderSize <= UInt64(Int.max) else {
+                throw WaxError.capacityExceeded(
+                    limit: UInt64(Int.max),
+                    requested: recordBytes
+                )
+            }
+            payloadSizes.append(Int(recordBytes - walHeaderSize))
             largest = max(largest, recordBytes)
             let (nextTotal, overflowed) = total.addingReportingOverflow(recordBytes)
             total = overflowed ? UInt64.max : nextTotal
@@ -719,7 +743,8 @@ package extension MemoryOrchestrator {
         let (conservativeTotal, overflowed) = total.addingReportingOverflow(perFrameOverhead.partialValue)
         return (
             largest: largest,
-            total: overflowed || perFrameOverhead.overflow ? UInt64.max : conservativeTotal
+            total: overflowed || perFrameOverhead.overflow ? UInt64.max : conservativeTotal,
+            payloadSizes: payloadSizes
         )
     }
 
@@ -832,6 +857,28 @@ package extension MemoryOrchestrator {
             }
             try fileManager.moveItem(at: backupURL, to: promotion.destinationURL)
         }
+    }
+
+    private static func finalizeRewritePromotion(_ promotion: RewritePromotion) throws {
+        guard let backupURL = promotion.backupURL else { return }
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: backupURL.path) else { return }
+
+        // Keep the rollback copy until the published destination is still the
+        // inode that passed verification. If another writer replaced the
+        // pathname after promotion, fail closed and retain the backup for
+        // operator recovery.
+        guard isRegularFile(at: promotion.destinationURL),
+              let expected = promotion.publishedIdentity,
+              fileIdentity(at: promotion.destinationURL) == expected else {
+            throw WaxError.io(
+                "rewriteLiveSet promotion destination changed before backup cleanup"
+            )
+        }
+        guard isRegularFile(at: backupURL) else {
+            throw WaxError.io("rewriteLiveSet promotion backup is no longer a regular file")
+        }
+        try fileManager.removeItem(at: backupURL)
     }
 
     private static func verifyRewriteOutput(at url: URL, deep: Bool) async throws {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -139,6 +139,7 @@ package actor MemoryOrchestrator {
         package var accessStatsScoringEnabled: Bool
         package var embedderIdentity: EmbeddingIdentity?
         package var embeddingStatus: EmbeddingStatus
+        package var framesWithoutVectors: UInt64
 
         package init(
             frameCount: UInt64,
@@ -153,7 +154,8 @@ package actor MemoryOrchestrator {
             structuredMemoryEnabled: Bool,
             accessStatsScoringEnabled: Bool,
             embedderIdentity: EmbeddingIdentity?,
-            embeddingStatus: EmbeddingStatus = .disabled
+            embeddingStatus: EmbeddingStatus = .disabled,
+            framesWithoutVectors: UInt64 = 0
         ) {
             self.frameCount = frameCount
             self.pendingFrames = pendingFrames
@@ -168,6 +170,7 @@ package actor MemoryOrchestrator {
             self.accessStatsScoringEnabled = accessStatsScoringEnabled
             self.embedderIdentity = embedderIdentity
             self.embeddingStatus = embeddingStatus
+            self.framesWithoutVectors = framesWithoutVectors
         }
     }
 
@@ -909,12 +912,16 @@ package actor MemoryOrchestrator {
     }
 
     private static func vecSegmentContains(frameId: UInt64, bytes: Data) -> Bool {
+        vecSegmentFrameIds(bytes: bytes).contains(frameId)
+    }
+
+    private static func vecSegmentFrameIds(bytes: Data) -> Set<UInt64> {
         guard let payload = try? VectorSerializer.decodeVecSegment(from: bytes) else {
-            return false
+            return []
         }
         switch payload {
         case .metal(_, _, let frameIds):
-            return frameIds.contains(frameId)
+            return Set(frameIds)
         }
     }
 
@@ -1339,7 +1346,8 @@ package actor MemoryOrchestrator {
             structuredMemoryEnabled: config.enableStructuredMemory,
             accessStatsScoringEnabled: config.enableAccessStatsScoring,
             embedderIdentity: embeddingStatus.identity,
-            embeddingStatus: embeddingStatus
+            embeddingStatus: embeddingStatus,
+            framesWithoutVectors: await Self.framesWithoutVectorsCount(wax)
         )
     }
 
@@ -1352,6 +1360,55 @@ package actor MemoryOrchestrator {
         guard config.enableVectorSearch else { return false }
         if case .loading = embeddingStatus { return true }
         return false
+    }
+
+    /// Embed live searchable frames that have no vectors using the attached provider.
+    ///
+    /// Returns the number of frames newly embedded. Already-vectorized frames are
+    /// skipped. Throws ``WaxError/missingEmbedder`` when no provider is attached.
+    @discardableResult
+    package func backfillUnembedded() async throws -> UInt64 {
+        let snapshot = readyEmbedderSnapshot
+        guard config.enableVectorSearch, let embedder = snapshot.provider else {
+            throw WaxError.missingEmbedder
+        }
+
+        let missing = await unembeddedLiveSources()
+        guard !missing.isEmpty else {
+            await refreshEmbeddingCoverage()
+            return 0
+        }
+
+        try await session.ensureVectorEngine(dimensions: embedder.dimensions)
+
+        let batchSize = max(1, config.ingestBatchSize)
+        var embedded: UInt64 = 0
+        var index = 0
+        while index < missing.count {
+            let end = min(index + batchSize, missing.count)
+            let batch = Array(missing[index..<end])
+            let vectors = try await Self.prepareEmbeddingsBatchOptimized(
+                chunks: batch.map(\.searchText),
+                embedder: embedder,
+                capabilities: snapshot.capabilities,
+                cache: embeddingCache,
+                timeout: config.ingestEmbeddingTimeout
+            )
+            try await wax.putEmbeddingBatch(
+                frameIds: batch.map(\.id),
+                vectors: vectors
+            )
+            if let identity = embedder.identity {
+                try await ensureMemoryBindingIfNeeded(
+                    MemoryBindingCompatibility.binding(from: identity)
+                )
+            }
+            embedded += UInt64(batch.count)
+            index = end
+        }
+
+        await refreshEmbeddingCoverage()
+        return embedded
     }
 
     /// Wait until automatic compile has attached, or throw if it failed.
@@ -2233,11 +2290,47 @@ package actor MemoryOrchestrator {
     }
 
     private static func storeHasUnembeddedChunks(_ wax: Wax) async -> Bool {
-        let chunks = await wax.liveChunkCount()
-        guard chunks > 0 else { return false }
-        let pending = UInt64(await wax.pendingEmbeddingMutations().count)
-        let indexed = await wax.committedVecIndexManifest()?.vectorCount ?? 0
-        return chunks > indexed + pending
+        await framesWithoutVectorsCount(wax) > 0
+    }
+
+    private static func framesWithoutVectorsCount(_ wax: Wax) async -> UInt64 {
+        UInt64((await unembeddedLiveSources(in: wax)).count)
+    }
+
+    private func unembeddedLiveSources() async -> [SurrogateSourceFrame] {
+        await Self.unembeddedLiveSources(in: wax)
+    }
+
+    private static func unembeddedLiveSources(in wax: Wax) async -> [SurrogateSourceFrame] {
+        let sources = await wax.activeSurrogateSourceFrames()
+        let embedded = await embeddedFrameIds(in: wax)
+        return sources.filter { !embedded.contains($0.id) }
+    }
+
+    private static func embeddedFrameIds(in wax: Wax) async -> Set<UInt64> {
+        var ids = Set<UInt64>()
+        for pending in await wax.pendingEmbeddingMutations() {
+            ids.insert(pending.frameId)
+        }
+        if let staged = await wax.readStagedVecIndexBytes() {
+            ids.formUnion(Self.vecSegmentFrameIds(bytes: staged.bytes))
+        }
+        if let bytes = try? await wax.readCommittedVecIndexBytes() {
+            ids.formUnion(Self.vecSegmentFrameIds(bytes: bytes))
+        }
+        return ids
+    }
+
+    private func refreshEmbeddingCoverage() async {
+        guard case .ready(let provider, let capabilities, _) = embedderLifecycle else {
+            return
+        }
+        let lacksVectors = await Self.storeHasUnembeddedChunks(wax)
+        embedderLifecycle = .ready(
+            provider: provider,
+            capabilities: capabilities,
+            degradedReason: lacksVectors ? "some saved frames have no vectors" : nil
+        )
     }
 
     private func queryEmbeddingResult(

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -411,12 +411,18 @@ package actor MemoryOrchestrator {
                 break
             }
         }
-        if let identity = embedder?.identity,
-           let binding = existingMemoryBinding,
-           !MemoryBindingCompatibility.isCompatible(binding, with: identity) {
-            let mismatch = MemoryBindingCompatibility.mismatchReason(binding, with: identity) ?? "unknown mismatch"
-            try? await wax.close()
-            throw WaxError.io("memory binding mismatch with embedder identity (\(mismatch))")
+        if let binding = existingMemoryBinding, !binding.isEmpty, let embedder {
+            guard let identity = embedder.identity else {
+                try? await wax.close()
+                throw WaxError.io(
+                    "memory binding requires an identifiable embedder provider"
+                )
+            }
+            guard MemoryBindingCompatibility.isCompatible(binding, with: identity) else {
+                let mismatch = MemoryBindingCompatibility.mismatchReason(binding, with: identity) ?? "unknown mismatch"
+                try? await wax.close()
+                throw WaxError.io("memory binding mismatch with embedder identity (\(mismatch))")
+            }
         }
 
         self.config = resolvedConfig
@@ -2244,12 +2250,16 @@ package actor MemoryOrchestrator {
         }
         let binding = await wax.memoryBinding()
         guard !isClosed else { return }
-        if let identity = provider.identity,
-           let binding,
-           !MemoryBindingCompatibility.isCompatible(binding, with: identity) {
-            let mismatch = MemoryBindingCompatibility.mismatchReason(binding, with: identity) ?? "unknown mismatch"
-            markUnavailable("memory binding mismatch with embedder identity (\(mismatch))")
-            return
+        if let binding, !binding.isEmpty {
+            guard let identity = provider.identity else {
+                markUnavailable("memory binding requires an identifiable embedder provider")
+                return
+            }
+            guard MemoryBindingCompatibility.isCompatible(binding, with: identity) else {
+                let mismatch = MemoryBindingCompatibility.mismatchReason(binding, with: identity) ?? "unknown mismatch"
+                markUnavailable("memory binding mismatch with embedder identity (\(mismatch))")
+                return
+            }
         }
         if config.enableVectorSearch {
             do {

--- a/Sources/Wax/UnifiedSearch/MatchPlan.swift
+++ b/Sources/Wax/UnifiedSearch/MatchPlan.swift
@@ -24,14 +24,18 @@ package struct MatchPlan: Equatable, Sendable {
         )
     }
 
-    package static func tokens(from query: String, maxTokens: Int = 16) -> [String] {
+    package static func tokens(
+        from query: String,
+        maxTokens: Int = 16,
+        splitIdentifierParts: Bool = true
+    ) -> [String] {
         let capped = max(0, maxTokens)
         guard capped > 0 else { return [] }
         var seen: Set<String> = []
         var tokens: [String] = []
         tokens.reserveCapacity(capped)
 
-        for token in aliasTokens(from: query) {
+        for token in aliasTokens(from: query, splitIdentifierParts: splitIdentifierParts) {
             let normalized = token.lowercased()
             guard !normalized.isEmpty else { continue }
             guard !ftsStopWords.contains(normalized) else { continue }
@@ -49,6 +53,13 @@ package struct MatchPlan: Equatable, Sendable {
     }
 
     package static func aliasTokens(from query: String) -> [String] {
+        aliasTokens(from: query, splitIdentifierParts: true)
+    }
+
+    private static func aliasTokens(
+        from query: String,
+        splitIdentifierParts: Bool
+    ) -> [String] {
         var tokens: [String] = []
         var buffer = String.UnicodeScalarView()
 
@@ -56,7 +67,8 @@ package struct MatchPlan: Equatable, Sendable {
             if !buffer.isEmpty {
                 let raw = String(buffer)
                 tokens.append(raw)
-                if raw.contains(where: { $0 == "-" || $0 == "_" }) {
+                if splitIdentifierParts,
+                   raw.contains(where: { $0 == "-" || $0 == "_" }) {
                     for part in raw.split(whereSeparator: { $0 == "-" || $0 == "_" }) {
                         let piece = String(part)
                         if !piece.isEmpty {
@@ -129,7 +141,14 @@ package struct MatchPlan: Equatable, Sendable {
         var normalized: [String] = []
 
         for phrase in rawQuotedPhrases(from: query, maxPhrases: maxPhrases) {
-            let phraseTokens = tokens(from: phrase, maxTokens: maxTokensPerPhrase)
+            // A quoted phrase is an intentional adjacency constraint. Keep
+            // identifier glue inside the phrase so `"foo-bar"` remains a
+            // single FTS phrase instead of becoming `"foo-bar foo bar"`.
+            let phraseTokens = tokens(
+                from: phrase,
+                maxTokens: maxTokensPerPhrase,
+                splitIdentifierParts: false
+            )
             guard !phraseTokens.isEmpty else { continue }
             let value = phraseTokens.joined(separator: " ")
             if seen.insert(value).inserted {

--- a/Sources/Wax/UnifiedSearch/MatchPlan.swift
+++ b/Sources/Wax/UnifiedSearch/MatchPlan.swift
@@ -54,7 +54,16 @@ package struct MatchPlan: Equatable, Sendable {
 
         func flush() {
             if !buffer.isEmpty {
-                tokens.append(String(buffer))
+                let raw = String(buffer)
+                tokens.append(raw)
+                if raw.contains(where: { $0 == "-" || $0 == "_" }) {
+                    for part in raw.split(whereSeparator: { $0 == "-" || $0 == "_" }) {
+                        let piece = String(part)
+                        if !piece.isEmpty {
+                            tokens.append(piece)
+                        }
+                    }
+                }
                 buffer.removeAll(keepingCapacity: true)
             }
         }
@@ -168,7 +177,9 @@ package struct MatchPlan: Equatable, Sendable {
     ]
 
     private static let asciiPunctuationScalars: Set<UnicodeScalar> = {
-        let scalars = "!\\\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~".unicodeScalars
+        // Keep '-' and '_' as identifier glue so hyphenated tokens stay intact;
+        // split parts are still emitted from `aliasTokens` for OR fallback.
+        let scalars = "!\\\"#$%&'()*+,./:;<=>?@[\\\\]^`{|}~".unicodeScalars
         return Set(scalars)
     }()
 

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -759,7 +759,9 @@ extension Wax {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { return results }
         let cappedWindow = min(max(0, maxWindow), results.count)
-        guard cappedWindow > 1 else { return results }
+        // Window 1 still publishes the bonus so a lone exact hit outranks
+        // OR-fallback name matches from another store after corpus merge.
+        guard cappedWindow > 0 else { return results }
 
         let lowerNeedle = needle.lowercased()
         // Larger than same-repo (0.9) + same-project (0.7) + decision (0.45) + durable (0.25).

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -63,7 +63,7 @@ extension Wax {
         // vectorOnly must not widen the pending window or promote a buried exact frame.
         let identifierWindow: Int? = (
             includeText && (trimmedQuery.map(RuleBasedQueryClassifier.isLexicalIdentifierQuery) ?? false)
-        ) ? min(max(requestedTopK * 3, 12), 48) : nil
+        ) ? min(max(Self.boundedMultiply(requestedTopK, by: 3), 12), 48) : nil
 
         let candidateLimit = Self.candidateLimit(for: requestedTopK, filter: filter)
         let cache = UnifiedSearchEngineCache.shared
@@ -593,14 +593,14 @@ extension Wax {
             filtered = Self.intentAwareRerank(
                 results: filtered,
                 query: trimmedQuery,
-                maxWindow: min(max(request.topK * 2, 10), 32)
+                maxWindow: min(max(Self.boundedMultiply(request.topK, by: 2), 10), 32)
             )
         }
         filtered = Self.semanticMemoryRerank(
             results: filtered,
             scopeContext: request.scopeContext,
             nowMs: semanticNowMs,
-            maxWindow: min(max(request.topK * 3, 12), 48)
+            maxWindow: min(max(Self.boundedMultiply(request.topK, by: 3), 12), 48)
         )
         if let identifierWindow, let trimmedQuery {
             filtered = Self.identifierExactMatchRerank(
@@ -1359,19 +1359,28 @@ extension Wax {
 
     private static func candidateLimit(for topK: Int) -> Int {
         guard topK > 0 else { return 0 }
-        let expanded = topK > Int.max / 3 ? Int.max : topK * 3
+        let expanded = boundedMultiply(topK, by: 3)
         let capped = min(expanded, 1000)
-        return max(topK, capped)
+        // Keep the public request's topK from becoming an unbounded SQLite or
+        // vector-engine limit. FTS independently caps at 10,000; matching the
+        // same ceiling here also makes Int.max requests safe.
+        return min(max(topK, capped), 10_000)
     }
 
     private static func candidateLimit(for topK: Int, filter: FrameFilter) -> Int {
         let baseLimit = candidateLimit(for: topK)
         guard needsCallerFilterOverfetch(filter) else { return baseLimit }
 
-        let multiplied = topK > Int.max / 5 ? Int.max : topK * 5
+        let multiplied = boundedMultiply(topK, by: 5)
         let withSlack = topK > Int.max - 200 ? Int.max : topK + 200
         let overfetchLimit = min(1000, max(multiplied, withSlack))
         return max(baseLimit, overfetchLimit)
+    }
+
+    private static func boundedMultiply(_ value: Int, by multiplier: Int) -> Int {
+        guard value > 0, multiplier > 0 else { return 0 }
+        guard value <= Int.max / multiplier else { return Int.max }
+        return value * multiplier
     }
 
     private static func needsCallerFilterOverfetch(_ filter: FrameFilter) -> Bool {

--- a/Sources/WaxCLI/CompactStoreCommand.swift
+++ b/Sources/WaxCLI/CompactStoreCommand.swift
@@ -1,0 +1,139 @@
+import ArgumentParser
+import Foundation
+import Wax
+import WaxCore
+
+struct CompactStoreCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "compact-store",
+        abstract: "Rewrite a copy of a Wax store with automatic WAL sizing"
+    )
+
+    @Option(
+        name: .customLong("store-path"),
+        help: "Source store path. Required; never defaults to ~/.wax/memory.wax."
+    )
+    var storePath: String
+
+    @Option(name: .customLong("output"), help: "Destination store path")
+    var output: String
+
+    @Flag(
+        name: .customLong("direct-store"),
+        help: "Required. Open the source store file directly; never talks to the broker."
+    )
+    var directStore: Bool = false
+
+    @Flag(
+        name: .customLong("no-embedder"),
+        help: "Disable MiniLM. Compact does not need an embedder."
+    )
+    var noEmbedder: Bool = false
+
+    @Flag(name: .customLong("overwrite"), help: "Replace an existing destination file")
+    var overwrite: Bool = false
+
+    @Option(name: .customLong("format"), help: "Output format: json or text")
+    var format: OutputFormat = .text
+
+    func validate() throws {
+        guard directStore else {
+            throw ValidationError("--direct-store is required for compact-store")
+        }
+        try CompactStorePathPolicy.validate(
+            storePath: storePath,
+            output: output
+        )
+    }
+
+    func runAsync() async throws {
+        _ = noEmbedder
+        let sourceURL = try StoreSession.resolveURL(storePath)
+        let destURL = try CompactStorePathPolicy.destinationURL(from: output)
+        try CompactStorePathPolicy.validate(
+            storePath: storePath,
+            output: output
+        )
+        try failFastIfStoreHeld(at: sourceURL)
+
+        let report = try await StoreSession.withOpen(at: sourceURL, noEmbedder: true) { memory in
+            try await memory.rewriteLiveSet(
+                to: destURL,
+                options: LiveSetRewriteOptions(
+                    overwriteDestination: overwrite,
+                    dropNonLivePayloads: true,
+                    verifyDeep: true
+                )
+            )
+        }
+
+        let dest = try await Wax.open(at: destURL)
+        let destWal = await dest.walStats()
+        try await dest.close()
+
+        switch format {
+        case .json:
+            printJSON([
+                "sourcePath": report.sourceURL.path,
+                "outputPath": report.destinationURL.path,
+                "frameCount": report.frameCount,
+                "activeFrameCount": report.activeFrameCount,
+                "droppedPayloadFrames": report.droppedPayloadFrames,
+                "logicalBytesBefore": report.logicalBytesBefore,
+                "logicalBytesAfter": report.logicalBytesAfter,
+                "walSizeAfter": destWal.walSize,
+            ])
+        case .text:
+            print("Compacted \(report.sourceURL.path) → \(report.destinationURL.path)")
+            print("Frames: \(report.frameCount) (\(report.activeFrameCount) active)")
+            print("Logical size: \(report.logicalBytesAfter) bytes (was \(report.logicalBytesBefore))")
+            print("WAL size: \(destWal.walSize)")
+        }
+    }
+
+    func failFastIfStoreHeld(at url: URL) throws {
+        guard try StoreLockProbe.tryExclusiveAccess(at: url) else {
+            throw CLIError(
+                "another process holds an exclusive lock on this store; if a broker is attached, use waxmcp stats / attach instead of waiting"
+            )
+        }
+    }
+}
+
+enum CompactStorePathPolicy {
+    static func validate(storePath: String, output: String) throws {
+        let source = expandedURL(storePath)
+        let dest = expandedURL(output)
+        try refuseLiveFamily(source, command: "compact-store")
+        try refuseLiveFamily(dest, command: "compact-store")
+        if source == dest {
+            throw ValidationError("compact-store destination must differ from source")
+        }
+    }
+
+    static func refuseLiveFamily(_ url: URL, command: String) throws {
+        if url == liveFamilyURL() {
+            throw ValidationError(
+                "\(command) refuses the live family store path \(StoreSession.defaultStorePath)"
+            )
+        }
+    }
+
+    static func destinationURL(from raw: String) throws -> URL {
+        let url = expandedURL(raw)
+        let dir = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func liveFamilyURL() -> URL {
+        expandedURL(StoreSession.defaultStorePath)
+    }
+
+    /// Trim then tilde-expand. Must match `StoreSession.resolveURL` identity without creating directories.
+    static func expandedURL(_ raw: String) -> URL {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expanded).standardizedFileURL
+    }
+}

--- a/Sources/WaxCLI/CompactStoreCommand.swift
+++ b/Sources/WaxCLI/CompactStoreCommand.swift
@@ -49,45 +49,103 @@ struct CompactStoreCommand: AsyncParsableCommand {
     func runAsync() async throws {
         _ = noEmbedder
         let sourceURL = try StoreSession.resolveURL(storePath)
-        let destURL = try CompactStorePathPolicy.destinationURL(from: output)
+        let destinationURL = try CompactStorePathPolicy.destinationURL(from: output)
         try CompactStorePathPolicy.validate(
             storePath: storePath,
             output: output
         )
+        try StoreRepairSupport.validate(
+            source: sourceURL,
+            destination: destinationURL,
+            command: "compact-store"
+        )
+        try StoreRepairSupport.ensureRegularFileIfPresent(
+            at: destinationURL,
+            label: "output",
+            command: "compact-store"
+        )
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            guard overwrite else {
+                throw CLIError("output destination already exists; pass --overwrite to replace it")
+            }
+            try StoreRepairSupport.ensureDestinationUnlockedIfPresent(
+                at: destinationURL,
+                command: "compact-store"
+            )
+        }
         try failFastIfStoreHeld(at: sourceURL)
 
-        let report = try await StoreSession.withOpen(at: sourceURL, noEmbedder: true) { memory in
+        let sourceIdentity = StoreRepairSupport.identity(of: sourceURL)
+        let sourceCopyURL = StoreRepairSupport.stagingURL(for: destinationURL)
+        let stagingURL = StoreRepairSupport.stagingURL(for: destinationURL)
+        defer {
+            try? FileManager.default.removeItem(at: sourceCopyURL)
+            try? FileManager.default.removeItem(at: stagingURL)
+        }
+        let sourceFingerprint = try StoreRepairSupport.copySource(
+            from: sourceURL,
+            to: sourceCopyURL,
+            overwrite: false
+        )
+        _ = try await StoreRepairSupport.verifyDeep(at: sourceCopyURL)
+
+        let report = try await StoreSession.withOpen(at: sourceCopyURL, noEmbedder: true) { memory in
             try await memory.rewriteLiveSet(
-                to: destURL,
+                to: stagingURL,
                 options: LiveSetRewriteOptions(
-                    overwriteDestination: overwrite,
+                    overwriteDestination: false,
                     dropNonLivePayloads: true,
                     verifyDeep: true
                 )
             )
         }
 
-        let dest = try await Wax.open(at: destURL)
-        let destWal = await dest.walStats()
-        try await dest.close()
+        _ = try await StoreRepairSupport.verifyDeep(at: stagingURL)
+        let sourceAfter = try StoreRepairSupport.fingerprint(of: sourceURL)
+        guard sourceAfter == sourceFingerprint,
+              StoreRepairSupport.identity(of: sourceURL) == sourceIdentity else {
+            throw CLIError("source store changed during compaction; output is not promoted")
+        }
+        try StoreRepairSupport.validate(
+            source: sourceURL,
+            destination: destinationURL,
+            command: "compact-store"
+        )
+        let promotion = try StoreRepairSupport.promoteVerifiedOutput(
+            from: stagingURL,
+            to: destinationURL,
+            overwrite: overwrite
+        )
+        let publishedWal: WaxWALStats
+        do {
+            publishedWal = try await StoreRepairSupport.verifyDeep(at: destinationURL)
+            try StoreRepairSupport.finalizePromotion(promotion)
+        } catch {
+            try? StoreRepairSupport.rollbackPromotion(promotion)
+            throw error
+        }
 
         switch format {
         case .json:
             printJSON([
-                "sourcePath": report.sourceURL.path,
-                "outputPath": report.destinationURL.path,
+                "sourcePath": sourceURL.path,
+                "outputPath": destinationURL.path,
                 "frameCount": report.frameCount,
                 "activeFrameCount": report.activeFrameCount,
                 "droppedPayloadFrames": report.droppedPayloadFrames,
                 "logicalBytesBefore": report.logicalBytesBefore,
                 "logicalBytesAfter": report.logicalBytesAfter,
-                "walSizeAfter": destWal.walSize,
+                "walSizeAfter": publishedWal.walSize,
+                "sourceUnchanged": true,
+                "deepVerified": true,
             ])
         case .text:
-            print("Compacted \(report.sourceURL.path) → \(report.destinationURL.path)")
+            print("Compacted \(sourceURL.path) → \(destinationURL.path)")
             print("Frames: \(report.frameCount) (\(report.activeFrameCount) active)")
             print("Logical size: \(report.logicalBytesAfter) bytes (was \(report.logicalBytesBefore))")
-            print("WAL size: \(destWal.walSize)")
+            print("WAL size: \(publishedWal.walSize)")
+            print("Source unchanged: yes")
+            print("Deep verification: PASS")
         }
     }
 
@@ -97,43 +155,5 @@ struct CompactStoreCommand: AsyncParsableCommand {
                 "another process holds an exclusive lock on this store; if a broker is attached, use waxmcp stats / attach instead of waiting"
             )
         }
-    }
-}
-
-enum CompactStorePathPolicy {
-    static func validate(storePath: String, output: String) throws {
-        let source = expandedURL(storePath)
-        let dest = expandedURL(output)
-        try refuseLiveFamily(source, command: "compact-store")
-        try refuseLiveFamily(dest, command: "compact-store")
-        if source == dest {
-            throw ValidationError("compact-store destination must differ from source")
-        }
-    }
-
-    static func refuseLiveFamily(_ url: URL, command: String) throws {
-        if url == liveFamilyURL() {
-            throw ValidationError(
-                "\(command) refuses the live family store path \(StoreSession.defaultStorePath)"
-            )
-        }
-    }
-
-    static func destinationURL(from raw: String) throws -> URL {
-        let url = expandedURL(raw)
-        let dir = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return url
-    }
-
-    static func liveFamilyURL() -> URL {
-        expandedURL(StoreSession.defaultStorePath)
-    }
-
-    /// Trim then tilde-expand. Must match `StoreSession.resolveURL` identity without creating directories.
-    static func expandedURL(_ raw: String) -> URL {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        let expanded = (trimmed as NSString).expandingTildeInPath
-        return URL(fileURLWithPath: expanded).standardizedFileURL
     }
 }

--- a/Sources/WaxCLI/CompactStoreCommand.swift
+++ b/Sources/WaxCLI/CompactStoreCommand.swift
@@ -114,7 +114,8 @@ struct CompactStoreCommand: AsyncParsableCommand {
         let promotion = try StoreRepairSupport.promoteVerifiedOutput(
             from: stagingURL,
             to: destinationURL,
-            overwrite: overwrite
+            overwrite: overwrite,
+            source: sourceURL
         )
         let publishedWal: WaxWALStats
         do {

--- a/Sources/WaxCLI/EmbedBackfillCommand.swift
+++ b/Sources/WaxCLI/EmbedBackfillCommand.swift
@@ -107,7 +107,8 @@ struct EmbedBackfillCommand: AsyncParsableCommand {
         let promotion = try StoreRepairSupport.promoteVerifiedOutput(
             from: stagingURL,
             to: destinationURL,
-            overwrite: overwrite
+            overwrite: overwrite,
+            source: sourceURL
         )
         do {
             _ = try await StoreRepairSupport.verifyDeep(at: destinationURL)

--- a/Sources/WaxCLI/EmbedBackfillCommand.swift
+++ b/Sources/WaxCLI/EmbedBackfillCommand.swift
@@ -11,28 +11,69 @@ struct EmbedBackfillCommand: AsyncParsableCommand {
 
     @OptionGroup var store: VectorStoreOptions
 
+    @Option(name: .customLong("output"), help: "Destination store path")
+    var output: String
+
+    @Flag(name: .customLong("overwrite"), help: "Replace an existing destination file after verification")
+    var overwrite: Bool = false
+
     func validate() throws {
         try store.validate()
         guard store.directStore else {
             throw ValidationError("--direct-store is required for embed-backfill")
         }
-        try CompactStorePathPolicy.refuseLiveFamily(
-            CompactStorePathPolicy.expandedURL(store.storePath),
+        try StoreRepairSupport.validate(
+            sourceRaw: store.storePath,
+            destinationRaw: output,
             command: "embed-backfill"
         )
     }
 
     func runAsync() async throws {
-        let url = try StoreSession.resolveURL(store.storePath)
-        try failFastIfStoreHeld(at: url)
-
-        if store.noEmbedder {
+        guard !store.noEmbedder else {
             throw CLIError("embed-backfill requires an embedder; --no-embedder fails closed")
         }
+        let sourceURL = try StoreSession.resolveURL(store.storePath)
+        let destinationURL = try StoreRepairSupport.destinationURL(from: output)
+        try StoreRepairSupport.validate(
+            source: sourceURL,
+            destination: destinationURL,
+            command: "embed-backfill"
+        )
+        try StoreRepairSupport.ensureRegularFileIfPresent(
+            at: destinationURL,
+            label: "output",
+            command: "embed-backfill"
+        )
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            guard overwrite else {
+                throw CLIError("output destination already exists; pass --overwrite to replace it")
+            }
+            try StoreRepairSupport.ensureDestinationUnlockedIfPresent(
+                at: destinationURL,
+                command: "embed-backfill"
+            )
+        }
+        try failFastIfStoreHeld(at: sourceURL)
 
-        do {
-            try await StoreSession.withOpen(
-                at: url,
+        let stagingURL = StoreRepairSupport.stagingURL(for: destinationURL)
+        defer { try? FileManager.default.removeItem(at: stagingURL) }
+
+        let sourceIdentity = StoreRepairSupport.identity(of: sourceURL)
+        let sourceFingerprint = try StoreRepairSupport.copySource(
+            from: sourceURL,
+            to: stagingURL,
+            overwrite: false
+        )
+        _ = try await StoreRepairSupport.verifyDeep(at: stagingURL)
+
+        let result: (
+            examined: UInt64,
+            embedded: UInt64,
+            remaining: UInt64,
+            status: String
+        ) = try await StoreSession.withOpen(
+                at: stagingURL,
                 noEmbedder: false,
                 embedderChoice: store.embedder,
                 embedderTuning: store.embedderTuning,
@@ -44,28 +85,56 @@ struct EmbedBackfillCommand: AsyncParsableCommand {
                 let embedded = try await memory.backfillUnembedded()
                 try await memory.flush()
                 let after = await memory.runtimeStats()
-                let payload: [String: Any] = [
-                    "examined": examined,
-                    "embedded": embedded,
-                    "skippedAlreadyEmbedded": max(0, Int64(before.frameCount) - Int64(examined)),
-                    "framesWithoutVectors": after.framesWithoutVectors,
-                    "embeddingStatus": after.embeddingStatus.wireName,
-                    "storePath": after.storeURL.path,
-                ]
-                switch store.format {
-                case .json:
-                    printJSON(payload)
-                case .text:
-                    print("Backfill examined \(examined) unembedded frame(s); embedded \(embedded).")
-                    print("Frames without vectors: \(after.framesWithoutVectors)")
-                    print("Embedding status: \(after.embeddingStatus.wireName)")
-                }
+                return (
+                    examined: examined,
+                    embedded: embedded,
+                    remaining: after.framesWithoutVectors,
+                    status: after.embeddingStatus.wireName
+                )
             }
-        } catch let error as WaxError {
-            if case .missingEmbedder = error {
-                throw CLIError("embed-backfill requires an embedder; none is attached")
-            }
+
+        _ = try await StoreRepairSupport.verifyDeep(at: stagingURL)
+        let sourceAfter = try StoreRepairSupport.fingerprint(of: sourceURL)
+        guard sourceAfter == sourceFingerprint,
+              StoreRepairSupport.identity(of: sourceURL) == sourceIdentity else {
+            throw CLIError("source store changed during backfill; no repair output was published")
+        }
+        try StoreRepairSupport.validate(
+            source: sourceURL,
+            destination: destinationURL,
+            command: "embed-backfill"
+        )
+        let promotion = try StoreRepairSupport.promoteVerifiedOutput(
+            from: stagingURL,
+            to: destinationURL,
+            overwrite: overwrite
+        )
+        do {
+            _ = try await StoreRepairSupport.verifyDeep(at: destinationURL)
+            try StoreRepairSupport.finalizePromotion(promotion)
+        } catch {
+            try? StoreRepairSupport.rollbackPromotion(promotion)
             throw error
+        }
+
+        switch store.format {
+        case .json:
+            printJSON([
+                "examined": result.examined,
+                "embedded": result.embedded,
+                "framesWithoutVectors": result.remaining,
+                "embeddingStatus": result.status,
+                "storePath": destinationURL.path,
+                "sourceUnchanged": true,
+                "deepVerified": true,
+            ])
+        case .text:
+            print("Backfill examined \(result.examined) unembedded frame(s); embedded \(result.embedded).")
+            print("Frames without vectors: \(result.remaining)")
+            print("Embedding status: \(result.status)")
+            print("Output: \(destinationURL.path)")
+            print("Source unchanged: yes")
+            print("Deep verification: PASS")
         }
     }
 

--- a/Sources/WaxCLI/EmbedBackfillCommand.swift
+++ b/Sources/WaxCLI/EmbedBackfillCommand.swift
@@ -1,0 +1,79 @@
+import ArgumentParser
+import Foundation
+import Wax
+import WaxCore
+
+struct EmbedBackfillCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "embed-backfill",
+        abstract: "Embed live frames that have no vectors on a copy of a store"
+    )
+
+    @OptionGroup var store: VectorStoreOptions
+
+    func validate() throws {
+        try store.validate()
+        guard store.directStore else {
+            throw ValidationError("--direct-store is required for embed-backfill")
+        }
+        try CompactStorePathPolicy.refuseLiveFamily(
+            CompactStorePathPolicy.expandedURL(store.storePath),
+            command: "embed-backfill"
+        )
+    }
+
+    func runAsync() async throws {
+        let url = try StoreSession.resolveURL(store.storePath)
+        try failFastIfStoreHeld(at: url)
+
+        if store.noEmbedder {
+            throw CLIError("embed-backfill requires an embedder; --no-embedder fails closed")
+        }
+
+        do {
+            try await StoreSession.withOpen(
+                at: url,
+                noEmbedder: false,
+                embedderChoice: store.embedder,
+                embedderTuning: store.embedderTuning,
+                requireVector: true
+            ) { memory in
+                try await memory.waitUntilReadyForRemember()
+                let before = await memory.runtimeStats()
+                let examined = before.framesWithoutVectors
+                let embedded = try await memory.backfillUnembedded()
+                try await memory.flush()
+                let after = await memory.runtimeStats()
+                let payload: [String: Any] = [
+                    "examined": examined,
+                    "embedded": embedded,
+                    "skippedAlreadyEmbedded": max(0, Int64(before.frameCount) - Int64(examined)),
+                    "framesWithoutVectors": after.framesWithoutVectors,
+                    "embeddingStatus": after.embeddingStatus.wireName,
+                    "storePath": after.storeURL.path,
+                ]
+                switch store.format {
+                case .json:
+                    printJSON(payload)
+                case .text:
+                    print("Backfill examined \(examined) unembedded frame(s); embedded \(embedded).")
+                    print("Frames without vectors: \(after.framesWithoutVectors)")
+                    print("Embedding status: \(after.embeddingStatus.wireName)")
+                }
+            }
+        } catch let error as WaxError {
+            if case .missingEmbedder = error {
+                throw CLIError("embed-backfill requires an embedder; none is attached")
+            }
+            throw error
+        }
+    }
+
+    func failFastIfStoreHeld(at url: URL) throws {
+        guard try StoreLockProbe.tryExclusiveAccess(at: url) else {
+            throw CLIError(
+                "another process holds an exclusive lock on this store; if a broker is attached, use waxmcp stats / attach instead of waiting"
+            )
+        }
+    }
+}

--- a/Sources/WaxCLI/StatsCommand.swift
+++ b/Sources/WaxCLI/StatsCommand.swift
@@ -28,6 +28,7 @@ struct StatsCommand: AsyncParsableCommand {
             case .text:
                 print("Store: \(brokerString(payload, "storePath") ?? store.storePath)")
                 print("Frames: \(brokerInt(payload, "frameCount") ?? 0) (\(brokerInt(payload, "pendingFrames") ?? 0) pending)")
+                print("Frames without vectors: \(brokerInt64(payload, "framesWithoutVectors") ?? 0)")
                 print("Generation: \(brokerInt(payload, "generation") ?? 0)")
                 let diskBytes = Int64(brokerInt64(payload, "diskBytes") ?? 0)
                 print("Disk: \(ByteCountFormatter.string(fromByteCount: diskBytes, countStyle: .file))")
@@ -70,6 +71,7 @@ struct StatsCommand: AsyncParsableCommand {
                 printJSON([
                     "frameCount": stats.frameCount,
                     "pendingFrames": stats.pendingFrames,
+                    "framesWithoutVectors": stats.framesWithoutVectors,
                     "generation": stats.generation,
                     "diskBytes": diskBytes,
                     "storePath": stats.storeURL.path,
@@ -103,6 +105,7 @@ struct StatsCommand: AsyncParsableCommand {
             case .text:
                 print("Store: \(stats.storeURL.path)")
                 print("Frames: \(stats.frameCount) (\(stats.pendingFrames) pending)")
+                print("Frames without vectors: \(stats.framesWithoutVectors)")
                 print("Generation: \(stats.generation)")
                 print("Disk: \(ByteCountFormatter.string(fromByteCount: Int64(diskBytes), countStyle: .file))")
                 print("MiniLM compiled: \(compiled ? "yes" : "no")")

--- a/Sources/WaxCLI/StoreRepairSupport.swift
+++ b/Sources/WaxCLI/StoreRepairSupport.swift
@@ -28,6 +28,9 @@ enum StoreRepairSupport {
         /// removes this inode; a path replaced by another process is left
         /// untouched for manual recovery.
         let publishedIdentity: FileIdentity?
+        /// Identity of the prior output captured at promotion time. Rollback
+        /// validates this inode before moving it back into place.
+        let backupIdentity: FileIdentity?
     }
 
     static func expandedURL(_ raw: String) -> URL {
@@ -300,28 +303,37 @@ enum StoreRepairSupport {
                 destinationPath,
                 withItemAt: stagingPath,
                 backupItemName: backupName,
-                options: []
+                // Keep the prior output until finalizePromotion has verified
+                // the published inode. Rollback needs this copy if a later
+                // validation step fails.
+                options: [.withoutDeletingBackupItem]
             )
             let backupURL = destinationPath.deletingLastPathComponent()
                 .appendingPathComponent(backupName)
             return Promotion(
                 destination: destinationPath,
                 backup: backupURL,
-                publishedIdentity: identity(of: destinationPath)
+                publishedIdentity: identity(of: destinationPath),
+                backupIdentity: identity(of: backupURL)
             )
         } else {
             try FileManager.default.moveItem(at: stagingPath, to: destinationPath)
             return Promotion(
                 destination: destinationPath,
                 backup: nil,
-                publishedIdentity: identity(of: destinationPath)
+                publishedIdentity: identity(of: destinationPath),
+                backupIdentity: nil
             )
         }
     }
 
     static func finalizePromotion(_ promotion: Promotion) throws {
         guard let backup = promotion.backup else { return }
-        guard FileManager.default.fileExists(atPath: backup.path) else { return }
+        guard FileManager.default.fileExists(atPath: backup.path) else {
+            throw CLIError(
+                "repair promotion backup disappeared; published output was retained"
+            )
+        }
 
         // Retain the rollback copy unless the destination is still the exact
         // inode that was verified and published by this promotion. A pathname
@@ -335,11 +347,70 @@ enum StoreRepairSupport {
             )
         }
         try ensureRegularFileIfPresent(at: backup, label: "promotion backup", command: "store repair")
+        guard let expected = promotion.backupIdentity,
+              identity(of: backup) == expected else {
+            throw CLIError(
+                "repair promotion backup changed before cleanup; published output was retained"
+            )
+        }
         try FileManager.default.removeItem(at: backup)
     }
 
     static func rollbackPromotion(_ promotion: Promotion) throws {
-        if FileManager.default.fileExists(atPath: promotion.destination.path) {
+        let fileManager = FileManager.default
+        if let backup = promotion.backup {
+            // Validate and pin the rollback source before touching the
+            // published destination. If it disappeared or changed, retain the
+            // published output for operator recovery.
+            guard fileManager.fileExists(atPath: backup.path),
+                  !isSymbolicLink(at: backup),
+                  let expected = promotion.backupIdentity,
+                  identity(of: backup) == expected else {
+                throw CLIError(
+                    "repair rollback retained published output because the backup changed or disappeared"
+                )
+            }
+            try ensureRegularFileIfPresent(at: backup, label: "promotion backup", command: "store repair")
+
+            if fileManager.fileExists(atPath: promotion.destination.path) {
+                guard !isSymbolicLink(at: promotion.destination),
+                      let expected = promotion.publishedIdentity,
+                      identity(of: promotion.destination) == expected else {
+                    throw CLIError(
+                        "repair rollback refused to remove a destination path changed after promotion"
+                    )
+                }
+            }
+
+            let quarantine = promotion.destination.deletingLastPathComponent()
+                .appendingPathComponent(".\(promotion.destination.lastPathComponent)-rollback-\(UUID().uuidString)")
+            guard !fileManager.fileExists(atPath: quarantine.path) else {
+                throw CLIError("repair rollback quarantine path already exists")
+            }
+            do {
+                if fileManager.fileExists(atPath: promotion.destination.path) {
+                    try fileManager.moveItem(at: promotion.destination, to: quarantine)
+                }
+                guard fileManager.fileExists(atPath: backup.path),
+                      !isSymbolicLink(at: backup),
+                      identity(of: backup) == expected else {
+                    throw CLIError(
+                        "repair rollback retained published output because the backup changed during restore"
+                    )
+                }
+                try fileManager.moveItem(at: backup, to: promotion.destination)
+                try? fileManager.removeItem(at: quarantine)
+            } catch {
+                // Restore the published inode when the backup race is
+                // detected after quarantine. Never overwrite a path another
+                // process recreated while rollback was in flight.
+                if fileManager.fileExists(atPath: quarantine.path),
+                   !fileManager.fileExists(atPath: promotion.destination.path) {
+                    try? fileManager.moveItem(at: quarantine, to: promotion.destination)
+                }
+                throw error
+            }
+        } else if fileManager.fileExists(atPath: promotion.destination.path) {
             guard !isSymbolicLink(at: promotion.destination),
                   let expected = promotion.publishedIdentity,
                   identity(of: promotion.destination) == expected else {
@@ -347,15 +418,7 @@ enum StoreRepairSupport {
                     "repair rollback refused to remove a destination path changed after promotion"
                 )
             }
-            try FileManager.default.removeItem(at: promotion.destination)
-        }
-        if let backup = promotion.backup,
-           FileManager.default.fileExists(atPath: backup.path) {
-            try ensureRegularFileIfPresent(at: backup, label: "promotion backup", command: "store repair")
-            guard !FileManager.default.fileExists(atPath: promotion.destination.path) else {
-                throw CLIError("repair rollback destination reappeared before backup restore")
-            }
-            try FileManager.default.moveItem(at: backup, to: promotion.destination)
+            try fileManager.removeItem(at: promotion.destination)
         }
     }
 

--- a/Sources/WaxCLI/StoreRepairSupport.swift
+++ b/Sources/WaxCLI/StoreRepairSupport.swift
@@ -320,11 +320,22 @@ enum StoreRepairSupport {
     }
 
     static func finalizePromotion(_ promotion: Promotion) throws {
-        if let backup = promotion.backup {
-            guard FileManager.default.fileExists(atPath: backup.path) else { return }
-            try ensureRegularFileIfPresent(at: backup, label: "promotion backup", command: "store repair")
-            try FileManager.default.removeItem(at: backup)
+        guard let backup = promotion.backup else { return }
+        guard FileManager.default.fileExists(atPath: backup.path) else { return }
+
+        // Retain the rollback copy unless the destination is still the exact
+        // inode that was verified and published by this promotion. A pathname
+        // race after verification must fail closed rather than deleting the
+        // only known-good prior output.
+        guard !isSymbolicLink(at: promotion.destination),
+              let expected = promotion.publishedIdentity,
+              identity(of: promotion.destination) == expected else {
+            throw CLIError(
+                "repair promotion destination changed before backup cleanup"
+            )
         }
+        try ensureRegularFileIfPresent(at: backup, label: "promotion backup", command: "store repair")
+        try FileManager.default.removeItem(at: backup)
     }
 
     static func rollbackPromotion(_ promotion: Promotion) throws {

--- a/Sources/WaxCLI/StoreRepairSupport.swift
+++ b/Sources/WaxCLI/StoreRepairSupport.swift
@@ -1,0 +1,343 @@
+import ArgumentParser
+import Foundation
+import Wax
+import WaxCore
+
+/// Path and copy guards shared by offline store-maintenance commands.
+///
+/// Maintenance commands operate on a committed source and a distinct output
+/// file. Lexical path comparison is not enough here: symlinks and hardlinks
+/// can make two different strings refer to the same store (including the live
+/// default store), and replacing one of those paths can destroy the source.
+enum StoreRepairSupport {
+    struct FileFingerprint: Equatable, Sendable {
+        let byteCount: UInt64
+        let contentHash: String
+    }
+
+    struct FileIdentity: Equatable, Sendable {
+        let canonicalPath: String
+        let device: UInt64?
+        let inode: UInt64?
+    }
+
+    struct Promotion: Sendable {
+        let destination: URL
+        let backup: URL?
+    }
+
+    static func expandedURL(_ raw: String) -> URL {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expanded).standardizedFileURL
+    }
+
+    static func canonicalURL(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    static func liveFamilyURL() -> URL {
+        canonicalURL(expandedURL(StoreSession.defaultStorePath))
+    }
+
+    static func destinationURL(from raw: String) throws -> URL {
+        let url = expandedURL(raw)
+        guard !url.path.isEmpty else {
+            throw CLIError("Output path cannot be empty")
+        }
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func stagingURL(for destination: URL) -> URL {
+        destination.deletingLastPathComponent()
+            .appendingPathComponent(
+                ".\(destination.deletingPathExtension().lastPathComponent)-repair-\(UUID().uuidString)"
+            )
+            .appendingPathExtension(destination.pathExtension.isEmpty ? "wax" : destination.pathExtension)
+    }
+
+    /// Validate path strings before ArgumentParser executes a command. This
+    /// check is intentionally also repeated after paths are resolved because a
+    /// destination may be created or replaced between parse and execution.
+    static func validate(
+        sourceRaw: String,
+        destinationRaw: String,
+        command: String
+    ) throws {
+        guard !sourceRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ValidationError("--store-path cannot be empty")
+        }
+        guard !destinationRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ValidationError("--output cannot be empty")
+        }
+        let source = expandedURL(sourceRaw)
+        let destination = expandedURL(destinationRaw)
+        try validate(source: source, destination: destination, command: command)
+    }
+
+    static func validate(
+        source: URL,
+        destination: URL,
+        command: String
+    ) throws {
+        let sourceCanonical = canonicalURL(source)
+        let destinationCanonical = canonicalURL(destination)
+        let liveCanonical = liveFamilyURL()
+
+        if sourceCanonical == liveCanonical {
+            throw ValidationError(
+                "\(command) refuses the live family store path \(StoreSession.defaultStorePath)"
+            )
+        }
+        if destinationCanonical == liveCanonical {
+            throw ValidationError(
+                "\(command) refuses the live family store path \(StoreSession.defaultStorePath)"
+            )
+        }
+
+        if isSymbolicLink(at: source) {
+            throw ValidationError(
+                "\(command) refuses a symlink source; pass the real store path"
+            )
+        }
+        if isSymbolicLink(at: destination) {
+            throw ValidationError(
+                "\(command) refuses a symlink destination; pass a new regular file path"
+            )
+        }
+
+        if sourceCanonical == destinationCanonical || sameFile(source, destination) {
+            throw ValidationError("\(command) destination must be a distinct file from source")
+        }
+
+        if sameFile(source, liveCanonical) || sameFile(destination, liveCanonical) {
+            throw ValidationError(
+                "\(command) refuses a source or destination alias of the live family store"
+            )
+        }
+
+        try ensureRegularFileIfPresent(at: source, label: "source", command: command)
+        try ensureRegularFileIfPresent(at: destination, label: "output", command: command)
+    }
+
+    static func isSymbolicLink(at url: URL) -> Bool {
+        (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil
+    }
+
+    static func identity(of url: URL) -> FileIdentity? {
+        let canonical = canonicalURL(url)
+        guard FileManager.default.fileExists(atPath: canonical.path) else { return nil }
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: canonical.path) else {
+            return FileIdentity(canonicalPath: canonical.path, device: nil, inode: nil)
+        }
+        let device = (attributes[.systemNumber] as? NSNumber)?.uint64Value
+        let inode = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+        return FileIdentity(canonicalPath: canonical.path, device: device, inode: inode)
+    }
+
+    static func sameFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        let left = identity(of: lhs)
+        let right = identity(of: rhs)
+        guard let left, let right else { return false }
+        if left.canonicalPath == right.canonicalPath { return true }
+        guard let leftInode = left.inode, let rightInode = right.inode,
+              leftInode == rightInode
+        else { return false }
+        if let leftDevice = left.device, let rightDevice = right.device {
+            return leftDevice == rightDevice
+        }
+        return true
+    }
+
+    /// Existing repair inputs/outputs must be regular files. In particular,
+    /// never let an overwrite path recursively remove a directory.
+    static func ensureRegularFileIfPresent(
+        at url: URL,
+        label: String,
+        command: String
+    ) throws {
+        let path = url.standardizedFileURL
+        guard FileManager.default.fileExists(atPath: path.path) else { return }
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path.path),
+              let type = attributes[.type] as? FileAttributeType,
+              type == .typeRegular
+        else {
+            throw CLIError("\(command) \(label) must be a regular file")
+        }
+    }
+
+    /// Take a non-blocking exclusive probe before replacing an existing
+    /// destination. Renaming over a locked file is legal on Unix and would
+    /// strand the writer on an unlinked inode, so this check belongs immediately
+    /// before promotion as well as at command start.
+    static func ensureDestinationUnlockedIfPresent(
+        at url: URL,
+        command: String
+    ) throws {
+        try ensureRegularFileIfPresent(at: url, label: "output", command: command)
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        guard try StoreLockProbe.tryExclusiveAccess(at: url.standardizedFileURL) else {
+            throw CLIError("\(command) output destination is locked by another process")
+        }
+    }
+
+    static func fingerprint(of url: URL) throws -> FileFingerprint {
+        let canonical = canonicalURL(url)
+        let handle = try FileHandle(forReadingFrom: canonical)
+        defer { try? handle.close() }
+
+        var hasher = SHA256Checksum()
+        var byteCount: UInt64 = 0
+        while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+            hasher.update(data)
+            byteCount += UInt64(data.count)
+        }
+        return FileFingerprint(byteCount: byteCount, contentHash: hasher.finalize().hexString)
+    }
+
+    /// Copy under a shared advisory lock, so a cooperating Wax writer cannot
+    /// mutate the source while the byte-for-byte snapshot is being made.
+    static func copySource(
+        from source: URL,
+        to destination: URL,
+        overwrite: Bool
+    ) throws -> FileFingerprint {
+        // Validate the caller's path spelling before resolving symlinks. If
+        // the destination is a symlink, validating only its resolved target
+        // would permit overwrite to remove the target behind the link.
+        let sourcePath = source.standardizedFileURL
+        let destinationPath = destination.standardizedFileURL
+        try validate(source: sourcePath, destination: destinationPath, command: "store repair")
+        let canonicalSource = canonicalURL(sourcePath)
+
+        let identityBefore = identity(of: canonicalSource)
+        let before = try fingerprint(of: canonicalSource)
+        let lock = try FileLock.acquire(at: canonicalSource, mode: .shared, timeout: .seconds(5))
+        defer { try? lock.release() }
+
+        guard identity(of: canonicalSource) == identityBefore else {
+            throw CLIError("source file identity changed while taking the copy")
+        }
+
+        try ensureRegularFileIfPresent(at: destinationPath, label: "output", command: "store repair")
+        if FileManager.default.fileExists(atPath: destinationPath.path) {
+            guard overwrite else {
+                throw CLIError("output destination already exists; pass --overwrite to replace it")
+            }
+            try ensureDestinationUnlockedIfPresent(at: destinationPath, command: "store repair")
+            try FileManager.default.removeItem(at: destinationPath)
+        }
+        try FileManager.default.copyItem(at: canonicalSource, to: destinationPath)
+        let copied = try fingerprint(of: destinationPath)
+        guard copied == before else {
+            try? FileManager.default.removeItem(at: destinationPath)
+            throw CLIError("source changed while taking the copy; no repair output was kept")
+        }
+        return before
+    }
+
+    /// Atomically publish a fully verified staging file. An existing regular
+    /// destination is replaced only after the new file has passed verification;
+    /// a failed repair therefore leaves the previous output untouched.
+    static func promoteVerifiedOutput(
+        from staging: URL,
+        to destination: URL,
+        overwrite: Bool
+    ) throws -> Promotion {
+        let stagingPath = staging.standardizedFileURL
+        let destinationPath = destination.standardizedFileURL
+        guard !isSymbolicLink(at: stagingPath), !isSymbolicLink(at: destinationPath) else {
+            throw CLIError("verified repair output refuses symlink staging or destination")
+        }
+        try ensureRegularFileIfPresent(at: stagingPath, label: "staging", command: "store repair")
+        try ensureRegularFileIfPresent(at: destinationPath, label: "output", command: "store repair")
+        let canonicalDestination = canonicalURL(destinationPath)
+        guard FileManager.default.fileExists(atPath: stagingPath.path) else {
+            throw CLIError("verified repair output is missing")
+        }
+
+        if FileManager.default.fileExists(atPath: destinationPath.path) {
+            guard overwrite else {
+                throw CLIError("output destination already exists; pass --overwrite to replace it")
+            }
+            try ensureDestinationUnlockedIfPresent(at: destinationPath, command: "store repair")
+            let backupName = ".\(canonicalDestination.lastPathComponent)-previous-\(UUID().uuidString)"
+            _ = try FileManager.default.replaceItemAt(
+                destinationPath,
+                withItemAt: stagingPath,
+                backupItemName: backupName,
+                options: []
+            )
+            let backupURL = destinationPath.deletingLastPathComponent()
+                .appendingPathComponent(backupName)
+            return Promotion(destination: destinationPath, backup: backupURL)
+        } else {
+            try FileManager.default.moveItem(at: stagingPath, to: destinationPath)
+            return Promotion(destination: destinationPath, backup: nil)
+        }
+    }
+
+    static func finalizePromotion(_ promotion: Promotion) throws {
+        if let backup = promotion.backup {
+            try? FileManager.default.removeItem(at: backup)
+        }
+    }
+
+    static func rollbackPromotion(_ promotion: Promotion) throws {
+        try? FileManager.default.removeItem(at: promotion.destination)
+        if let backup = promotion.backup,
+           FileManager.default.fileExists(atPath: backup.path) {
+            try FileManager.default.moveItem(at: backup, to: promotion.destination)
+        }
+    }
+
+    static func verifyDeep(at url: URL) async throws -> WaxWALStats {
+        let store = try await Wax.open(at: canonicalURL(url))
+        do {
+            try await store.verify(deep: true)
+            let wal = await store.walStats()
+            try await store.close()
+            return wal
+        } catch {
+            try? await store.close()
+            throw error
+        }
+    }
+}
+
+/// Compatibility façade retained for tests and callers of the released
+/// compact-store command. The implementation lives in StoreRepairSupport so
+/// embed-backfill and compact-store share exactly the same path policy.
+enum CompactStorePathPolicy {
+    static func validate(storePath: String, output: String) throws {
+        try StoreRepairSupport.validate(
+            sourceRaw: storePath,
+            destinationRaw: output,
+            command: "compact-store"
+        )
+    }
+
+    static func refuseLiveFamily(_ url: URL, command: String) throws {
+        let canonical = StoreRepairSupport.canonicalURL(url)
+        let live = StoreRepairSupport.liveFamilyURL()
+        if canonical == live || StoreRepairSupport.sameFile(canonical, live) {
+            throw ValidationError(
+                "\(command) refuses the live family store path \(StoreSession.defaultStorePath)"
+            )
+        }
+    }
+
+    static func destinationURL(from raw: String) throws -> URL {
+        try StoreRepairSupport.destinationURL(from: raw)
+    }
+
+    static func liveFamilyURL() -> URL {
+        StoreRepairSupport.liveFamilyURL()
+    }
+
+    static func expandedURL(_ raw: String) -> URL {
+        StoreRepairSupport.expandedURL(raw)
+    }
+}

--- a/Sources/WaxCLI/StoreRepairSupport.swift
+++ b/Sources/WaxCLI/StoreRepairSupport.swift
@@ -24,6 +24,10 @@ enum StoreRepairSupport {
     struct Promotion: Sendable {
         let destination: URL
         let backup: URL?
+        /// Identity of the file this promotion installed. Rollback only
+        /// removes this inode; a path replaced by another process is left
+        /// untouched for manual recovery.
+        let publishedIdentity: FileIdentity?
     }
 
     static func expandedURL(_ raw: String) -> URL {
@@ -160,6 +164,9 @@ enum StoreRepairSupport {
     ) throws {
         let path = url.standardizedFileURL
         guard FileManager.default.fileExists(atPath: path.path) else { return }
+        guard !isSymbolicLink(at: path) else {
+            throw CLIError("\(command) \(label) must be a regular file, not a symlink")
+        }
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: path.path),
               let type = attributes[.type] as? FileAttributeType,
               type == .typeRegular
@@ -171,7 +178,10 @@ enum StoreRepairSupport {
     /// Take a non-blocking exclusive probe before replacing an existing
     /// destination. Renaming over a locked file is legal on Unix and would
     /// strand the writer on an unlinked inode, so this check belongs immediately
-    /// before promotion as well as at command start.
+    /// before promotion as well as at command start. The probe is advisory and
+    /// cannot stop an uncooperating process from swapping the pathname after
+    /// it closes; no-follow checks and identity matching below keep rollback
+    /// from deleting an unexpected path.
     static func ensureDestinationUnlockedIfPresent(
         at url: URL,
         command: String
@@ -227,6 +237,11 @@ enum StoreRepairSupport {
                 throw CLIError("output destination already exists; pass --overwrite to replace it")
             }
             try ensureDestinationUnlockedIfPresent(at: destinationPath, command: "store repair")
+            let destinationIdentity = identity(of: destinationPath)
+            guard !isSymbolicLink(at: destinationPath),
+                  identity(of: destinationPath) == destinationIdentity else {
+                throw CLIError("output destination changed while preparing the copy")
+            }
             try FileManager.default.removeItem(at: destinationPath)
         }
         try FileManager.default.copyItem(at: canonicalSource, to: destinationPath)
@@ -244,7 +259,8 @@ enum StoreRepairSupport {
     static func promoteVerifiedOutput(
         from staging: URL,
         to destination: URL,
-        overwrite: Bool
+        overwrite: Bool,
+        source: URL? = nil
     ) throws -> Promotion {
         let stagingPath = staging.standardizedFileURL
         let destinationPath = destination.standardizedFileURL
@@ -257,12 +273,28 @@ enum StoreRepairSupport {
         guard FileManager.default.fileExists(atPath: stagingPath.path) else {
             throw CLIError("verified repair output is missing")
         }
+        // The staging pathname is also untrusted until the atomic operation;
+        // do not move a path that was swapped to a symlink or directory.
+        try ensureRegularFileIfPresent(at: stagingPath, label: "staging", command: "store repair")
+        if let source {
+            guard !sameFile(source, destinationPath) else {
+                throw CLIError("verified repair output destination aliases source")
+            }
+        }
 
         if FileManager.default.fileExists(atPath: destinationPath.path) {
             guard overwrite else {
                 throw CLIError("output destination already exists; pass --overwrite to replace it")
             }
             try ensureDestinationUnlockedIfPresent(at: destinationPath, command: "store repair")
+            // Re-check immediately before replace. The advisory lock is
+            // released by the probe, so an external writer can still race;
+            // these no-follow checks minimize the unsafe window and the
+            // identity carried by Promotion makes rollback fail closed.
+            try ensureRegularFileIfPresent(at: destinationPath, label: "output", command: "store repair")
+            guard !isSymbolicLink(at: destinationPath) else {
+                throw CLIError("verified repair output refuses a destination symlink")
+            }
             let backupName = ".\(canonicalDestination.lastPathComponent)-previous-\(UUID().uuidString)"
             _ = try FileManager.default.replaceItemAt(
                 destinationPath,
@@ -272,23 +304,46 @@ enum StoreRepairSupport {
             )
             let backupURL = destinationPath.deletingLastPathComponent()
                 .appendingPathComponent(backupName)
-            return Promotion(destination: destinationPath, backup: backupURL)
+            return Promotion(
+                destination: destinationPath,
+                backup: backupURL,
+                publishedIdentity: identity(of: destinationPath)
+            )
         } else {
             try FileManager.default.moveItem(at: stagingPath, to: destinationPath)
-            return Promotion(destination: destinationPath, backup: nil)
+            return Promotion(
+                destination: destinationPath,
+                backup: nil,
+                publishedIdentity: identity(of: destinationPath)
+            )
         }
     }
 
     static func finalizePromotion(_ promotion: Promotion) throws {
         if let backup = promotion.backup {
-            try? FileManager.default.removeItem(at: backup)
+            guard FileManager.default.fileExists(atPath: backup.path) else { return }
+            try ensureRegularFileIfPresent(at: backup, label: "promotion backup", command: "store repair")
+            try FileManager.default.removeItem(at: backup)
         }
     }
 
     static func rollbackPromotion(_ promotion: Promotion) throws {
-        try? FileManager.default.removeItem(at: promotion.destination)
+        if FileManager.default.fileExists(atPath: promotion.destination.path) {
+            guard !isSymbolicLink(at: promotion.destination),
+                  let expected = promotion.publishedIdentity,
+                  identity(of: promotion.destination) == expected else {
+                throw CLIError(
+                    "repair rollback refused to remove a destination path changed after promotion"
+                )
+            }
+            try FileManager.default.removeItem(at: promotion.destination)
+        }
         if let backup = promotion.backup,
            FileManager.default.fileExists(atPath: backup.path) {
+            try ensureRegularFileIfPresent(at: backup, label: "promotion backup", command: "store repair")
+            guard !FileManager.default.fileExists(atPath: promotion.destination.path) else {
+                throw CLIError("repair rollback destination reappeared before backup restore")
+            }
             try FileManager.default.moveItem(at: backup, to: promotion.destination)
         }
     }

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -23,6 +23,8 @@ struct WaxCLI: ParsableCommand {
             CorpusSearchCommand.self,
             DaemonCommand.self,
             StatsCommand.self,
+            CompactStoreCommand.self,
+            EmbedBackfillCommand.self,
             VectorHealthCommand.self,
             FlushCommand.self,
             SessionStartCommand.self,

--- a/Sources/WaxCore/Constants.swift
+++ b/Sources/WaxCore/Constants.swift
@@ -40,10 +40,17 @@ package enum Constants {
     /// WAL starts immediately after the header region.
     package static let walOffset: UInt64 = headerRegionSize
 
-    /// Default WAL size used by tests/examples (256 MiB).
-    package static let defaultWalSize: UInt64 = 256 * 1024 * 1024
+    /// WAL size for newly created long-term stores (8 MiB).
+    /// Existing 256 MiB files stay 256 MiB until copy-first compact; this only affects new creates.
+    package static let longTermWalSize: UInt64 = 8 * 1024 * 1024
 
-    /// WAL size for new broker virtual session stores only; open keeps existing WAL. Long-term stores keep `defaultWalSize`.
+    /// Historical long-term WAL size retained by existing stores until copy-first compact.
+    package static let legacyLargeWalSize: UInt64 = 256 * 1024 * 1024
+
+    /// Default WAL size for new long-term stores.
+    package static let defaultWalSize: UInt64 = longTermWalSize
+
+    /// WAL size for new broker virtual session stores only; open keeps existing WAL.
     package static let sessionWalSize: UInt64 = 4 * 1024 * 1024
 
     // MARK: - Decoder Limits (recommended defaults)

--- a/Sources/WaxCore/WAL/WALSizing.swift
+++ b/Sources/WaxCore/WAL/WALSizing.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Package-facing WAL sizing helpers for higher-level maintenance code.
+package enum WALSizing {
+    /// Return the bytes consumed by a put-frame WAL record, including the
+    /// fixed record header and the encoded frame metadata entry.
+    package static func putFrameRecordBytes(_ put: PutFrame) throws -> UInt64 {
+        let encodedEntry = try WALEntryCodec.encode(.putFrame(put))
+        return UInt64(WALRecord.headerSize + encodedEntry.count)
+    }
+}

--- a/Sources/WaxCore/Wax.swift
+++ b/Sources/WaxCore/Wax.swift
@@ -2887,6 +2887,15 @@ package actor Wax {
         }
     }
 
+    /// Return whether a WAL payload can be appended without overflowing the
+    /// current pending ring. Higher-level maintenance uses this preflight to
+    /// commit a batch before writing the next frame record.
+    package func canAppendWALPayload(payloadSize: Int) async -> Bool {
+        await withReadLock {
+            wal.canAppend(payloadSize: payloadSize)
+        }
+    }
+
     package func timeline(_ query: TimelineQuery) async -> [FrameMeta] {
         await withReadLock {
             TimelineQuery.filter(frames: toc.frames, query: query)

--- a/Sources/WaxCore/WaxCore.docc/Articles/FileFormat.md
+++ b/Sources/WaxCore/WaxCore.docc/Articles/FileFormat.md
@@ -11,7 +11,7 @@ Offset          Region              Size
 ──────          ──────              ────
 0 KiB           Header Page A       4 KiB
 4 KiB           Header Page B       4 KiB
-8 KiB           WAL Ring Buffer     Configurable (default 256 MiB)
+8 KiB           WAL Ring Buffer     Configurable (default 8 MiB)
 WAL + 8 KiB     Frame Payloads      Variable
 After Payloads  TOC                 Variable
 After TOC       Footer              64 bytes
@@ -117,7 +117,7 @@ Frame payloads support four encoding strategies via ``CanonicalEncoding``:
 | Header region (A+B) | 8 KiB |
 | Footer size | 64 bytes |
 | WAL record header | 48 bytes |
-| Default WAL size | 256 MiB |
+| Default WAL size | 8 MiB |
 | Max string bytes | 16 MiB |
 | Max blob bytes | 256 MiB |
 | Max array count | 10,000,000 |

--- a/Sources/WaxCore/WaxCore.docc/Articles/WALAndCrashRecovery.md
+++ b/Sources/WaxCore/WaxCore.docc/Articles/WALAndCrashRecovery.md
@@ -12,7 +12,7 @@ The WAL (Write-Ahead Log) is a fixed-size circular ring buffer that records all 
 
 ## Ring Buffer Architecture
 
-The WAL occupies a contiguous region starting at file offset 8 KiB. Its default size is 256 MiB, configurable at creation time. The ring buffer uses two pointers:
+The WAL occupies a contiguous region starting at file offset 8 KiB. Its default size is 8 MiB, configurable at creation time. The ring buffer uses two pointers:
 
 - **Write position** — where the next record will be written
 - **Checkpoint position** — the boundary of committed records

--- a/Tests/WaxCLITests/CompactStoreCommandTests.swift
+++ b/Tests/WaxCLITests/CompactStoreCommandTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+import WaxCore
+@testable import wax_cli
+
+struct CompactStoreCommandTests {
+    @Test func compactStoreRequiresDirectStoreFlag() throws {
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--store-path", "/tmp/wax-compact-in.wax",
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+    }
+
+    @Test func compactStoreRefusesLiveFamilyPath() throws {
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", StoreSession.defaultStorePath,
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax",
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+        // Quoted trailing space must still refuse: open trims, so this is the live file.
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax ",
+                "--output", "/tmp/wax-compact-out.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", "/tmp/wax-compact-in.wax",
+                "--output", StoreSession.defaultStorePath,
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--overwrite",
+                "--store-path", "/tmp/wax-compact-in.wax",
+                "--output", "~/.wax/memory.wax",
+            ])
+        }
+    }
+
+    @Test func compactStoreRewritesTempCopyWithLongTermWal() async throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-compact-src-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        let destURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-compact-dst-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destURL)
+        }
+
+        let source = try await Wax.create(at: sourceURL)
+        for index in 0..<5 {
+            _ = try await source.put(
+                Data("compact live payload \(index)".utf8),
+                options: FrameMetaSubset(searchText: "compact live payload \(index)")
+            )
+        }
+        try await source.commit()
+        let sourceWal = await source.walStats()
+        #expect(sourceWal.walSize == Constants.defaultWalSize)
+        try await source.close()
+
+        var command = try CompactStoreCommand.parse([
+            "--direct-store",
+            "--no-embedder",
+            "--store-path", sourceURL.path,
+            "--output", destURL.path,
+            "--format", "json",
+        ])
+        try await command.runAsync()
+
+        let dest = try await Wax.open(at: destURL)
+        let destWal = await dest.walStats()
+        // Shipped rewriteLiveSet automatic dest for a 256 MiB source with small
+        // payload is sessionWalSize. Constants.longTermWalSize is not on this line.
+        #expect(destWal.walSize == Constants.sessionWalSize)
+        try await dest.verify(deep: true)
+        try await dest.close()
+
+        let destSize = try destURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        #expect(destSize < 32 * 1024 * 1024)
+        #expect(destSize < Int(Constants.defaultWalSize))
+    }
+}

--- a/Tests/WaxCLITests/CompactStoreCommandTests.swift
+++ b/Tests/WaxCLITests/CompactStoreCommandTests.swift
@@ -76,6 +76,7 @@ struct CompactStoreCommandTests {
         let sourceWal = await source.walStats()
         #expect(sourceWal.walSize == Constants.defaultWalSize)
         try await source.close()
+        let sourceHashBefore = try StoreRepairSupport.fingerprint(of: sourceURL)
 
         var command = try CompactStoreCommand.parse([
             "--direct-store",
@@ -97,5 +98,6 @@ struct CompactStoreCommandTests {
         let destSize = try destURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
         #expect(destSize < 32 * 1024 * 1024)
         #expect(destSize < Int(Constants.defaultWalSize))
+        #expect(try StoreRepairSupport.fingerprint(of: sourceURL) == sourceHashBefore)
     }
 }

--- a/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
+++ b/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
@@ -18,6 +18,7 @@ struct EmbedBackfillCommandTests {
             _ = try EmbedBackfillCommand.parse([
                 "--store-path", "/tmp/wax-backfill.wax",
                 "--no-embedder",
+                "--output", "/tmp/wax-backfill-out.wax",
             ])
         }
     }
@@ -27,18 +28,21 @@ struct EmbedBackfillCommandTests {
             _ = try EmbedBackfillCommand.parse([
                 "--direct-store",
                 "--store-path", StoreSession.defaultStorePath,
+                "--output", "/tmp/wax-backfill-out.wax",
             ])
         }
         #expect(throws: (any Error).self) {
             _ = try EmbedBackfillCommand.parse([
                 "--direct-store",
                 "--store-path", "~/.wax/memory.wax",
+                "--output", "/tmp/wax-backfill-out.wax",
             ])
         }
         #expect(throws: (any Error).self) {
             _ = try EmbedBackfillCommand.parse([
                 "--direct-store",
                 "--store-path", "~/.wax/memory.wax ",
+                "--output", "/tmp/wax-backfill-out.wax",
             ])
         }
     }
@@ -62,6 +66,8 @@ struct EmbedBackfillCommandTests {
             "--direct-store",
             "--no-embedder",
             "--store-path", storeURL.path,
+            "--output", FileManager.default.temporaryDirectory
+                .appendingPathComponent("wax-backfill-out-\(UUID().uuidString).wax").path,
             "--format", "json",
         ])
         do {

--- a/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
+++ b/Tests/WaxCLITests/EmbedBackfillCommandTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+import Wax
+import WaxCore
+@testable import wax_cli
+
+struct EmbedBackfillCommandTests {
+    @Test func waxCLIExposesEmbedBackfillCommand() throws {
+        let source = try String(
+            contentsOfFile: "Sources/WaxCLI/WaxCLICommand.swift",
+            encoding: .utf8
+        )
+        #expect(source.contains("EmbedBackfillCommand.self"))
+    }
+
+    @Test func embedBackfillRequiresDirectStoreFlag() throws {
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--store-path", "/tmp/wax-backfill.wax",
+                "--no-embedder",
+            ])
+        }
+    }
+
+    @Test func embedBackfillRefusesLiveFamilyPath() throws {
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", StoreSession.defaultStorePath,
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax ",
+            ])
+        }
+    }
+
+    @Test func embedBackfillNoEmbedderFailsClosed() async throws {
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-backfill-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        do {
+            var config = OrchestratorConfig.default
+            config.enableVectorSearch = false
+            let memory = try await MemoryOrchestrator(at: storeURL, config: config)
+            try await memory.remember("text-only frame must not invent vectors")
+            try await memory.flush()
+            try await memory.close()
+        }
+
+        var command = try EmbedBackfillCommand.parse([
+            "--direct-store",
+            "--no-embedder",
+            "--store-path", storeURL.path,
+            "--format", "json",
+        ])
+        do {
+            try await command.runAsync()
+            Issue.record("embed-backfill --no-embedder must fail closed")
+        } catch let error as CLIError {
+            #expect(error.message.lowercased().contains("embedder") || error.message.lowercased().contains("no-embedder"))
+        } catch let error as WaxError {
+            guard case .missingEmbedder = error else {
+                Issue.record("expected WaxError.missingEmbedder, got \(error)")
+                return
+            }
+        }
+
+        let reopened = try await MemoryOrchestrator(at: storeURL, config: {
+            var config = OrchestratorConfig.default
+            config.enableVectorSearch = false
+            return config
+        }())
+        let stats = await reopened.runtimeStats()
+        #expect(stats.embeddingStatus == .disabled)
+        try await reopened.close()
+    }
+}

--- a/Tests/WaxCLITests/StoreRepairSupportTests.swift
+++ b/Tests/WaxCLITests/StoreRepairSupportTests.swift
@@ -92,4 +92,29 @@ struct StoreRepairSupportTests {
         #expect(StoreRepairSupport.isSymbolicLink(at: destination))
         #expect(try Data(contentsOf: attackerTarget) == Data("attacker".utf8))
     }
+
+    @Test
+    func rollbackRetainsPublishedDestinationWhenBackupDisappears() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-rollback-missing-backup-\(UUID().uuidString)", isDirectory: true)
+        let destination = root.appendingPathComponent("destination.wax")
+        let staging = root.appendingPathComponent("staging.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: destination.path, contents: Data("previous".utf8))
+        FileManager.default.createFile(atPath: staging.path, contents: Data("published".utf8))
+        let promotion = try StoreRepairSupport.promoteVerifiedOutput(
+            from: staging,
+            to: destination,
+            overwrite: true
+        )
+        let backup = try #require(promotion.backup)
+        try FileManager.default.removeItem(at: backup)
+
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.rollbackPromotion(promotion)
+        }
+        #expect(try Data(contentsOf: destination) == Data("published".utf8))
+    }
 }

--- a/Tests/WaxCLITests/StoreRepairSupportTests.swift
+++ b/Tests/WaxCLITests/StoreRepairSupportTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+import WaxCore
+@testable import wax_cli
+
+@Suite("Store repair path safety", .serialized)
+struct StoreRepairSupportTests {
+    @Test
+    func rejectsSymlinkHardlinkDirectoryAndLockedDestinations() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-paths-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("source.wax")
+        let hardlink = root.appendingPathComponent("source-hardlink.wax")
+        let sourceLink = root.appendingPathComponent("source-link.wax")
+        let destination = root.appendingPathComponent("destination.wax")
+        let destinationLink = root.appendingPathComponent("destination-link.wax")
+        let destinationDirectory = root.appendingPathComponent("destination-directory", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: source.path, contents: Data("source".utf8))
+        try FileManager.default.linkItem(at: source, to: hardlink)
+        try FileManager.default.createSymbolicLink(at: sourceLink, withDestinationURL: source)
+        FileManager.default.createFile(atPath: destination.path, contents: Data("destination".utf8))
+        try FileManager.default.createSymbolicLink(at: destinationLink, withDestinationURL: destination)
+        try FileManager.default.createDirectory(at: destinationDirectory, withIntermediateDirectories: true)
+
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.validate(source: source, destination: hardlink, command: "compact-store")
+        }
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.validate(source: sourceLink, destination: root.appendingPathComponent("new.wax"), command: "compact-store")
+        }
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.validate(source: source, destination: destinationLink, command: "compact-store")
+        }
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.validate(source: source, destination: destinationDirectory, command: "compact-store")
+        }
+
+        let lock = try FileLock.acquire(at: destination, mode: .exclusive)
+        defer { try? lock.release() }
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.ensureDestinationUnlockedIfPresent(at: destination, command: "compact-store")
+        }
+    }
+
+    @Test
+    func copySourcePreservesFingerprintAndCreatesNestedDestination() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-copy-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("source.wax")
+        let copy = root.appendingPathComponent("nested/copy.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: source.path, contents: Data("source bytes".utf8))
+        let before = try StoreRepairSupport.fingerprint(of: source)
+        let destination = try StoreRepairSupport.destinationURL(from: copy.path)
+        let copied = try StoreRepairSupport.copySource(from: source, to: destination, overwrite: false)
+
+        #expect(copied == before)
+        #expect(try StoreRepairSupport.fingerprint(of: source) == before)
+        #expect(try StoreRepairSupport.fingerprint(of: destination) == before)
+    }
+}

--- a/Tests/WaxCLITests/StoreRepairSupportTests.swift
+++ b/Tests/WaxCLITests/StoreRepairSupportTests.swift
@@ -63,4 +63,33 @@ struct StoreRepairSupportTests {
         #expect(try StoreRepairSupport.fingerprint(of: source) == before)
         #expect(try StoreRepairSupport.fingerprint(of: destination) == before)
     }
+
+    @Test
+    func rollbackLeavesSwappedSymlinkDestinationUntouched() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-rollback-\(UUID().uuidString)", isDirectory: true)
+        let destination = root.appendingPathComponent("destination.wax")
+        let staging = root.appendingPathComponent("staging.wax")
+        let attackerTarget = root.appendingPathComponent("attacker-target.txt")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: destination.path, contents: Data("previous".utf8))
+        FileManager.default.createFile(atPath: staging.path, contents: Data("published".utf8))
+        let promotion = try StoreRepairSupport.promoteVerifiedOutput(
+            from: staging,
+            to: destination,
+            overwrite: true
+        )
+
+        FileManager.default.createFile(atPath: attackerTarget.path, contents: Data("attacker".utf8))
+        try FileManager.default.removeItem(at: destination)
+        try FileManager.default.createSymbolicLink(at: destination, withDestinationURL: attackerTarget)
+
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.rollbackPromotion(promotion)
+        }
+        #expect(StoreRepairSupport.isSymbolicLink(at: destination))
+        #expect(try Data(contentsOf: attackerTarget) == Data("attacker".utf8))
+    }
 }

--- a/Tests/WaxCoreTests/DefaultWalSizeTests.swift
+++ b/Tests/WaxCoreTests/DefaultWalSizeTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import WaxCore
+
+@Test func createUsesLongTermWalSizeByDefault() async throws {
+    let url = TempFiles.uniqueURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let wax = try await Wax.create(at: url)
+    let walStats = await wax.walStats()
+    try await wax.close()
+
+    #expect(walStats.walSize == Constants.longTermWalSize)
+}
+
+@Test func emptyStoreLogicalSizeIsNotLegacyLargeWal() async throws {
+    let url = TempFiles.uniqueURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let wax = try await Wax.create(at: url)
+    try await wax.close()
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+    let logicalSize = try #require(attributes[.size] as? NSNumber).uint64Value
+    #expect(logicalSize < Constants.legacyLargeWalSize)
+}
+
+@Test func sessionWalSizeUnchanged() {
+    #expect(Constants.sessionWalSize == 4 * 1024 * 1024)
+}

--- a/Tests/WaxIntegrationTests/DocumentationExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/DocumentationExamplesTests.swift
@@ -73,6 +73,23 @@ func websiteGettingStartedUsesPublicMemoryQuickStart() throws {
 }
 
 @Test
+func websiteStoreMaintenanceDocumentsCopyFirstOperatorContract() throws {
+    let path = DocumentationPaths.websiteDocs
+        .appendingPathComponent("core/store-maintenance.md")
+    let text = try String(contentsOf: path, encoding: .utf8)
+
+    #expect(text.contains("compact-store"))
+    #expect(text.contains("embed-backfill"))
+    #expect(text.contains("--direct-store"))
+    #expect(text.contains("--output"))
+    #expect(text.contains("--overwrite"))
+    #expect(text.contains("source file unchanged"))
+    #expect(text.contains("deep verification"))
+    #expect(text.contains("advisory lock"))
+    #expect(!text.contains("MemoryOrchestrator"))
+}
+
+@Test
 func websiteFoundationModelsGuideMatchesPublicSessionAPI() throws {
     let path = DocumentationPaths.websiteDocs
         .appendingPathComponent("ios/foundation-models.md")

--- a/Tests/WaxIntegrationTests/EmbeddingBackfillTests.swift
+++ b/Tests/WaxIntegrationTests/EmbeddingBackfillTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+import Wax
+
+@Test
+func backfillUnembeddedLiveChunksClearsDegradedAndRanksKnownHit() async throws {
+    try await TempFiles.withTempFile { url in
+        let needle = "unique backfill needle about swift actors"
+        let decoy = "unrelated gardening notes about tomatoes"
+
+        do {
+            let seeded = try await Memory(at: url) {
+                $0.enableVectorSearch = false
+                $0.requireOnDeviceProviders = false
+            }
+            try await seeded.save(needle)
+            try await seeded.save(decoy)
+            try await seeded.flush()
+            try await seeded.close()
+        }
+
+        let provider = DeterministicTextEmbedder()
+        let memory = try await Memory(at: url) {
+            $0.requireOnDeviceProviders = false
+            $0.embedding = .custom(provider)
+        }
+
+        let before = await memory.stats()
+        guard case .degraded = before.embeddingStatus else {
+            Issue.record("expected degraded before backfill, got \(before.embeddingStatus)")
+            try await memory.close()
+            return
+        }
+        #expect(before.framesWithoutVectors > 0)
+        #expect(before.queryEmbedderConfigured)
+
+        let first = try await memory.backfillUnembedded()
+        #expect(first > 0)
+        try await memory.flush()
+
+        let after = await memory.stats()
+        #expect(after.embeddingStatus == .active(provider.identity))
+        #expect(after.framesWithoutVectors == 0)
+
+        let vectorHits = try await memory.search(
+            needle,
+            options: .init(topK: 1, mode: .vectorOnly)
+        )
+        #expect(vectorHits.items.first?.text.contains("swift actors") == true)
+
+        let hybridHits = try await memory.search(
+            needle,
+            options: .init(topK: 1, mode: .hybrid())
+        )
+        #expect(hybridHits.items.first?.text.contains("swift actors") == true)
+
+        let second = try await memory.backfillUnembedded()
+        #expect(second == 0)
+        try await memory.flush()
+        let again = await memory.stats()
+        #expect(again.embeddingStatus == .active(provider.identity))
+        #expect(again.framesWithoutVectors == 0)
+
+        try await memory.close()
+    }
+}
+
+@Test
+func backfillUnembeddedClearsDegradedWhenEverySourceFrameHasAVector() async throws {
+    try await TempFiles.withTempFile { url in
+        let provider = DeterministicTextEmbedder()
+        let staleText = "an old source frame whose vector remains in the index"
+        let currentText = "the live source frame that backfill must embed"
+
+        do {
+            let seeded = try await Memory(
+                at: url,
+                config: .init(
+                    requireOnDeviceProviders: false,
+                    embedding: .custom(provider)
+                )
+            )
+            try await seeded.save(staleText)
+            try await seeded.flush()
+            try await seeded.close()
+        }
+
+        do {
+            let textOnly = try await Memory(
+                at: url,
+                config: .init(
+                    enableVectorSearch: false,
+                    requireOnDeviceProviders: false
+                )
+            )
+            let staleResults = try await textOnly.search(
+                staleText,
+                options: .init(topK: 1, mode: .textOnly)
+            )
+            guard let staleFrameId = staleResults.items.first?.frameId else {
+                Issue.record("setup: expected the vectorized source frame to be searchable")
+                try await textOnly.close()
+                return
+            }
+            try await textOnly.delete(frameID: staleFrameId)
+            try await textOnly.save(currentText)
+            try await textOnly.flush()
+            try await textOnly.close()
+        }
+
+        let memory = try await Memory(
+            at: url,
+            config: .init(
+                requireOnDeviceProviders: false,
+                embedding: .custom(provider)
+            )
+        )
+        let before = await memory.stats()
+        #expect(before.framesWithoutVectors == 1)
+        guard case .degraded = before.embeddingStatus else {
+            Issue.record("expected degraded coverage before backfill, got \(before.embeddingStatus)")
+            try await memory.close()
+            return
+        }
+
+        let embedded = try await memory.backfillUnembedded()
+        #expect(embedded == 1)
+        try await memory.flush()
+
+        let after = await memory.stats()
+        #expect(after.framesWithoutVectors == 0)
+        #expect(after.embeddingStatus == .active(provider.identity))
+        try await memory.close()
+    }
+}
+
+@Test
+func backfillUnembeddedFailsClosedWithoutEmbedder() async throws {
+    try await TempFiles.withTempFile { url in
+        let memory = try await Memory(at: url) {
+            $0.enableVectorSearch = false
+            $0.requireOnDeviceProviders = false
+        }
+        try await memory.save("text-only frame must not invent vectors")
+        try await memory.flush()
+
+        do {
+            _ = try await memory.backfillUnembedded()
+            Issue.record("backfill without an embedder must fail closed")
+        } catch let error as WaxError {
+            guard case .missingEmbedder = error else {
+                Issue.record("expected WaxError.missingEmbedder, got \(error)")
+                try await memory.close()
+                return
+            }
+        }
+
+        let stats = await memory.stats()
+        #expect(stats.embeddingStatus == .disabled)
+        try await memory.close()
+    }
+}

--- a/Tests/WaxIntegrationTests/EmbeddingReadinessMemoryTests.swift
+++ b/Tests/WaxIntegrationTests/EmbeddingReadinessMemoryTests.swift
@@ -497,6 +497,67 @@ func waitUntilReadyForRememberThrowsWhenCompileFails() async throws {
     }
 }
 
+@Test
+func framesWithoutVectorsCountsUnembeddedSourceFramesNotChunks() async throws {
+    try await TempFiles.withTempFile { url in
+        let provider = DeterministicTextEmbedder()
+        let staleText = "this source frame has a vector before deletion"
+        let currentText = "this live source frame still needs a vector"
+
+        do {
+            let seeded = try await Memory(
+                at: url,
+                config: .init(
+                    requireOnDeviceProviders: false,
+                    embedding: .custom(provider)
+                )
+            )
+            try await seeded.save(staleText)
+            try await seeded.flush()
+            try await seeded.close()
+        }
+
+        do {
+            let textOnly = try await Memory(
+                at: url,
+                config: .init(
+                    enableVectorSearch: false,
+                    requireOnDeviceProviders: false
+                )
+            )
+            let staleResults = try await textOnly.search(
+                staleText,
+                options: .init(topK: 1, mode: .textOnly)
+            )
+            guard let staleFrameId = staleResults.items.first?.frameId else {
+                Issue.record("setup: expected the vectorized source frame to be searchable")
+                try await textOnly.close()
+                return
+            }
+            try await textOnly.delete(frameID: staleFrameId)
+            try await textOnly.save(currentText)
+            try await textOnly.flush()
+            try await textOnly.close()
+        }
+
+        let reopened = try await Memory(
+            at: url,
+            config: .init(
+                requireOnDeviceProviders: false,
+                embedding: .custom(provider)
+            )
+        )
+        let stats = await reopened.stats()
+        #expect(stats.framesWithoutVectors == 1)
+        guard case .degraded = stats.embeddingStatus else {
+            Issue.record("expected degraded coverage for the live source without a vector, got \(stats.embeddingStatus)")
+            try await reopened.close()
+            return
+        }
+        try await reopened.close()
+    }
+}
+
 private enum TestReadinessError: Error {
     case boom
 }

--- a/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
+++ b/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
@@ -94,6 +94,97 @@ func rewriteLiveSetDropsNonLivePayloadsAndPreservesFrameState() async throws {
 }
 
 @Test
+func rewriteLiveSetWalSizeFloorsAtSessionSizeAndCapsAtSourceRing() {
+    let session = Constants.sessionWalSize
+    let defaultRing = Constants.defaultWalSize
+
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: defaultRing,
+            payloadBytes: 107_000
+        ) == session
+    )
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: defaultRing,
+            payloadBytes: session + 1
+        ) == session + 1
+    )
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: defaultRing,
+            payloadBytes: defaultRing + 1
+        ) == defaultRing
+    )
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: session / 2,
+            payloadBytes: 1
+        ) == session / 2
+    )
+}
+
+@Test
+func rewriteLiveSetChoosesWalSizeFromPayloadNotSourceRing() async throws {
+    try await TempFiles.withTempFile { sourceURL in
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: destinationURL) }
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+
+        do {
+            let wax = try await Wax.create(at: sourceURL)
+            for index in 0..<20 {
+                _ = try await wax.put(
+                    Data("small live payload \(index)".utf8),
+                    options: FrameMetaSubset(searchText: "small live payload \(index)")
+                )
+            }
+            try await wax.commit()
+            let sourceWal = await wax.walStats()
+            #expect(sourceWal.walSize == Constants.defaultWalSize)
+            try await wax.close()
+        }
+
+        let sourceSizesBefore = try fileSizes(at: sourceURL)
+        #expect(sourceSizesBefore.logical >= Constants.defaultWalSize)
+
+        let report: LiveSetRewriteReport
+        do {
+            let orchestrator = try await MemoryOrchestrator(at: sourceURL, config: config)
+            report = try await orchestrator.rewriteLiveSet(to: destinationURL)
+            try await orchestrator.close()
+        }
+
+        let sourceSizesAfter = try fileSizes(at: sourceURL)
+        #expect(sourceSizesAfter.logical == sourceSizesBefore.logical)
+
+        let rewrittenWax = try await Wax.open(at: destinationURL)
+        let destWal = await rewrittenWax.walStats()
+        #expect(destWal.walSize == Constants.sessionWalSize)
+        #expect(destWal.walSize >= Constants.sessionWalSize)
+        #expect(destWal.walSize <= Constants.defaultWalSize)
+        #expect(destWal.walSize <= 8 * 1024 * 1024)
+
+        let destFrames = await rewrittenWax.frameMetas()
+        #expect(destFrames.count == 20)
+        #expect(destFrames.filter { $0.status == .active && $0.supersededBy == nil }.count == 20)
+        try await rewrittenWax.verify()
+        try await rewrittenWax.close()
+
+        let destSizes = try fileSizes(at: destinationURL)
+        #expect(destSizes.logical < sourceSizesBefore.logical)
+        #expect(destSizes.logical < 16 * 1024 * 1024)
+        #expect(report.logicalBytesAfter < report.logicalBytesBefore)
+        #expect(report.frameCount == 20)
+        #expect(report.activeFrameCount == 20)
+    }
+}
+
+@Test
 func rewriteLiveSetRespectsDestinationOverwriteGuard() async throws {
     try await TempFiles.withTempFile { sourceURL in
         let destinationURL = FileManager.default.temporaryDirectory

--- a/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
+++ b/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 import Wax
 import WaxCore
+import WaxVectorSearch
 
 @Test
 func rewriteLiveSetDropsNonLivePayloadsAndPreservesFrameState() async throws {
@@ -335,6 +336,61 @@ func rewriteLiveSetRefusesDirectoryAndLockedDestinationBeforePromotion() async t
 }
 
 @Test
+func rewriteLiveSetPreservesMemoryBindingAndRejectsIncompatibleProvider() async throws {
+    try await TempFiles.withTempFile { sourceURL in
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: destinationURL) }
+
+        let source = try await Wax.create(at: sourceURL)
+        let binding = MemoryBinding(
+            embeddingProvider: "rewrite-provider",
+            embeddingModel: "rewrite-model-v1",
+            embeddingDimensions: 4,
+            embeddingNormalized: true
+        )
+        try await source.overwriteMemoryBindingForTesting(binding)
+        _ = try await source.put(
+            Data("binding preservation frame".utf8),
+            options: FrameMetaSubset(searchText: "binding preservation frame")
+        )
+        try await source.commit()
+        try await source.close()
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        let orchestrator = try await MemoryOrchestrator(at: sourceURL, config: config)
+        _ = try await orchestrator.rewriteLiveSet(to: destinationURL)
+        try await orchestrator.close()
+
+        let rewritten = try await Wax.open(at: destinationURL)
+        #expect(await rewritten.memoryBinding() == binding)
+        try await rewritten.close()
+
+        var vectorConfig = OrchestratorConfig.default
+        vectorConfig.enableVectorSearch = true
+        do {
+            _ = try await MemoryOrchestrator(
+                at: destinationURL,
+                config: vectorConfig,
+                embedder: RewriteBindingEmbedder(
+                    provider: "rewrite-provider",
+                    model: "rewrite-model-v2"
+                )
+            )
+            Issue.record("rewrite output must retain the binding and reject an incompatible provider")
+        } catch let error as WaxError {
+            guard case .io(let reason) = error else {
+                Issue.record("expected memory binding mismatch, got \(error)")
+                return
+            }
+            #expect(reason.contains("memory binding"))
+        }
+    }
+}
+
+@Test
 func scheduledLiveSetRewriteCreatesValidatedCandidateWhenThresholdMet() async throws {
     try await TempFiles.withTempFile { sourceURL in
         let maintenanceDir = FileManager.default.temporaryDirectory
@@ -562,6 +618,26 @@ private func seedDeadPayloadStore(at url: URL) async throws {
 
     try await wax.commit()
     try await wax.close()
+}
+
+private struct RewriteBindingEmbedder: EmbeddingProvider, Sendable {
+    let dimensions: Int = 4
+    let normalize: Bool = true
+    let identity: EmbeddingIdentity?
+
+    init(provider: String, model: String) {
+        identity = EmbeddingIdentity(
+            provider: provider,
+            model: model,
+            dimensions: 4,
+            normalized: true
+        )
+    }
+
+    func embed(_ text: String) async throws -> [Float] {
+        _ = text
+        return [0.5, 0.5, 0.5, 0.5]
+    }
 }
 
 private func fileSizes(at url: URL) throws -> (logical: UInt64, allocated: UInt64) {

--- a/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
+++ b/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
@@ -210,6 +210,58 @@ func rewriteLiveSetBatchesWhenAggregateFrameWalExceedsSourceRing() async throws 
 }
 
 @Test
+func rewriteLiveSetPreflightsLargeNextFrameBeforeAppending() async throws {
+    try await TempFiles.withTempFile { sourceURL in
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: destinationURL) }
+
+        let sourceWalSize = 8 * 1024 * 1024
+        let firstMetadata = String(repeating: "a", count: 3 * 1024 * 1024)
+        let secondMetadata = String(repeating: "b", count: 4 * 1024 * 1024)
+        let thirdMetadata = String(repeating: "c", count: 2 * 1024 * 1024)
+        let wax = try await Wax.create(at: sourceURL, walSize: UInt64(sourceWalSize))
+        _ = try await wax.put(
+            Data("first large metadata frame".utf8),
+            options: FrameMetaSubset(
+                searchText: "first large metadata frame",
+                metadata: Metadata(["large": firstMetadata])
+            )
+        )
+        try await wax.commit()
+        _ = try await wax.put(
+            Data("second large metadata frame".utf8),
+            options: FrameMetaSubset(
+                searchText: "second large metadata frame",
+                metadata: Metadata(["large": secondMetadata])
+            )
+        )
+        try await wax.commit()
+        _ = try await wax.put(
+            Data("third large metadata frame".utf8),
+            options: FrameMetaSubset(
+                searchText: "third large metadata frame",
+                metadata: Metadata(["large": thirdMetadata])
+            )
+        )
+        try await wax.commit()
+        try await wax.close()
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        let orchestrator = try await MemoryOrchestrator(at: sourceURL, config: config)
+        _ = try await orchestrator.rewriteLiveSet(to: destinationURL)
+        try await orchestrator.close()
+
+        let rewritten = try await Wax.open(at: destinationURL)
+        #expect((await rewritten.frameMetas()).count == 3)
+        try await rewritten.verify(deep: true)
+        try await rewritten.close()
+    }
+}
+
+@Test
 func rewriteLiveSetChoosesWalSizeFromPayloadNotSourceRing() async throws {
     try await TempFiles.withTempFile { sourceURL in
         let destinationURL = FileManager.default.temporaryDirectory

--- a/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
+++ b/Tests/WaxIntegrationTests/LiveSetRewriteCompactionTests.swift
@@ -122,6 +122,90 @@ func rewriteLiveSetWalSizeFloorsAtSessionSizeAndCapsAtSourceRing() {
             payloadBytes: 1
         ) == session / 2
     )
+    #expect(
+        MemoryOrchestrator.walSizeForLiveSetRewrite(
+            sourceWalSize: defaultRing,
+            payloadBytes: 1,
+            largestFrameWalBytes: session + 1024,
+            totalFrameWalBytes: session + 2048
+        ) == session + 2048
+    )
+}
+
+@Test
+func rewriteLiveSetAccountsForLargeFrameMetadataInWalSize() async throws {
+    try await TempFiles.withTempFile { sourceURL in
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: destinationURL) }
+
+        let sourceWalSize = 8 * 1024 * 1024
+        let wax = try await Wax.create(at: sourceURL, walSize: UInt64(sourceWalSize))
+        let largeMetadata = Metadata([
+            "large": String(repeating: "m", count: 4 * 1024 * 1024)
+        ])
+        _ = try await wax.put(
+            Data("metadata-rich frame".utf8),
+            options: FrameMetaSubset(
+                searchText: "metadata-rich frame",
+                metadata: largeMetadata
+            )
+        )
+        try await wax.commit()
+        try await wax.close()
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        let orchestrator = try await MemoryOrchestrator(at: sourceURL, config: config)
+        _ = try await orchestrator.rewriteLiveSet(to: destinationURL)
+        try await orchestrator.close()
+
+        let rewritten = try await Wax.open(at: destinationURL)
+        let wal = await rewritten.walStats()
+        #expect(wal.walSize > Constants.sessionWalSize)
+        #expect(wal.walSize <= UInt64(sourceWalSize))
+        try await rewritten.verify(deep: true)
+        try await rewritten.close()
+    }
+}
+
+@Test
+func rewriteLiveSetBatchesWhenAggregateFrameWalExceedsSourceRing() async throws {
+    try await TempFiles.withTempFile { sourceURL in
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wax")
+        defer { try? FileManager.default.removeItem(at: destinationURL) }
+
+        let sourceWalSize = 1 * 1024 * 1024
+        let metadataValue = String(repeating: "m", count: 32 * 1024)
+        let wax = try await Wax.create(at: sourceURL, walSize: UInt64(sourceWalSize))
+        for index in 0..<64 {
+            _ = try await wax.put(
+                Data("metadata-rich frame \(index)".utf8),
+                options: FrameMetaSubset(
+                    searchText: "metadata-rich frame \(index)",
+                    metadata: Metadata(["large": metadataValue])
+                )
+            )
+        }
+        try await wax.commit()
+        try await wax.close()
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        let orchestrator = try await MemoryOrchestrator(at: sourceURL, config: config)
+        _ = try await orchestrator.rewriteLiveSet(to: destinationURL)
+        try await orchestrator.close()
+
+        let rewritten = try await Wax.open(at: destinationURL)
+        let wal = await rewritten.walStats()
+        #expect(wal.walSize == UInt64(sourceWalSize))
+        #expect((await rewritten.frameMetas()).count == 64)
+        try await rewritten.verify(deep: true)
+        try await rewritten.close()
+    }
 }
 
 @Test
@@ -209,6 +293,43 @@ func rewriteLiveSetRespectsDestinationOverwriteGuard() async throws {
             options: .init(overwriteDestination: true, dropNonLivePayloads: true, verifyDeep: false)
         )
         #expect(report.destinationURL == destinationURL.standardizedFileURL)
+        try await orchestrator.close()
+    }
+}
+
+@Test
+func rewriteLiveSetRefusesDirectoryAndLockedDestinationBeforePromotion() async throws {
+    try await TempFiles.withTempFile { sourceURL in
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-rewrite-safety-\(UUID().uuidString)", isDirectory: true)
+        let destinationURL = root.appendingPathComponent("destination.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        let orchestrator = try await MemoryOrchestrator(at: sourceURL, config: config)
+        try await orchestrator.remember("rewrite safety frame")
+        try await orchestrator.flush()
+
+        try FileManager.default.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+        await #expect(throws: WaxError.self) {
+            _ = try await orchestrator.rewriteLiveSet(
+                to: destinationURL,
+                options: .init(overwriteDestination: true)
+            )
+        }
+
+        try FileManager.default.removeItem(at: destinationURL)
+        FileManager.default.createFile(atPath: destinationURL.path, contents: Data("occupied".utf8))
+        let lock = try FileLock.acquire(at: destinationURL, mode: .exclusive)
+        await #expect(throws: WaxError.self) {
+            _ = try await orchestrator.rewriteLiveSet(
+                to: destinationURL,
+                options: .init(overwriteDestination: true)
+            )
+        }
+        try lock.release()
         try await orchestrator.close()
     }
 }

--- a/Tests/WaxIntegrationTests/ModelBindingTests.swift
+++ b/Tests/WaxIntegrationTests/ModelBindingTests.swift
@@ -35,6 +35,17 @@ private struct BindingTestEmbedder: EmbeddingProvider, Sendable {
     }
 }
 
+private struct UnidentifiedBindingTestEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 4
+    let normalize = true
+    let identity: EmbeddingIdentity? = nil
+
+    func embed(_ text: String) async throws -> [Float] {
+        _ = text
+        return Array(repeating: 0.25, count: dimensions)
+    }
+}
+
 @Test func modelBindingIsPersistedOnFirstEmbeddingIngest() async throws {
     try await TempFiles.withTempFile { url in
         var config = TestHelpers.defaultMemoryConfig(vector: true)
@@ -79,6 +90,27 @@ private struct BindingTestEmbedder: EmbeddingProvider, Sendable {
             }
         } catch {
             #expect(Bool(false))
+        }
+    }
+}
+
+@Test func modelBindingMissingProviderIdentityFailsClosedOnOpen() async throws {
+    try await TempFiles.withTempFile { url in
+        let writerEmbedder = BindingTestEmbedder(provider: "Local", model: "v1", dimensions: 4, normalized: true)
+        var config = TestHelpers.defaultMemoryConfig(vector: true)
+        config.chunking = .tokenCount(targetTokens: 8, overlapTokens: 0)
+
+        let writer = try await MemoryOrchestrator(at: url, config: config, embedder: writerEmbedder)
+        try await writer.remember("Persist vector data before reopening without an identity.")
+        try await writer.flush()
+        try await writer.close()
+
+        await #expect(throws: WaxError.self) {
+            _ = try await MemoryOrchestrator(
+                at: url,
+                config: config,
+                embedder: UnidentifiedBindingTestEmbedder()
+            )
         }
     }
 }

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -155,6 +155,27 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
     }
 }
 
+@Test func extremeTopKUsesBoundedOverfetchWithoutIntegerOverflow() async throws {
+    try await TempFiles.withTempFile { url in
+        let wax = try await Wax.create(at: url)
+        let text = try await wax.openSession(.readWrite(), config: WaxSession.Config(enableVectorSearch: false))
+        let frameID = try await wax.put(Data("WAX-OVERFLOW-CANARY".utf8))
+        try await text.indexText(frameId: frameID, text: "WAX-OVERFLOW-CANARY")
+        try await text.commit()
+
+        let response = try await wax.search(
+            SearchRequest(
+                query: "WAX-OVERFLOW-CANARY",
+                mode: .textOnly,
+                topK: Int.max
+            )
+        )
+        #expect(response.results.first?.frameId == frameID)
+
+        try await wax.close()
+    }
+}
+
 @Test func structuredSearchTimeRangeBeforeDoesNotOverrideExplicitAsOf() async throws {
     try await TempFiles.withTempFile { url in
         let wax = try await Wax.create(at: url)

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -1223,6 +1223,21 @@ func handoffRoundTripWorksOnBroker() async throws {
     }
 }
 
+@Test
+func statsPayloadIncludesFramesWithoutVectors() async throws {
+    try await withIsolatedBroker { service, _ in
+        let response = await service.handle(.init(command: "stats"))
+        #expect(response.ok == true, "stats failed: \(response.error ?? "nil")")
+
+        let data = try JSONEncoder().encode(response)
+        let json = try JSONSerialization.jsonObject(with: data)
+        let responseObject = try #require(json as? [String: Any])
+        let payload = try #require(responseObject["payload"] as? [String: Any])
+        let framesWithoutVectors = try #require(payload["framesWithoutVectors"] as? NSNumber)
+        #expect(framesWithoutVectors.int64Value >= 0)
+    }
+}
+
 private func recallItem(
     frameId: UInt64,
     score: Float,

--- a/Tests/WaxTests/MatchPlanTests.swift
+++ b/Tests/WaxTests/MatchPlanTests.swift
@@ -25,6 +25,16 @@ func matchPlanStopwordsAndOperatorsAloneAreEmpty() {
 }
 
 @Test
+func matchPlanKeepsHyphenatedIdentifierAsToken() {
+    let tokens = MatchPlan.tokens(from: "qx7m-ishi-qa")
+    #expect(tokens.contains("qx7m-ishi-qa"))
+    #expect(tokens.contains("ishi"))
+    let plan = MatchPlan.plan(query: "qx7m-ishi-qa")
+    #expect(plan?.primaryMatch.contains("qx7m-ishi-qa") == true)
+    #expect(plan?.fallbackMatch?.contains(" OR ") == true)
+}
+
+@Test
 func matchPlanTreatsFTSPunctuationAsLiteralTokens() {
     let plan = MatchPlan.plan(query: #"task:(F076) NEAR(unclosed "quote""#)
     let primary = plan?.primaryMatch ?? ""

--- a/Tests/WaxTests/MatchPlanTests.swift
+++ b/Tests/WaxTests/MatchPlanTests.swift
@@ -35,6 +35,14 @@ func matchPlanKeepsHyphenatedIdentifierAsToken() {
 }
 
 @Test
+func matchPlanKeepsHyphenatedQuotedPhraseTogether() {
+    let plan = MatchPlan.plan(query: #"What is "foo-bar"?"#)
+    #expect(plan?.primaryMatch.contains(#""foo-bar""#) == true)
+    #expect(plan?.primaryMatch.contains(#""foo-bar foo bar""#) == false)
+    #expect(MatchPlan.normalizedQuotedPhrases(from: #""foo-bar""#) == ["foo-bar"])
+}
+
+@Test
 func matchPlanTreatsFTSPunctuationAsLiteralTokens() {
     let plan = MatchPlan.plan(query: #"task:(F076) NEAR(unclosed "quote""#)
     let primary = plan?.primaryMatch ?? ""

--- a/Tests/WaxTests/UniqueTokenRankingTests.swift
+++ b/Tests/WaxTests/UniqueTokenRankingTests.swift
@@ -108,8 +108,9 @@ private func seedUniqueTokenCorpus(
             command: "remember",
             arguments: [
                 "content": .string(text),
+                "session_id": .string(sessionIDString),
                 "memory_type": .string("task_state"),
-                "durability": .string("durable"),
+                "durability": .string("working"),
                 "project": .string("ishi-qa"),
                 "repo": .string("ishi-qa"),
             ]

--- a/Tests/WaxTests/UniqueTokenRankingTests.swift
+++ b/Tests/WaxTests/UniqueTokenRankingTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Testing
+@testable import Wax
+
+private struct UniqueTokenRankingEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 4
+    let normalize = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "UniqueTokenRanking",
+        model: "Deterministic",
+        dimensions: 4,
+        normalized: true
+    )
+
+    func embed(_ text: String) async throws -> [Float] {
+        let lower = text.lowercased()
+        if lower.contains("qx7m-ishi-qa") {
+            return [1, 0, 0, 0]
+        }
+        if lower.contains("ishi") {
+            return [0, 1, 0, 0]
+        }
+        return [0, 0, 1, 0]
+    }
+}
+
+private func withUniqueTokenBroker<T>(
+    _ body: (AgentBrokerService) async throws -> T
+) async throws -> T {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-unique-token-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    var config = OrchestratorConfig.default
+    config.enableVectorSearch = true
+    config.enableTextSearch = true
+    config.rag.searchMode = .hybrid(alpha: 0.5)
+
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "auto",
+        requireVector: false,
+        embedderOverride: UniqueTokenRankingEmbedder(),
+        orchestratorConfig: config
+    )
+    do {
+        let result = try await body(service)
+        try await service.close()
+        return result
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+private func requireObject(_ value: AgentBrokerValue?) throws -> [String: AgentBrokerValue] {
+    try #require(value?.objectValue)
+}
+
+private func firstHitText(_ payload: [String: AgentBrokerValue]) -> String {
+    let first = payload["results"]?.arrayValue?.first?.objectValue
+    return first?["text"]?.stringValue
+        ?? first?["preview"]?.stringValue
+        ?? ""
+}
+
+private func seedUniqueTokenCorpus(
+    _ service: AgentBrokerService
+) async throws -> UUID {
+    let started = await service.handle(.init(
+        command: "session_start",
+        arguments: [
+            "agent_id": .string("unique-token-agent"),
+            "run_id": .string("unique-token-run"),
+            "project": .string("ishi-qa"),
+            "repo": .string("ishi-qa"),
+        ]
+    ))
+    #expect(started.ok == true, "session_start failed: \(started.error ?? "nil")")
+    let sessionIDString = try #require(try requireObject(started.payload)["session_id"]?.stringValue)
+    let sessionID = try #require(UUID(uuidString: sessionIDString))
+
+    let nonce = await service.handle(.init(
+        command: "remember",
+        arguments: [
+            "content": .string("WAX_MCP_QA marker Unique token qx7m-ishi-qa."),
+            "session_id": .string(sessionIDString),
+            "memory_type": .string("note"),
+            "durability": .string("working"),
+        ]
+    ))
+    #expect(nonce.ok == true, "nonce remember failed: \(nonce.error ?? "nil")")
+
+    let distractors = [
+        "Ishi is reviewing the family memory store tonight.",
+        "Ask Ishi before changing the MCP daemon wrapper.",
+        "Ishi prefers copy-store hygiene over live vacuum.",
+        "Task state: wait for Ishi to confirm the ranking gold set.",
+        "Ishi noted that hyphenated identifiers should stay tokens.",
+    ]
+    for (index, text) in distractors.enumerated() {
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string(text),
+                "memory_type": .string("task_state"),
+                "durability": .string("durable"),
+                "project": .string("ishi-qa"),
+                "repo": .string("ishi-qa"),
+            ]
+        ))
+        #expect(write.ok == true, "distractor \(index) remember failed: \(write.error ?? "nil")")
+    }
+    return sessionID
+}
+
+private func expectUniqueTokenHitAt1(
+    _ response: AgentBrokerResponse,
+    command: String
+) throws {
+    #expect(response.ok == true, "\(command) failed: \(response.error ?? "nil")")
+    let payload = try requireObject(response.payload)
+    let top = firstHitText(payload)
+    #expect(
+        top.localizedCaseInsensitiveContains("qx7m-ishi-qa"),
+        "\(command) hit@1 missed unique token; top=\(top) display=\(payload["display_text"]?.stringValue ?? "")"
+    )
+}
+
+@Test
+func uniqueTokenRanksHitAt1OnSearchRecallMemoryAndCorpus() async throws {
+    try await withUniqueTokenBroker { service in
+        let sessionID = try await seedUniqueTokenCorpus(service)
+        let query = "qx7m-ishi-qa"
+
+        let textSearch = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "topK": .int(8),
+                "session_id": .string(sessionID.uuidString),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(textSearch, command: "search text")
+
+        let hybridSearch = await service.handle(.init(
+            command: "search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("hybrid"),
+                "topK": .int(8),
+                "session_id": .string(sessionID.uuidString),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(hybridSearch, command: "search hybrid")
+
+        let recall = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "scope": .string("project"),
+                "project": .string("ishi-qa"),
+                "repo": .string("ishi-qa"),
+                "session_id": .string(sessionID.uuidString),
+                "limit": .int(8),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(recall, command: "recall")
+
+        let memorySearch = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "session_id": .string(sessionID.uuidString),
+                "include_working": .bool(true),
+                "include_durable": .bool(true),
+                "include_episodic": .bool(false),
+                "topK": .int(8),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(memorySearch, command: "memory_search")
+
+        let corpusSearch = await service.handle(.init(
+            command: "corpus_search",
+            arguments: [
+                "query": .string(query),
+                "mode": .string("text"),
+                "topK": .int(8),
+                "rebuild": .bool(true),
+            ]
+        ))
+        try expectUniqueTokenHitAt1(corpusSearch, command: "corpus_search")
+    }
+}

--- a/Tests/WaxTests/WaxCLISurfaceParityTests.swift
+++ b/Tests/WaxTests/WaxCLISurfaceParityTests.swift
@@ -32,6 +32,11 @@ import Testing
     #expect(source.contains("DemoCommand.self"))
 }
 
+@Test func waxCLIExposesEmbedBackfillCommand() throws {
+    let source = try WaxCLISource.load("WaxCLICommand.swift")
+    #expect(source.contains("EmbedBackfillCommand.self"))
+}
+
 @Test func waxCLIParitySessionLifecycleUsesPersistentBroker() throws {
     let executable = try WaxCLIProcess.builtProductURL()
     let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary
- Bring #165 / #166 / #168 onto development `main`: honest `framesWithoutVectors`, 8 MiB new-store WAL, unique-token ranking, and copy-first `compact-store` / `embed-backfill`.
- Keep repair copy-first and fail-closed: preserve embedder bindings, pin rollback backups before mutation, and batch oversized rewrites instead of cloning a 256 MiB empty ring.
- Bound lexical `topK` overflow and keep hyphenated quoted phrases matchable.

This is the base PR. Merge it before the stacked follow-ups:
- #173 exact-intent routing
- #174 store-repair hardening

Independent siblings that will likely need a rebase after this lands: #170 session_open, #171 access ranking, #172 durable task_state.

## Test plan
- [ ] `swift test --filter UniqueTokenRankingTests`
- [ ] `swift test --filter MatchPlanTests`
- [ ] `swift test --filter scheduledLiveSetRewritePromotesValidatedCandidateOnCloseAndShrinksSource`
- [ ] `bash Resources/scripts/quality/production_readiness_gates.sh full`