### PR TITLE
fix(mcp): bound session_open to session_id plus short handoff

### DIFF
--- a/Resources/docs/wax-mcp-reliability-plan.md
+++ b/Resources/docs/wax-mcp-reliability-plan.md
@@ -131,7 +131,7 @@ Score bands (“~61 → ~80”) are not exit criteria (C9). Exit = contracts bel
 
 #### 2.1 Cheap open and one write API (G4) — C10
 
-- `session_open(project?, agent_id?, run_id?, recall_query?)` → `{session_id, handoff, recall?, project, repo}`.
+- `session_open(project?, agent_id?, run_id?, recall_query?)` → `{session_id, handoff, recall?}`. The default response contains only the session UUID and a bounded handoff projection (content ≤2,048 UTF-8 bytes and ≤256 tokenizer tokens; at most 3 pending tasks, each ≤256 bytes), plus truncation counters/flags. Recall is omitted unless `recall_query` is non-empty and is always capped at 5 results. Use explicit `handoff_latest`, `session_start`, or `recall` when the full metadata or unbounded handoff is required.
 - `remember(content, scope: session|durable, type?, project?)` — stop teaching “omit session_id = durable” as the only rule (keep omit-compat short-term).
 - Canonical verbs in playbook + `AgentInstructions`: `session_open`, `remember`, `recall`, `session_close`, `stats`. Aliases remain callable for compat but are absent from paste blocks and default blurbs.
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1208,31 +1208,20 @@ extension AgentBrokerService {
             recallPayload = try await recall(try BrokerCommand.Recall.decode(BrokerArguments(recallArgs)))
         }
 
+        // Keep the bootstrap wire shape deliberately small.  Callers that
+        // need project/repo, lease state, or the full handoff can issue the
+        // corresponding explicit read after they have the session UUID.
         var payload: [String: AgentBrokerValue] = [
-            "status": .string("ok"),
             "session_id": .from(sessionID),
-            "handoff": Self.compactSessionOpenHandoff(handoffPayload),
-            "project": .from(resolvedProject),
-            "repo": .from(resolvedRepo),
-            "display_text": .string(
-                "Session open. session_id=\(sessionID ?? "nil") project=\(resolvedProject ?? "nil")."
-            ),
+            "handoff": try await Self.compactSessionOpenHandoff(handoffPayload),
         ]
-        if let startObject {
-            if let resumed = startObject["resumed"] {
-                payload["resumed"] = resumed
-            }
-            if let recovered = startObject["recovered_lease"] {
-                payload["recovered_lease"] = recovered
-            }
-        }
         if let recallPayload {
             payload["recall"] = recallPayload
         }
         return .object(payload)
     }
 
-    private static func compactSessionOpenHandoff(_ value: AgentBrokerValue) -> AgentBrokerValue {
+    private static func compactSessionOpenHandoff(_ value: AgentBrokerValue) async throws -> AgentBrokerValue {
         guard let handoff = value.objectValue,
               handoff["found"]?.boolValue == true
         else {
@@ -1244,9 +1233,16 @@ extension AgentBrokerService {
             originalContent,
             maxBytes: BrokerLimits.maxSessionOpenHandoffContentBytes
         )
-        let compactContent = tokenPrefix(
+        let tokenCounter = try await TokenCounter.shared()
+        let tokenLimitedContent = await tokenCounter.truncate(
             byteLimitedContent,
             maxTokens: BrokerLimits.maxSessionOpenHandoffContentTokens
+        )
+        // Token decoding is normally a prefix, but retain the byte guard as a
+        // final invariant for unusual tokenizer normalization sequences.
+        let compactContent = utf8Prefix(
+            tokenLimitedContent,
+            maxBytes: BrokerLimits.maxSessionOpenHandoffContentBytes
         )
         let contentTruncated = compactContent != originalContent
 
@@ -1274,7 +1270,7 @@ extension AgentBrokerService {
             "pending_tasks_truncated": .from(pendingTaskTruncations),
             "pending_tasks_omitted": .from(omittedTaskCount),
             "content_bytes": .from(compactContent.utf8.count),
-            "content_tokens": .from(whitespaceTokenCount(compactContent)),
+            "content_tokens": .from(await tokenCounter.count(compactContent)),
         ])
     }
 
@@ -1291,32 +1287,6 @@ extension AgentBrokerService {
             bytes += characterBytes
         }
         return result
-    }
-
-    /// Count stable, whitespace-delimited tokens for the compact bootstrap bound.
-    private static func whitespaceTokenCount(_ text: String) -> Int {
-        text.split(whereSeparator: \.isWhitespace).count
-    }
-
-    private static func tokenPrefix(_ text: String, maxTokens: Int) -> String {
-        guard maxTokens > 0 else { return "" }
-        var tokenCount = 0
-        var insideToken = false
-        var index = text.startIndex
-        while index < text.endIndex {
-            let character = text[index]
-            if character.isWhitespace {
-                insideToken = false
-            } else if !insideToken {
-                guard tokenCount < maxTokens else {
-                    return String(text[..<index])
-                }
-                tokenCount += 1
-                insideToken = true
-            }
-            index = text.index(after: index)
-        }
-        return text
     }
 
     private func sessionEndPayload(_ result: VirtualSessionStore.EndResult) -> AgentBrokerValue {

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1234,15 +1234,10 @@ extension AgentBrokerService {
             maxBytes: BrokerLimits.maxSessionOpenHandoffContentBytes
         )
         let tokenCounter = try await TokenCounter.shared()
-        let tokenLimitedContent = await tokenCounter.truncate(
+        let compactContent = await Self.tokenLimitedPrefix(
             byteLimitedContent,
+            counter: tokenCounter,
             maxTokens: BrokerLimits.maxSessionOpenHandoffContentTokens
-        )
-        // Token decoding is normally a prefix, but retain the byte guard as a
-        // final invariant for unusual tokenizer normalization sequences.
-        let compactContent = utf8Prefix(
-            tokenLimitedContent,
-            maxBytes: BrokerLimits.maxSessionOpenHandoffContentBytes
         )
         let contentTruncated = compactContent != originalContent
 
@@ -1287,6 +1282,32 @@ extension AgentBrokerService {
             bytes += characterBytes
         }
         return result
+    }
+
+    /// Select a prefix from the original grapheme sequence rather than
+    /// decoding a sliced BPE token array. Decoding an arbitrary token prefix
+    /// can end in the middle of a multibyte scalar and introduce U+FFFD.
+    private static func tokenLimitedPrefix(
+        _ text: String,
+        counter: TokenCounter,
+        maxTokens: Int
+    ) async -> String {
+        guard maxTokens > 0, !text.isEmpty else { return "" }
+        let characters = Array(text)
+        var lower = 0
+        var upper = characters.count
+        var best = 0
+        while lower <= upper {
+            let middle = lower + (upper - lower) / 2
+            let candidate = String(characters.prefix(middle))
+            if await counter.count(candidate) <= maxTokens {
+                best = middle
+                lower = middle + 1
+            } else {
+                upper = middle - 1
+            }
+        }
+        return String(characters.prefix(best))
     }
 
     private func sessionEndPayload(_ result: VirtualSessionStore.EndResult) -> AgentBrokerValue {

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1140,6 +1140,10 @@ extension AgentBrokerService {
     }
 
     /// `handoff_latest` + `session_start` + optional `recall` in one round-trip (Phase 2).
+    ///
+    /// The handoff is intentionally projected to a bounded bootstrap shape.
+    /// Callers that need frame metadata or the complete pending-task list can
+    /// use `handoff_latest` explicitly.
     func sessionOpen(_ command: BrokerCommand.SessionOpen) async throws -> AgentBrokerValue {
         let project = command.project
         let repo = command.repo
@@ -1195,6 +1199,7 @@ extension AgentBrokerService {
             var recallArgs: [String: AgentBrokerValue] = [
                 "query": .string(recallQuery),
                 "scope": .string("project"),
+                "limit": .from(5),
             ]
             if let resolvedProject { recallArgs["project"] = .string(resolvedProject) }
             if let resolvedRepo { recallArgs["repo"] = .string(resolvedRepo) }
@@ -1206,7 +1211,7 @@ extension AgentBrokerService {
         var payload: [String: AgentBrokerValue] = [
             "status": .string("ok"),
             "session_id": .from(sessionID),
-            "handoff": handoffPayload,
+            "handoff": Self.compactSessionOpenHandoff(handoffPayload),
             "project": .from(resolvedProject),
             "repo": .from(resolvedRepo),
             "display_text": .string(
@@ -1225,6 +1230,93 @@ extension AgentBrokerService {
             payload["recall"] = recallPayload
         }
         return .object(payload)
+    }
+
+    private static func compactSessionOpenHandoff(_ value: AgentBrokerValue) -> AgentBrokerValue {
+        guard let handoff = value.objectValue,
+              handoff["found"]?.boolValue == true
+        else {
+            return value
+        }
+
+        let originalContent = handoff["content"]?.stringValue ?? ""
+        let byteLimitedContent = utf8Prefix(
+            originalContent,
+            maxBytes: BrokerLimits.maxSessionOpenHandoffContentBytes
+        )
+        let compactContent = tokenPrefix(
+            byteLimitedContent,
+            maxTokens: BrokerLimits.maxSessionOpenHandoffContentTokens
+        )
+        let contentTruncated = compactContent != originalContent
+
+        let originalTasks = handoff["pending_tasks"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        let boundedTasks = originalTasks
+            .prefix(BrokerLimits.maxSessionOpenPendingTasks)
+            .map { task in
+                utf8Prefix(task, maxBytes: BrokerLimits.maxSessionOpenPendingTaskBytes)
+            }
+        let pendingTaskTruncations = zip(
+            originalTasks.prefix(BrokerLimits.maxSessionOpenPendingTasks),
+            boundedTasks
+        ).reduce(into: 0) { count, task in
+            if task.0 != task.1 { count += 1 }
+        }
+        let omittedTaskCount = max(0, originalTasks.count - boundedTasks.count)
+        let anyTruncated = contentTruncated || pendingTaskTruncations > 0 || omittedTaskCount > 0
+
+        return .object([
+            "found": .bool(true),
+            "content": .string(compactContent),
+            "pending_tasks": .array(boundedTasks.map { .string($0) }),
+            "truncated": .bool(anyTruncated),
+            "content_truncated": .bool(contentTruncated),
+            "pending_tasks_truncated": .from(pendingTaskTruncations),
+            "pending_tasks_omitted": .from(omittedTaskCount),
+            "content_bytes": .from(compactContent.utf8.count),
+            "content_tokens": .from(whitespaceTokenCount(compactContent)),
+        ])
+    }
+
+    /// Return a prefix without splitting a user-visible Unicode grapheme.
+    private static func utf8Prefix(_ text: String, maxBytes: Int) -> String {
+        guard maxBytes > 0 else { return "" }
+        var bytes = 0
+        var result = String()
+        result.reserveCapacity(min(text.utf8.count, maxBytes))
+        for character in text {
+            let characterBytes = String(character).utf8.count
+            guard bytes + characterBytes <= maxBytes else { break }
+            result.append(character)
+            bytes += characterBytes
+        }
+        return result
+    }
+
+    /// Count stable, whitespace-delimited tokens for the compact bootstrap bound.
+    private static func whitespaceTokenCount(_ text: String) -> Int {
+        text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private static func tokenPrefix(_ text: String, maxTokens: Int) -> String {
+        guard maxTokens > 0 else { return "" }
+        var tokenCount = 0
+        var insideToken = false
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+            if character.isWhitespace {
+                insideToken = false
+            } else if !insideToken {
+                guard tokenCount < maxTokens else {
+                    return String(text[..<index])
+                }
+                tokenCount += 1
+                insideToken = true
+            }
+            index = text.index(after: index)
+        }
+        return text
     }
 
     private func sessionEndPayload(_ result: VirtualSessionStore.EndResult) -> AgentBrokerValue {

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1284,30 +1284,31 @@ extension AgentBrokerService {
         return result
     }
 
-    /// Select a prefix from the original grapheme sequence rather than
-    /// decoding a sliced BPE token array. Decoding an arbitrary token prefix
-    /// can end in the middle of a multibyte scalar and introduce U+FFFD.
+    /// Bound `text` to `maxTokens` while remaining a grapheme prefix of `text`.
+    ///
+    /// Encode the full string once, then take a proportional character prefix
+    /// and shrink by graphemes if that prefix is still over budget. This avoids
+    /// re-tokenizing every binary-search midpoint on `TokenCounter.shared()`,
+    /// which serializes orchestrator chunking and MCP remember/recall.
     private static func tokenLimitedPrefix(
         _ text: String,
         counter: TokenCounter,
         maxTokens: Int
     ) async -> String {
         guard maxTokens > 0, !text.isEmpty else { return "" }
+        let fullCount = await counter.count(text)
+        if fullCount <= maxTokens { return text }
+
         let characters = Array(text)
-        var lower = 0
-        var upper = characters.count
-        var best = 0
-        while lower <= upper {
-            let middle = lower + (upper - lower) / 2
-            let candidate = String(characters.prefix(middle))
-            if await counter.count(candidate) <= maxTokens {
-                best = middle
-                lower = middle + 1
-            } else {
-                upper = middle - 1
-            }
+        var high = max(1, min(characters.count, (maxTokens * characters.count) / fullCount))
+        var candidate = String(characters.prefix(high))
+        var candidateCount = await counter.count(candidate)
+        while candidateCount > maxTokens && high > 1 {
+            high = max(1, (high * 3) / 4)
+            candidate = String(characters.prefix(high))
+            candidateCount = await counter.count(candidate)
         }
-        return String(characters.prefix(best))
+        return candidateCount <= maxTokens ? candidate : ""
     }
 
     private func sessionEndPayload(_ result: VirtualSessionStore.EndResult) -> AgentBrokerValue {

--- a/Sources/Wax/Broker/BrokerLimits.swift
+++ b/Sources/Wax/Broker/BrokerLimits.swift
@@ -16,4 +16,13 @@ package enum BrokerLimits {
     package static let maxPathBytes = 4096
     package static let maxCompactContextTokenBudget = 32_000
     package static let maxCompactContextItems = 64
+    /// Bounds for the handoff projection returned by `session_open`.
+    ///
+    /// The token limit is intentionally a deterministic whitespace-token
+    /// estimate. It keeps the session bootstrap path independent of the BPE
+    /// tokenizer while still preventing unbounded model input.
+    package static let maxSessionOpenHandoffContentBytes = 2_048
+    package static let maxSessionOpenHandoffContentTokens = 256
+    package static let maxSessionOpenPendingTasks = 3
+    package static let maxSessionOpenPendingTaskBytes = 256
 }

--- a/Sources/Wax/Broker/BrokerLimits.swift
+++ b/Sources/Wax/Broker/BrokerLimits.swift
@@ -18,9 +18,8 @@ package enum BrokerLimits {
     package static let maxCompactContextItems = 64
     /// Bounds for the handoff projection returned by `session_open`.
     ///
-    /// The token limit is intentionally a deterministic whitespace-token
-    /// estimate. It keeps the session bootstrap path independent of the BPE
-    /// tokenizer while still preventing unbounded model input.
+    /// The token limit is enforced with the shared deterministic BPE tokenizer
+    /// while the byte limit keeps the bootstrap payload bounded before counting.
     package static let maxSessionOpenHandoffContentBytes = 2_048
     package static let maxSessionOpenHandoffContentTokens = 256
     package static let maxSessionOpenPendingTasks = 3

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -91,7 +91,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "session_open",
-            description: "Open a session in one call: handoff_latest + session_start + optional recall. Returns session_id, handoff, and optional recall.",
+            description: "Open a session in one call. Returns session_id plus a bounded short handoff projection; optional non-empty recall_query adds capped project-scoped recall. Use handoff_latest for the complete handoff and pending tasks.",
             inputSchema: waxSessionOpen
         ),
         Tool(
@@ -562,7 +562,7 @@ enum ToolSchemas {
             ],
             "recall_query": [
                 "type": "string",
-                "description": "Optional query to run project-scoped recall after session_start.",
+                "description": "Optional non-empty query to run capped project-scoped recall after session_start. Omitted or whitespace-only means no recall.",
             ],
             "cwd": [
                 "type": "string",

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -388,10 +388,12 @@ private extension WaxMCPTools {
     static func encodeJSON(_ value: Value) -> String? {
         let object = toJSONObject(value)
         guard JSONSerialization.isValidJSONObject(object),
-              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes]) else {
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes]),
+              let json = String(data: data, encoding: .utf8),
+              !json.isEmpty else {
             return nil
         }
-        return String(data: data, encoding: .utf8)
+        return json
     }
 
     static func toJSONObject(_ value: Value) -> Any {
@@ -403,7 +405,7 @@ private extension WaxMCPTools {
         case .int(let value):
             return value
         case .double(let value):
-            return value
+            return value.isFinite ? value : NSNull()
         case .string(let value):
             return value
         case .data(_, let data):

--- a/Tests/WaxMCPServerTests/WaxMCPReliabilityPlanContractsTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPReliabilityPlanContractsTests.swift
@@ -270,8 +270,7 @@ func t02SessionOpenStampsExplicitProjectOntoManifestAndRemember() async throws {
         ))
         #expect(opened.ok == true, "session_open failed: \(opened.error ?? "nil")")
         let openPayload = try requireObject(opened.payload)
-        #expect(openPayload["project"]?.stringValue == "Espresso")
-        #expect(openPayload["repo"]?.stringValue == "Espresso")
+        #expect(Set(openPayload.keys) == Set(["session_id", "handoff"]))
         let sessionID = try requireString(openPayload, "session_id")
 
         let remembered = await service.handle(.init(
@@ -708,9 +707,7 @@ func sessionOpenStampsExplicitProjectOntoSessionManifest() async throws {
         ))
         #expect(opened.ok == true, "session_open failed: \(opened.error ?? "nil")")
         let payload = try requireObject(opened.payload)
-        #expect(payload["project"]?.stringValue == "ExplicitOpenProject")
-        #expect(payload["repo"]?.stringValue == "ExplicitOpenProject")
-        #expect(payload["repo"]?.stringValue != "ForeignOpenRepo")
+        #expect(Set(payload.keys) == Set(["session_id", "handoff"]))
         let sessionID = try requireString(payload, "session_id")
 
         let recall = await service.handle(.init(

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -5491,7 +5491,7 @@ func sessionOpenDefaultsToBoundedHandoffWithoutRecall() async throws {
     try await withAgentBrokerService { service, _ in
         let project = "session-open-bounded-\(UUID().uuidString)"
         let content = String(repeating: "handoff content 🚀 ", count: 400)
-        let pendingTasks = (0..<12).map { index in
+        let pendingTasks: [AgentBrokerValue] = (0..<12).map { index in
             .string("task-\(index) " + String(repeating: "待", count: 200))
         }
         #expect((await service.handle(.init(

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -5539,7 +5539,7 @@ func sessionOpenDefaultsToBoundedHandoffWithoutRecall() async throws {
 func sessionOpenCompactHandoffTruncationPreservesUnicodeBoundaries() async throws {
     try await withAgentBrokerService { service, _ in
         let project = "session-open-unicode-\(UUID().uuidString)"
-        let content = String(repeating: "🧠界", count: 2_000)
+        let content = String(repeating: "🧠", count: 2_000)
         #expect((await service.handle(.init(
             command: "handoff",
             arguments: [
@@ -5566,6 +5566,7 @@ func sessionOpenCompactHandoffTruncationPreservesUnicodeBoundaries() async throw
         #expect(await counter.count(compactContent) <= 256)
         #expect(content.hasPrefix(compactContent))
         #expect(String(data: Data(compactContent.utf8), encoding: .utf8) == compactContent)
+        #expect(!compactContent.contains("�"))
         #expect((handoff["content_truncated"] as? Bool) == true)
     }
 }

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -6087,14 +6087,30 @@ private func containsKeyRecursively(_ key: String, in value: Any) -> Bool {
 
 private func parseJSONText(in result: CallTool.Result) throws -> [String: Any] {
     let text = firstText(in: result)
-    guard let data = text.data(using: .utf8) else {
-        throw NSError(domain: "WaxMCPServerTests", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid UTF-8 result"])
+    if let dict = decodeJSONObject(text) {
+        return dict
     }
-    let object = try JSONSerialization.jsonObject(with: data)
-    guard let dict = object as? [String: Any] else {
-        throw NSError(domain: "WaxMCPServerTests", code: 3, userInfo: [NSLocalizedDescriptionKey: "Result is not a JSON object"])
+    for content in result.content {
+        if case .resource(let resource, _, _) = content,
+           let resourceText = resource.text,
+           let dict = decodeJSONObject(resourceText) {
+            return dict
+        }
     }
-    return dict
+    let preview = text.isEmpty ? "<empty>" : String(text.prefix(200))
+    throw NSError(
+        domain: "WaxMCPServerTests",
+        code: 3,
+        userInfo: [NSLocalizedDescriptionKey: "Result is not a JSON object: \(preview)"]
+    )
+}
+
+private func decodeJSONObject(_ text: String) -> [String: Any]? {
+    guard !text.isEmpty, let data = text.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) else {
+        return nil
+    }
+    return object as? [String: Any]
 }
 
 private func parseJSONResource(in result: CallTool.Result, uriSuffix: String) throws -> [String: Any] {

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -5517,6 +5517,7 @@ func sessionOpenDefaultsToBoundedHandoffWithoutRecall() async throws {
 
         #expect(opened.isError != true)
         let payload = try parseJSONText(in: opened)
+        #expect(Set(payload.keys) == Set(["session_id", "handoff"]))
         #expect(payload["session_id"] as? String != nil)
         #expect(payload["recall"] == nil)
         let handoff = try requireObject(payload, key: "handoff")
@@ -5561,6 +5562,8 @@ func sessionOpenCompactHandoffTruncationPreservesUnicodeBoundaries() async throw
         let handoff = try requireObject(try parseJSONText(in: opened), key: "handoff")
         let compactContent = try requireString(handoff, key: "content")
         #expect(compactContent.utf8.count <= 2_048)
+        let counter = try await TokenCounter.shared()
+        #expect(await counter.count(compactContent) <= 256)
         #expect(content.hasPrefix(compactContent))
         #expect(String(data: Data(compactContent.utf8), encoding: .utf8) == compactContent)
         #expect((handoff["content_truncated"] as? Bool) == true)

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -5487,6 +5487,166 @@ func sessionOpenCompactRecursivelyRemovesDisplayText() async throws {
 }
 
 @Test
+func sessionOpenDefaultsToBoundedHandoffWithoutRecall() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "session-open-bounded-\(UUID().uuidString)"
+        let content = String(repeating: "handoff content 🚀 ", count: 400)
+        let pendingTasks = (0..<12).map { index in
+            .string("task-\(index) " + String(repeating: "待", count: 200))
+        }
+        #expect((await service.handle(.init(
+            command: "handoff",
+            arguments: [
+                "content": .string(content),
+                "project": .string(project),
+                "pending_tasks": .array(pendingTasks),
+            ]
+        ))).ok == true)
+
+        let opened = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": .string(project),
+                    "agent_id": .string("bounded-open-agent"),
+                    "run_id": .string(UUID().uuidString),
+                ]
+            ),
+            broker: service
+        )
+
+        #expect(opened.isError != true)
+        let payload = try parseJSONText(in: opened)
+        #expect(payload["session_id"] as? String != nil)
+        #expect(payload["recall"] == nil)
+        let handoff = try requireObject(payload, key: "handoff")
+        let compactContent = try requireString(handoff, key: "content")
+        let tasks = try requireArray(handoff, key: "pending_tasks")
+        #expect(compactContent.utf8.count <= 2_048)
+        #expect((handoff["content_bytes"] as? Int ?? 2_049) <= 2_048)
+        #expect((handoff["content_tokens"] as? Int ?? 257) <= 256)
+        #expect(tasks.count <= 3)
+        #expect(tasks.allSatisfy { (($0 as? String)?.utf8.count ?? 257) <= 256 })
+        #expect((handoff["truncated"] as? Bool) == true)
+        #expect((handoff["pending_tasks_omitted"] as? Int) == 9)
+        #expect(handoff["frame_id"] == nil)
+        #expect(handoff["timestamp_ms"] == nil)
+    }
+}
+
+@Test
+func sessionOpenCompactHandoffTruncationPreservesUnicodeBoundaries() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "session-open-unicode-\(UUID().uuidString)"
+        let content = String(repeating: "🧠界", count: 2_000)
+        #expect((await service.handle(.init(
+            command: "handoff",
+            arguments: [
+                "content": .string(content),
+                "project": .string(project),
+            ]
+        ))).ok == true)
+
+        let opened = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": .string(project),
+                    "agent_id": .string("unicode-open-agent"),
+                    "run_id": .string(UUID().uuidString),
+                ]
+            ),
+            broker: service
+        )
+        let handoff = try requireObject(try parseJSONText(in: opened), key: "handoff")
+        let compactContent = try requireString(handoff, key: "content")
+        #expect(compactContent.utf8.count <= 2_048)
+        #expect(content.hasPrefix(compactContent))
+        #expect(String(data: Data(compactContent.utf8), encoding: .utf8) == compactContent)
+        #expect((handoff["content_truncated"] as? Bool) == true)
+    }
+}
+
+@Test
+func sessionOpenExplicitRecallRemainsCapped() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "session-open-recall-\(UUID().uuidString)"
+        let marker = "SESSION_OPEN_RECALL_CAP_\(UUID().uuidString)"
+        for index in 0..<8 {
+            #expect((await service.handle(.init(
+                command: "remember",
+                arguments: [
+                    "content": .string("\(marker) result \(index)"),
+                    "project": .string(project),
+                ]
+            ))).ok == true)
+        }
+
+        let opened = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": .string(project),
+                    "agent_id": .string("recall-open-agent"),
+                    "run_id": .string(UUID().uuidString),
+                    "recall_query": .string(marker),
+                ]
+            ),
+            broker: service
+        )
+        let payload = try parseJSONText(in: opened)
+        let recall = try requireObject(payload, key: "recall")
+        #expect((recall["limit"] as? Int) == 5)
+        #expect((recall["result_count"] as? Int ?? 6) <= 5)
+    }
+}
+
+@Test
+func sessionOpenLeavesFullHandoffLatestExplicitReadUnchanged() async throws {
+    try await withAgentBrokerService { service, _ in
+        let project = "session-open-full-read-\(UUID().uuidString)"
+        let content = "Full handoff content stays on handoff_latest."
+        let tasks = ["task one", "task two", "task three", "task four"]
+        #expect((await service.handle(.init(
+            command: "handoff",
+            arguments: [
+                "content": .string(content),
+                "project": .string(project),
+                "pending_tasks": .array(tasks.map { .string($0) }),
+            ]
+        ))).ok == true)
+
+        let opened = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": .string(project),
+                    "agent_id": .string("full-read-agent"),
+                    "run_id": .string(UUID().uuidString),
+                ]
+            ),
+            broker: service
+        )
+        let compactHandoff = try requireObject(try parseJSONText(in: opened), key: "handoff")
+        #expect(compactHandoff["frame_id"] == nil)
+        #expect(compactHandoff["timestamp_ms"] == nil)
+
+        let latest = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "handoff_latest",
+                arguments: ["project": .string(project)]
+            ),
+            broker: service
+        )
+        let latestPayload = try parseJSONText(in: latest)
+        #expect(latestPayload["content"] as? String == content)
+        #expect((latestPayload["pending_tasks"] as? [String]) == tasks)
+        #expect(latestPayload["frame_id"] != nil)
+        #expect(latestPayload["timestamp_ms"] != nil)
+    }
+}
+
+@Test
 func invalidArgumentErrorListsAcceptedArguments() async throws {
     try await withAgentBrokerService { service, _ in
         let result = await WaxMCPTools.handleCall(


### PR DESCRIPTION
## Summary
- Default `session_open` returns only `session_id` plus a bounded handoff. Recall runs only when `recall_query` is explicit, and is capped at 5.
- Truncate handoff content with grapheme-safe `TokenCounter` bounds using a proportional prefix, not midpoint re-tokenization (avoids parallel-test tokenizer contention).
- `handoff_latest` stays the full unbounded read path.
- Rebased onto `main` after #169.

## Test plan
- [x] `swift test --traits MCPServer --filter sessionOpen`
- [x] `swift test --traits MCPServer --filter vectorSearchRememberFlushRecallHappyPath`
- [x] `swift test --traits MCPServer --filter brokerBackedSessionResumeReopensPersistedSessionAfterRestart`
- [ ] CI gates on `6e607fa35`