### PR TITLE
feat: apply access-frequency scoring to retrieval ranking

### DIFF
--- a/Resources/docs/wax-mcp-setup.md
+++ b/Resources/docs/wax-mcp-setup.md
@@ -87,8 +87,8 @@ swift run --traits MCPServer wax-cli mcp serve
 - `WAX_MCP_FEATURE_LICENSE=1`: enable `LicenseValidator`
 - `WAX_MCP_FEATURE_STRUCTURED_MEMORY=1` (default): enable graph/entity/fact tools
 - `WAX_MCP_FEATURE_STRUCTURED_MEMORY=0`: disable structured memory graph tools
-- `WAX_MCP_FEATURE_ACCESS_STATS=0` (default): disable access-stat-based scoring persistence
-- `WAX_MCP_FEATURE_ACCESS_STATS=1`: enable access-stat recording + scoring path
+- `WAX_MCP_FEATURE_ACCESS_STATS=1` (default): enable access-stat recording + retrieval scoring
+- `WAX_MCP_FEATURE_ACCESS_STATS=0`: disable access-stat-based scoring persistence
 
 ## MCP tool highlights
 

--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -24,7 +24,7 @@ Source: `Sources/Wax/Memory.swift`
 
 ### Memory.Config
 
-`public struct Config: Sendable` with `enableTextSearch` (true), `enableVectorSearch` (true), `enableStructuredMemory` (false), `enableAccessStatsScoring` (false), `enableAsyncEnrichment` (false), `ingestConcurrency` (1), `ingestBatchSize` (32), `requireOnDeviceProviders` (true), `embedding` (`.automatic`); `public static let .default`.
+`public struct Config: Sendable` with `enableTextSearch` (true), `enableVectorSearch` (true), `enableStructuredMemory` (false), `enableAccessStatsScoring` (true), `enableAsyncEnrichment` (false), `ingestConcurrency` (1), `ingestBatchSize` (32), `requireOnDeviceProviders` (true), `embedding` (`.automatic`); `public static let .default`.
 
 ### Memory.EmbeddingSource
 

--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -24,7 +24,7 @@ Source: `Sources/Wax/Memory.swift`
 
 ### Memory.Config
 
-`public struct Config: Sendable` with `enableTextSearch` (true), `enableVectorSearch` (true), `enableStructuredMemory` (false), `enableAccessStatsScoring` (true), `enableAsyncEnrichment` (false), `ingestConcurrency` (1), `ingestBatchSize` (32), `requireOnDeviceProviders` (true), `embedding` (`.automatic`); `public static let .default`.
+`public struct Config: Sendable` with `enableTextSearch` (true), `enableVectorSearch` (true), `enableStructuredMemory` (false), `enableAccessStatsScoring` (true), `enableAsyncEnrichment` (false), `ingestConcurrency` (1), `ingestBatchSize` (32), `requireOnDeviceProviders` (true), `embedding` (`.automatic`); `public static let .default`. `enableAccessStatsScoring` applies a bounded rank offset from stored access stats. Search and recall are non-mutating; stats accrue from explicit get/promote (`memory_get` / `memory_promote`). Access stats persist as a system frame, not a user-visible content frame.
 
 ### Memory.EmbeddingSource
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -34,7 +34,7 @@ package actor AgentBrokerService {
         noEmbedder: Bool,
         embedderChoice: String,
         requireVector: Bool,
-        enableAccessStatsScoring: Bool = false,
+        enableAccessStatsScoring: Bool = true,
         embedderTuning: CommandLineEmbedderRuntimeTuning = .fromEnvironment(),
         embedderOverride: (any EmbeddingProvider)? = nil,
         readiness: EmbeddingReadiness = .shared,

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -744,6 +744,7 @@ extension AgentBrokerService {
             content = sourceDocument.text
             sourceMetadata = sourceDocument.metadata
             sourceFrameId = sourceDocument.frameId
+            await session.memory.recordAccess(frameId: sourceDocument.frameId)
         }
 
         let baseMetadata = command.metadata.merging(sourceMetadata) { current, _ in current }
@@ -1922,6 +1923,7 @@ extension AgentBrokerService {
         switch reference.horizon {
         case .durable:
             let document = try await requireDocument(frameID: reference.frameID, memory: longTermMemory)
+            await longTermMemory.recordAccess(frameId: document.frameId)
             return LayeredMemoryHit(
                 reference: Self.makeMemoryReference(.durable, sessionID: nil, frameID: reference.frameID),
                 horizon: .durable,
@@ -1943,6 +1945,7 @@ extension AgentBrokerService {
             let manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)
             let loader: (MemoryOrchestrator) async throws -> LayeredMemoryHit = { memory in
                 let document = try await self.requireDocument(frameID: reference.frameID, memory: memory)
+                await memory.recordAccess(frameId: document.frameId)
                 return LayeredMemoryHit(
                     reference: Self.makeMemoryReference(reference.horizon, sessionID: sessionID, frameID: reference.frameID),
                     horizon: reference.horizon,

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -6,6 +6,10 @@ public actor Memory {
         public var enableTextSearch: Bool
         public var enableVectorSearch: Bool
         public var enableStructuredMemory: Bool
+        /// When true (default), retrieval ranking applies a bounded offset from
+        /// stored access stats. Search and recall do not record access; stats
+        /// accrue from explicit get/promote. Access stats persist as a system
+        /// frame, not a user-visible content frame.
         public var enableAccessStatsScoring: Bool
         public var enableAsyncEnrichment: Bool
         public var ingestConcurrency: Int

--- a/Sources/Wax/Memory.swift
+++ b/Sources/Wax/Memory.swift
@@ -18,7 +18,7 @@ public actor Memory {
             enableTextSearch: Bool = true,
             enableVectorSearch: Bool = true,
             enableStructuredMemory: Bool = false,
-            enableAccessStatsScoring: Bool = false,
+            enableAccessStatsScoring: Bool = true,
             enableAsyncEnrichment: Bool = false,
             ingestConcurrency: Int = 1,
             ingestBatchSize: Int = 32,

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -348,19 +348,33 @@ package enum MemorySemantics {
 
     package static func accessReasons(
         stats: FrameAccessStats?,
+        metadata: [String: String] = [:],
         nowMs: Int64
     ) -> (adjustment: Float, reasons: [String]) {
         guard let stats else { return (0, []) }
-        var adjustment: Float = 0
+        var adjustment = AccessFrequencyRanker.rawAdjustment(stats: stats, nowMs: nowMs)
+
+        // Durable and locked memories remain governed by their stronger
+        // semantic policy. Access history may reinforce them, but stale access
+        // must not demote an explicitly durable/locked record.
+        let durability = parse(metadata: metadata, nowMs: nowMs).durability
+        if adjustment < 0, durability == .durable || durability == .locked {
+            adjustment = 0
+        }
+
         var reasons: [String] = []
-        if stats.accessCount >= 3 {
-            adjustment += min(0.25, Float(stats.accessCount) * 0.03)
+        let cappedCount = min(stats.accessCount, 32)
+        if cappedCount >= 3 {
             reasons.append("repeated use")
         }
         let hoursSinceAccess = max(0, nowMs - stats.lastAccessMs) / (1000 * 60 * 60)
         if hoursSinceAccess <= 24 {
-            adjustment += 0.15
             reasons.append("recently used")
+        }
+        if adjustment < 0 {
+            reasons.append("stale access")
+        } else if adjustment > 0, reasons.isEmpty {
+            reasons.append("access frequency boost")
         }
         return (adjustment, reasons)
     }

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -2583,11 +2583,12 @@ package actor MemoryOrchestrator {
     }
 
     private func persistAccessStatsIfNeeded() async throws {
-        guard let exported = await accessStatsManager.exportStatsIfDirty() else {
+        guard let snapshot = await accessStatsManager.exportStatsSnapshotIfDirty() else {
             return
         }
+        let exported = snapshot.stats
         guard !exported.isEmpty else {
-            await accessStatsManager.markPersisted()
+            _ = await accessStatsManager.markPersisted(ifRevision: snapshot.revision)
             return
         }
         let payload = try JSONEncoder().encode(exported)
@@ -2619,6 +2620,9 @@ package actor MemoryOrchestrator {
                 )
             }
         }
-        await accessStatsManager.markPersisted()
+        // A search may have recorded newer accesses while the WAL writes
+        // above awaited. Only acknowledge the revision we actually persisted;
+        // a newer revision remains dirty for the next flush.
+        _ = await accessStatsManager.markPersisted(ifRevision: snapshot.revision)
     }
 }

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -231,6 +231,7 @@ package actor MemoryOrchestrator {
     let config: OrchestratorConfig
     private let ragBuilder: FastRAGContextBuilder
     private let handoffWriteMutex = AsyncMutex()
+    private let flushMutex = AsyncMutex()
 
     let session: WaxSession
     private var embedderLifecycle: EmbedderLifecycle
@@ -241,6 +242,11 @@ package actor MemoryOrchestrator {
 
     package func setSearchSnapshotHoldForTesting(_ duration: Duration?) {
         searchSnapshotHoldForTesting = duration
+    }
+    package var accessStatsPersistenceHoldForTesting: Duration? = nil
+
+    package func setAccessStatsPersistenceHoldForTesting(_ duration: Duration?) {
+        accessStatsPersistenceHoldForTesting = duration
     }
     private let enrichmentPipeline: EnrichmentPipeline?
     private let accessStatsManager = AccessStatsManager()
@@ -1932,6 +1938,12 @@ package actor MemoryOrchestrator {
     // MARK: - Persistence lifecycle
 
     package func flush() async throws {
+        try await flushMutex.withLock { [self] in
+            try await flushSerialized()
+        }
+    }
+
+    private func flushSerialized() async throws {
         if let enrichmentPipeline {
             let drained = try await enrichmentPipeline.waitUntilIdle(
                 bestEffortTimeout: config.enrichmentFlushDrainTimeout
@@ -2585,6 +2597,9 @@ package actor MemoryOrchestrator {
     private func persistAccessStatsIfNeeded() async throws {
         guard let snapshot = await accessStatsManager.exportStatsSnapshotIfDirty() else {
             return
+        }
+        if let hold = accessStatsPersistenceHoldForTesting {
+            try await Task.sleep(for: hold)
         }
         let exported = snapshot.stats
         guard !exported.isEmpty else {

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1212,6 +1212,7 @@ package actor MemoryOrchestrator {
             var item = item
             let accessReasons = MemorySemantics.accessReasons(
                 stats: accessStatsMap[item.frameId],
+                metadata: item.metadata,
                 nowMs: recallNowMs
             ).reasons
             if !accessReasons.isEmpty {
@@ -1290,13 +1291,22 @@ package actor MemoryOrchestrator {
             embeddingAvailable: queryEmbedding.embedding != nil
         )
 
+        // Access-aware ranking needs additional candidates so a stale top hit
+        // can be displaced by a close, recently/frequently used result. The
+        // candidate window is bounded and applies only when the feature is on.
+        let searchTopK: Int
+        if !config.enableAccessStatsScoring || topK > 16 {
+            searchTopK = topK
+        } else {
+            searchTopK = topK * 3
+        }
         let request = SearchRequest(
             query: trimmed,
             embedding: queryEmbedding.embedding,
             vectorEnginePreference: preference,
             vectorSearchTimeout: config.vectorSearchTimeout,
             mode: searchMode,
-            topK: topK,
+            topK: searchTopK,
             timeRange: timeRange,
             frameFilter: frameFilter,
             scopeContext: config.defaultScopeContext,
@@ -1310,9 +1320,19 @@ package actor MemoryOrchestrator {
         } else {
             [:]
         }
-        let hits = response.results.map { result in
+        let scoredResults = config.enableAccessStatsScoring
+            ? AccessFrequencyRanker.rerank(
+                results: response.results,
+                query: trimmed,
+                accessStats: accessStatsMap,
+                nowMs: searchNowMs,
+                maxWindow: searchTopK
+            )
+            : response.results
+        let hits = scoredResults.prefix(topK).map { result in
             let accessReasons = MemorySemantics.accessReasons(
                 stats: accessStatsMap[result.frameId],
+                metadata: result.metadata,
                 nowMs: searchNowMs
             ).reasons
             return MemorySearchHit(

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1176,9 +1176,9 @@ package actor MemoryOrchestrator {
         )
     }
 
-    /// Shared recall implementation: builds the RAG context and records frame accesses.
-    /// All package recall() overloads funnel through here so that `ragConfigForRecall()` and
-    /// `recordAccessesIfEnabled` cannot diverge between overloads in future edits.
+    /// Shared recall implementation: builds the RAG context from the access-stat
+    /// snapshot taken before this call. Recall does not record access, so identical
+    /// queries stay byte-identical. Stats accrue from explicit get/promote.
     private func buildRecallContext(
         query: String,
         embedding: [Float]?,
@@ -1209,7 +1209,11 @@ package actor MemoryOrchestrator {
             config: recallConfig
         )
         let accessStatsMap: [UInt64: FrameAccessStats] = if config.enableAccessStatsScoring {
-            await accessStatsManager.getStats(frameIds: context.items.map(\.frameId))
+            await AccessFrequencyRanker.statsForRanking(
+                frameIds: context.items.map(\.frameId),
+                manager: accessStatsManager,
+                wax: wax
+            )
         } else {
             [:]
         }
@@ -1226,7 +1230,6 @@ package actor MemoryOrchestrator {
             }
             return item
         }
-        await recordAccessesIfEnabled(frameIds: context.items.map(\.frameId), nowMs: recallNowMs)
         return RAGContext(query: context.query, items: enrichedItems, totalTokens: context.totalTokens)
     }
 
@@ -1322,7 +1325,11 @@ package actor MemoryOrchestrator {
 
         let searchNowMs = config.rag.deterministicNowMs ?? nowProvider()
         let accessStatsMap: [UInt64: FrameAccessStats] = if config.enableAccessStatsScoring {
-            await accessStatsManager.getStats(frameIds: response.results.map(\.frameId))
+            await AccessFrequencyRanker.statsForRanking(
+                frameIds: response.results.map(\.frameId),
+                manager: accessStatsManager,
+                wax: wax
+            )
         } else {
             [:]
         }
@@ -1350,7 +1357,6 @@ package actor MemoryOrchestrator {
                 explanations: dedupedExplanations(result.explanations + accessReasons)
             )
         }
-        await recordAccessesIfEnabled(frameIds: hits.map(\.frameId), nowMs: searchNowMs)
         return SearchExecution(
             hits: hits,
             requestedMode: mode,
@@ -1463,6 +1469,13 @@ package actor MemoryOrchestrator {
 
     package func accessStatsSnapshot() async -> [UInt64: FrameAccessStats] {
         await accessStatsManager.snapshot()
+    }
+
+    /// Records an explicit use of a frame (get/promote). Search and recall rank
+    /// against the stored snapshot but do not mutate it.
+    package func recordAccess(frameId: UInt64) async {
+        let nowMs = config.rag.deterministicNowMs ?? nowProvider()
+        await recordAccessesIfEnabled(frameIds: [frameId], nowMs: nowMs)
     }
 
     private func dedupedExplanations(_ reasons: [String]) -> [String] {
@@ -2635,7 +2648,7 @@ package actor MemoryOrchestrator {
                 )
             }
         }
-        // A search may have recorded newer accesses while the WAL writes
+        // A get/promote may have recorded newer accesses while the WAL writes
         // above awaited. Only acknowledge the revision we actually persisted;
         // a newer revision remains dirty for the next flush.
         _ = await accessStatsManager.markPersisted(ifRevision: snapshot.revision)

--- a/Sources/Wax/Orchestrator/OrchestratorConfig.swift
+++ b/Sources/Wax/Orchestrator/OrchestratorConfig.swift
@@ -5,7 +5,7 @@ package struct OrchestratorConfig: Sendable {
     package var enableTextSearch: Bool = true
     package var enableVectorSearch: Bool = true
     package var enableStructuredMemory: Bool = false
-    package var enableAccessStatsScoring: Bool = false
+    package var enableAccessStatsScoring: Bool = true
     package var enableAsyncEnrichment: Bool = false
 
     package var rag: FastRAGConfig = .init()

--- a/Sources/Wax/RAG/AccessFrequencyRanker.swift
+++ b/Sources/Wax/RAG/AccessFrequencyRanker.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// Bounded access-aware reranking for already-retrieved candidates.
+///
+/// Access statistics are a weak preference signal. They may break close ties,
+/// but they must not erase lexical/vector relevance or make a frame permanently
+/// self-reinforcing merely because it was returned in the past.
+package enum AccessFrequencyRanker {
+    /// Public to package tests so the cap remains an explicit contract.
+    package static let maximumAdjustment: Float = 0.20
+    package static let minimumAdjustment: Float = -0.12
+
+    private static let frequencyHalfLifeHours: Float = 30 * 24
+    private static let recencyHalfLifeHours: Float = 24
+    private static let frequencyCenter: Float = 0.30
+    private static let adjustmentScale: Float = 0.45
+    private static let countSaturation: UInt32 = 32
+
+    /// Re-rank only a bounded candidate window, preserving the original order
+    /// as the final tie-breaker. The caller controls whether the feature is
+    /// enabled; an empty stats map is therefore a no-op.
+    package static func rerank(
+        results: [SearchResponse.Result],
+        query: String?,
+        accessStats: [UInt64: FrameAccessStats],
+        nowMs: Int64,
+        maxWindow: Int
+    ) -> [SearchResponse.Result] {
+        let cappedWindow = min(max(0, maxWindow), results.count)
+        guard cappedWindow > 0, !accessStats.isEmpty else { return results }
+
+        let query = query?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let scoredHead = results.prefix(cappedWindow).enumerated().map { index, result in
+            let stats = accessStats[result.frameId]
+            let base = MemorySemantics.accessReasons(
+                stats: stats,
+                metadata: result.metadata,
+                nowMs: nowMs
+            )
+            let exact = isExplicitExactMatch(result: result, query: query)
+            // Exact identifier/quoted phrase hits are already protected by the
+            // lexical lane. Never let a stale-access penalty undo that guarantee.
+            let adjustment = exact ? max(0, base.adjustment) : base.adjustment
+            var updated = result
+            // Search scores are published as normalized values. Keep the
+            // weak access signal from producing an out-of-contract score when
+            // a candidate already sits at either boundary.
+            updated.score = min(1, max(0, result.score + adjustment))
+
+            var explanations = result.explanations
+            if !base.reasons.isEmpty {
+                explanations.append(contentsOf: base.reasons)
+            }
+            if exact, let query, !query.isEmpty {
+                let exactReason = MatchPlan.rawQuotedPhrases(from: query).isEmpty
+                    ? "exact identifier match"
+                    : "exact phrase match"
+                explanations.append(exactReason)
+            }
+            updated.explanations = dedupedExplanations(explanations)
+
+            return (
+                index: index,
+                composite: updated.score,
+                baseScore: result.score,
+                result: updated
+            )
+        }
+
+        let rankedHead = scoredHead.sorted { lhs, rhs in
+            if lhs.composite != rhs.composite { return lhs.composite > rhs.composite }
+            if lhs.baseScore != rhs.baseScore { return lhs.baseScore > rhs.baseScore }
+            return lhs.index < rhs.index
+        }.map(\.result)
+
+        guard cappedWindow < results.count else { return rankedHead }
+        var combined = rankedHead
+        combined.reserveCapacity(results.count)
+        combined.append(contentsOf: results.dropFirst(cappedWindow))
+        return combined
+    }
+
+    /// Computes a bounded, decay-aware adjustment from one access record.
+    /// Frequency saturates at 32 accesses and decays over 30 days; recency has
+    /// a 24-hour half-life. This makes stale low-use frames demotable without
+    /// allowing repeated retrievals to grow the score without bound.
+    package static func adjustment(
+        stats: FrameAccessStats?,
+        metadata: [String: String] = [:],
+        nowMs: Int64
+    ) -> Float {
+        MemorySemantics.accessReasons(
+            stats: stats,
+            metadata: metadata,
+            nowMs: nowMs
+        ).adjustment
+    }
+
+    package static func rawAdjustment(stats: FrameAccessStats?, nowMs: Int64) -> Float {
+        guard let stats else { return 0 }
+        let hoursSinceAccess = Float(max(0, nowMs - stats.lastAccessMs)) / (1000 * 60 * 60)
+        let frequency = min(
+            1,
+            log(Float(min(stats.accessCount, countSaturation)) + 1)
+                / log(Float(countSaturation) + 1)
+        )
+        let frequencyDecay = exp(-hoursSinceAccess / frequencyHalfLifeHours)
+        let recencyDecay = exp(-hoursSinceAccess / recencyHalfLifeHours)
+        let engagement = 0.65 * frequency * frequencyDecay + 0.35 * recencyDecay
+        let raw = (engagement - frequencyCenter) * adjustmentScale
+        return min(maximumAdjustment, max(minimumAdjustment, raw))
+    }
+
+    private static func isExplicitExactMatch(result: SearchResponse.Result, query: String?) -> Bool {
+        guard let query, !query.isEmpty,
+              let preview = result.previewText,
+              !preview.isEmpty
+        else { return false }
+
+        let haystack = dehighlightedPreviewText(preview).lowercased()
+        let phrases = MatchPlan.rawQuotedPhrases(from: query)
+        if phrases.contains(where: { haystack.contains($0.lowercased()) }) {
+            return true
+        }
+        return RuleBasedQueryClassifier.isLexicalIdentifierQuery(query)
+            && haystack.contains(query.lowercased())
+    }
+
+    private static func dedupedExplanations(_ reasons: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        result.reserveCapacity(reasons.count)
+        for reason in reasons {
+            let normalized = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
+            result.append(normalized)
+        }
+        return result
+    }
+
+    private static func dehighlightedPreviewText(_ preview: String) -> String {
+        preview
+            .replacingOccurrences(of: "[", with: "")
+            .replacingOccurrences(of: "]", with: "")
+    }
+}

--- a/Sources/Wax/RAG/AccessFrequencyRanker.swift
+++ b/Sources/Wax/RAG/AccessFrequencyRanker.swift
@@ -42,10 +42,10 @@ package enum AccessFrequencyRanker {
             // lexical lane. Never let a stale-access penalty undo that guarantee.
             let adjustment = exact ? max(0, base.adjustment) : base.adjustment
             var updated = result
-            // Search scores are published as normalized values. Keep the
-            // weak access signal from producing an out-of-contract score when
-            // a candidate already sits at either boundary.
-            updated.score = min(1, max(0, result.score + adjustment))
+            // Search scores are rank keys rather than probabilities. Preserve
+            // the existing score scale and apply access as a bounded offset;
+            // the composite ordering below remains stable for ties.
+            updated.score = result.score + adjustment
 
             var explanations = result.explanations
             if !base.reasons.isEmpty {

--- a/Sources/Wax/RAG/AccessFrequencyRanker.swift
+++ b/Sources/Wax/RAG/AccessFrequencyRanker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WaxCore
 
 /// Bounded access-aware reranking for already-retrieved candidates.
 ///
@@ -78,6 +79,30 @@ package enum AccessFrequencyRanker {
         combined.reserveCapacity(results.count)
         combined.append(contentsOf: results.dropFirst(cappedWindow))
         return combined
+    }
+
+    /// Maps stored access stats onto search/recall hits. Chunk hits inherit a
+    /// parent document's stats so explicit get/promote of a document can still
+    /// rerank later retrieval of its chunks.
+    package static func statsForRanking(
+        frameIds: [UInt64],
+        manager: AccessStatsManager,
+        wax: Wax
+    ) async -> [UInt64: FrameAccessStats] {
+        let direct = await manager.getStats(frameIds: frameIds)
+        let missing = frameIds.filter { direct[$0] == nil }
+        guard !missing.isEmpty else { return direct }
+        let metas = await wax.frameMetas(frameIds: missing)
+        let parentIds = metas.values.compactMap(\.parentId)
+        guard !parentIds.isEmpty else { return direct }
+        let parentStats = await manager.getStats(frameIds: parentIds)
+        var resolved = direct
+        for frameId in missing {
+            if let parentId = metas[frameId]?.parentId, let inherited = parentStats[parentId] {
+                resolved[frameId] = inherited
+            }
+        }
+        return resolved
     }
 
     /// Computes a bounded, decay-aware adjustment from one access record.

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -88,6 +88,10 @@ package struct FastRAGContextBuilder: Sendable {
                 analyzer: queryAnalyzer
             )
             : accessRankedResults
+        // The search request may be overfetched only to give access-aware
+        // reranking headroom. Context assembly still honors the caller's
+        // requested result count.
+        let contextResults = Array(rankedResults.prefix(max(0, clamped.searchTopK)))
 
         var items: [RAGContext.Item] = []
         var usedTokens = 0
@@ -106,7 +110,7 @@ package struct FastRAGContextBuilder: Sendable {
             && clamped.maxSurrogates > 0
             && clamped.surrogateMaxTokens > 0
             && clamped.maxContextTokens > 0
-        let sourceFrameIds = rankedResults.map { $0.frameId }
+        let sourceFrameIds = contextResults.map { $0.frameId }
         let surrogateMapTask: [UInt64: UInt64] = shouldPrefetchSurrogates
             ? await wax.surrogateFrameIds(for: sourceFrameIds)
             : [:]
@@ -129,7 +133,7 @@ package struct FastRAGContextBuilder: Sendable {
 
         // 2) Expansion: first result with valid UTF-8 frame content
         if clamped.expansionMaxTokens > 0, clamped.expansionMaxBytes > 0 {
-            for result in rankedResults {
+            for result in contextResults {
                 if let expanded = try await expansionText(
                     frameId: result.frameId,
                     wax: wax,
@@ -183,7 +187,7 @@ package struct FastRAGContextBuilder: Sendable {
             // Keep only the top candidates, preserving response order.
             var orderedSurrogateIds: [UInt64] = []
             orderedSurrogateIds.reserveCapacity(maxToLoad)
-            for result in rankedResults {
+            for result in contextResults {
                 if let expandedFrameId, result.frameId == expandedFrameId { continue }
                 guard let surrogateId = surrogateMap[result.frameId] else { continue }
                 orderedSurrogateIds.append(surrogateId)
@@ -224,7 +228,7 @@ package struct FastRAGContextBuilder: Sendable {
             let frameMetaMap = sourceFrameMetasTask
 
             // Parallel tier selection and tier extraction, preserving response order.
-            let surrogateWorkItems = rankedResults
+            let surrogateWorkItems = contextResults
                 .compactMap { result -> (result: SearchResponse.Result, surrogateFrameId: UInt64)? in
                     if let expandedFrameId, result.frameId == expandedFrameId { return nil }
                     guard let surrogateId = surrogateMap[result.frameId] else { return nil }
@@ -316,7 +320,7 @@ package struct FastRAGContextBuilder: Sendable {
             var snippetCandidates: [(result: SearchResponse.Result, preview: String)] = []
             snippetCandidates.reserveCapacity(min(clamped.maxSnippets, 32))
 
-            for result in rankedResults {
+            for result in contextResults {
                 if let expandedFrameId, result.frameId == expandedFrameId { continue }
                 if surrogateSourceFrameIds.contains(result.frameId) { continue }
                 guard snippetCount < clamped.maxSnippets else { break }

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -28,12 +28,23 @@ package struct FastRAGContextBuilder: Sendable {
         let counter = try await TokenCounter.shared()
 
         // 1) Run unified search
+        // Access-aware ranking needs a little headroom so a stale top result can
+        // be displaced by a recently/frequently used candidate just outside the
+        // normal context window. The bound keeps enabled-mode work predictable.
+        let searchTopK: Int
+        if accessStatsManager == nil {
+            searchTopK = clamped.searchTopK
+        } else if clamped.searchTopK <= 24 {
+            searchTopK = clamped.searchTopK * 2
+        } else {
+            searchTopK = clamped.searchTopK
+        }
         let request = SearchRequest(
             query: query,
             embedding: embedding,
             vectorEnginePreference: vectorEnginePreference,
             mode: clamped.searchMode,
-            topK: clamped.searchTopK,
+            topK: searchTopK,
             timeRange: timeRange,
             frameFilter: frameFilter,
             scopeContext: scopeContext,
@@ -45,20 +56,38 @@ package struct FastRAGContextBuilder: Sendable {
         } else {
             try await wax.search(request)
         }
+        let scoringMetadata: [UInt64: FrameMeta] = if accessStatsManager != nil,
+                                                        clamped.deterministicNowMs == nil {
+            await wax.frameMetas(frameIds: response.results.map(\.frameId))
+        } else {
+            [:]
+        }
+        let accessScoringNowMs = clamped.deterministicNowMs
+            ?? scoringMetadata.values.map(\.timestamp).max()
+            ?? 0
+        let accessStatsMap: [UInt64: FrameAccessStats] = if let accessStatsManager {
+            await accessStatsManager.getStats(frameIds: response.results.map { $0.frameId })
+        } else {
+            [:]
+        }
+        let accessRankedResults = accessStatsManager == nil
+            ? response.results
+            : AccessFrequencyRanker.rerank(
+                results: response.results,
+                query: query,
+                accessStats: accessStatsMap,
+                nowMs: accessScoringNowMs,
+                maxWindow: searchTopK
+            )
         let queryAnalyzer = QueryAnalyzer()
         let rankedResults = clamped.enableAnswerFocusedRanking
             ? Self.orderCandidatesForAnswer(
-                results: response.results,
+                results: accessRankedResults,
                 query: query,
                 config: clamped,
                 analyzer: queryAnalyzer
             )
-            : response.results
-        let accessStatsMap: [UInt64: FrameAccessStats] = if let accessStatsManager {
-            await accessStatsManager.getStats(frameIds: rankedResults.map { $0.frameId })
-        } else {
-            [:]
-        }
+            : accessRankedResults
 
         var items: [RAGContext.Item] = []
         var usedTokens = 0
@@ -122,6 +151,7 @@ package struct FastRAGContextBuilder: Sendable {
                             explanations: enrichedExplanations(
                                 result.explanations,
                                 frameId: result.frameId,
+                                metadata: result.metadata,
                                 accessStatsMap: accessStatsMap,
                                 nowMs: nowMs
                             )
@@ -262,6 +292,7 @@ package struct FastRAGContextBuilder: Sendable {
                             explanations: enrichedExplanations(
                                 result.explanations,
                                 frameId: result.frameId,
+                                metadata: result.metadata,
                                 accessStatsMap: accessStatsMap,
                                 nowMs: nowMs
                             )
@@ -356,6 +387,7 @@ package struct FastRAGContextBuilder: Sendable {
                             explanations: enrichedExplanations(
                                 result.explanations,
                                 frameId: result.frameId,
+                                metadata: result.metadata,
                                 accessStatsMap: accessStatsMap,
                                 nowMs: nowMs
                             )
@@ -393,13 +425,18 @@ package struct FastRAGContextBuilder: Sendable {
     private func enrichedExplanations(
         _ existing: [String],
         frameId: UInt64,
+        metadata: [String: String],
         accessStatsMap: [UInt64: FrameAccessStats],
         nowMs: Int64?
     ) -> [String] {
         // Unknown "now" skips access-reason enrichment: a zero sentinel would mark
         // every frame with access stats as "recently used".
         let accessReasons = nowMs.map {
-            MemorySemantics.accessReasons(stats: accessStatsMap[frameId], nowMs: $0).reasons
+            MemorySemantics.accessReasons(
+                stats: accessStatsMap[frameId],
+                metadata: metadata,
+                nowMs: $0
+            ).reasons
         } ?? []
         var seen = Set<String>()
         var combined: [String] = []

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -66,7 +66,11 @@ package struct FastRAGContextBuilder: Sendable {
             ?? scoringMetadata.values.map(\.timestamp).max()
             ?? 0
         let accessStatsMap: [UInt64: FrameAccessStats] = if let accessStatsManager {
-            await accessStatsManager.getStats(frameIds: response.results.map { $0.frameId })
+            await AccessFrequencyRanker.statsForRanking(
+                frameIds: response.results.map(\.frameId),
+                manager: accessStatsManager,
+                wax: wax
+            )
         } else {
             [:]
         }

--- a/Sources/Wax/Stats/AccessStats.swift
+++ b/Sources/Wax/Stats/AccessStats.swift
@@ -23,7 +23,8 @@ package struct FrameAccessStats: Sendable, Equatable, Codable {
 
     package mutating func recordAccess(nowMs: Int64) {
         // Use saturating addition to prevent overflow
-        accessCount = accessCount.addingReportingOverflow(1).partialValue
+        let (nextCount, overflowed) = accessCount.addingReportingOverflow(1)
+        accessCount = overflowed ? UInt32.max : nextCount
         lastAccessMs = nowMs
     }
 }

--- a/Sources/Wax/Stats/AccessStats.swift
+++ b/Sources/Wax/Stats/AccessStats.swift
@@ -33,6 +33,7 @@ package struct FrameAccessStats: Sendable, Equatable, Codable {
 package actor AccessStatsManager {
     private var stats: [UInt64: FrameAccessStats] = [:]
     private var dirty = false
+    private var revision: UInt64 = 0
 
     package init() {}
 
@@ -45,6 +46,7 @@ package actor AccessStatsManager {
             stats[frameId] = FrameAccessStats(frameId: frameId, nowMs: nowMs)
         }
         dirty = true
+        revision = revision == UInt64.max ? 0 : revision + 1
     }
 
     /// Record accesses for multiple frames at once.
@@ -59,6 +61,7 @@ package actor AccessStatsManager {
             }
         }
         dirty = true
+        revision = revision == UInt64.max ? 0 : revision + 1
     }
     
     /// Get stats for a single frame.
@@ -88,6 +91,7 @@ package actor AccessStatsManager {
         stats = stats.filter { activeFrameIds.contains($0.key) }
         if stats.count != before {
             dirty = true
+            revision = revision == UInt64.max ? 0 : revision + 1
         }
     }
     
@@ -102,15 +106,33 @@ package actor AccessStatsManager {
         return exportStats()
     }
 
+    /// Return a dirty snapshot together with the revision observed at the
+    /// snapshot boundary. Persistence can then acknowledge only that exact
+    /// revision, preserving accesses recorded while the store write awaited.
+    package func exportStatsSnapshotIfDirty() -> (stats: [FrameAccessStats], revision: UInt64)? {
+        guard dirty else { return nil }
+        return (exportStats(), revision)
+    }
+
     /// Mark the current in-memory snapshot as persisted.
     package func markPersisted() {
         dirty = false
+    }
+
+    /// Clear the dirty bit only when no newer access mutation occurred after
+    /// the persisted snapshot was taken.
+    @discardableResult
+    package func markPersisted(ifRevision snapshotRevision: UInt64) -> Bool {
+        guard revision == snapshotRevision else { return false }
+        dirty = false
+        return true
     }
     
     /// Import stats from persistence.
     package func importStats(_ imported: [FrameAccessStats]) {
         stats = Dictionary(uniqueKeysWithValues: imported.map { ($0.frameId, $0) })
         dirty = false
+        revision = revision == UInt64.max ? 0 : revision + 1
     }
     
     /// Total number of tracked frames.

--- a/Sources/WaxCLI/DaemonCommand.swift
+++ b/Sources/WaxCLI/DaemonCommand.swift
@@ -42,7 +42,7 @@ struct DaemonCommand: AsyncParsableCommand {
             requireVector: store.requireVector,
             enableAccessStatsScoring: featureFlagEnabled(
                 "WAX_MCP_FEATURE_ACCESS_STATS",
-                default: false
+                default: true
             ),
             embedderTuning: store.embedderTuning
         )

--- a/Sources/WaxMCPServer/MCPMemoryFactory.swift
+++ b/Sources/WaxMCPServer/MCPMemoryFactory.swift
@@ -54,7 +54,7 @@ enum MCPMemoryFactory {
         }
         var config = OrchestratorConfig.default
         config.enableStructuredMemory = structuredMemoryEnabled
-        config.enableAccessStatsScoring = false
+        config.enableAccessStatsScoring = true
         let request = try HostEmbeddingReadiness.request(
             noEmbedder: noEmbedder,
             requireVector: false,
@@ -117,7 +117,7 @@ enum MCPMemoryFactory {
         config.enableVectorSearch = false
         config.rag.searchMode = .textOnly
         config.enableStructuredMemory = false
-        config.enableAccessStatsScoring = false
+        config.enableAccessStatsScoring = true
         do {
             return try await MemoryOrchestrator(at: url, config: config, waxOptions: waxOptions())
         } catch {

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -105,7 +105,7 @@ struct WaxMCPServerCommand: ParsableCommand {
         )
         memoryConfig.enableAccessStatsScoring = featureFlagEnabled(
             "WAX_MCP_FEATURE_ACCESS_STATS",
-            default: false
+            default: true
         )
 
         let currentExecutablePath = try resolveCurrentExecutablePath()

--- a/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
+++ b/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func accessFrequencyDisabledModeLeavesCandidatesUntouched() {
+    let results = [
+        makeAccessRankingResult(frameId: 1, score: 0.40, preview: "alpha"),
+        makeAccessRankingResult(frameId: 2, score: 0.35, preview: "beta"),
+    ]
+    var stats = FrameAccessStats(frameId: 2, nowMs: 1_700_000_000_000)
+    stats.accessCount = 32
+
+    let ranked = AccessFrequencyRanker.rerank(
+        results: results,
+        query: "alpha",
+        accessStats: [2: stats],
+        nowMs: 1_700_000_000_000,
+        maxWindow: 2
+    )
+
+    // The caller's disabled path never invokes the ranker; an empty stats map
+    // is also a no-op so it is safe for shared search plumbing.
+    let disabled = AccessFrequencyRanker.rerank(
+        results: results,
+        query: "alpha",
+        accessStats: [:],
+        nowMs: 1_700_000_000_000,
+        maxWindow: 2
+    )
+    #expect(disabled == results)
+    #expect(ranked.first?.frameId == 2)
+    #expect((ranked.first?.score ?? 0) > results[1].score)
+}
+
+@Test
+func accessFrequencyDemotesStaleLowUseAndExplainsPublishedAdjustment() {
+    let nowMs: Int64 = 1_700_000_000_000
+    let results = [
+        makeAccessRankingResult(frameId: 1, score: 0.50, preview: "shared token"),
+        makeAccessRankingResult(frameId: 2, score: 0.50, preview: "shared token"),
+    ]
+    var stale = FrameAccessStats(frameId: 1, nowMs: nowMs - 30 * dayMs)
+    stale.accessCount = 1
+    var recent = FrameAccessStats(frameId: 2, nowMs: nowMs - 6 * hourMs)
+    recent.accessCount = 8
+
+    let ranked = AccessFrequencyRanker.rerank(
+        results: results,
+        query: "shared token",
+        accessStats: [1: stale, 2: recent],
+        nowMs: nowMs,
+        maxWindow: 2
+    )
+
+    #expect(ranked.map(\.frameId) == [2, 1])
+    #expect(ranked[0].score > results[1].score)
+    #expect(ranked[1].score < results[0].score)
+    #expect(ranked[0].explanations.contains("repeated use"))
+    #expect(ranked[1].explanations.contains("stale access"))
+
+    let recentAdjustment = AccessFrequencyRanker.adjustment(
+        stats: recent,
+        metadata: ranked[0].metadata,
+        nowMs: nowMs
+    )
+    #expect(abs((ranked[0].score - results[1].score) - recentAdjustment) < 0.0001)
+}
+
+@Test
+func accessFrequencyProtectsExactIdentifierAndDurablePolicy() {
+    let nowMs: Int64 = 1_700_000_000_000
+    let exact = makeAccessRankingResult(
+        frameId: 1,
+        // The lexical lane gives explicit identifier hits a strong base score;
+        // access scoring must not erase that protection.
+        score: 0.99,
+        preview: "deployment token Atlas-42 is locked",
+        metadata: [
+            MemoryMetadataKeys.type: MemoryType.note.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.working.rawValue,
+        ]
+    )
+    let neighbor = makeAccessRankingResult(
+        frameId: 2,
+        score: 0.79,
+        preview: "deployment token Atlas context"
+    )
+    let staleExact = FrameAccessStats(frameId: 1, nowMs: nowMs - 90 * dayMs)
+    var recentNeighbor = FrameAccessStats(frameId: 2, nowMs: nowMs)
+    recentNeighbor.accessCount = 32
+
+    let ranked = AccessFrequencyRanker.rerank(
+        results: [exact, neighbor],
+        query: "Atlas-42",
+        accessStats: [1: staleExact, 2: recentNeighbor],
+        nowMs: nowMs,
+        maxWindow: 2
+    )
+    #expect(ranked.first?.frameId == exact.frameId)
+
+    let durable = makeAccessRankingResult(
+        frameId: 3,
+        score: 0.50,
+        preview: "durable fact",
+        metadata: [MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue]
+    )
+    let durableStats = FrameAccessStats(frameId: 3, nowMs: nowMs - 90 * dayMs)
+    #expect(
+        AccessFrequencyRanker.adjustment(
+            stats: durableStats,
+            metadata: durable.metadata,
+            nowMs: nowMs
+        ) == 0
+    )
+}
+
+@Test
+func accessFrequencyAdjustmentIsBoundedAgainstRichGetRicherAmplification() {
+    let nowMs: Int64 = 1_700_000_000_000
+    var saturated = FrameAccessStats(frameId: 1, nowMs: nowMs)
+    saturated.accessCount = UInt32.max
+    let positive = AccessFrequencyRanker.adjustment(stats: saturated, nowMs: nowMs)
+    #expect(positive == AccessFrequencyRanker.maximumAdjustment)
+
+    let stale = FrameAccessStats(frameId: 2, nowMs: nowMs - 365 * dayMs)
+    let negative = AccessFrequencyRanker.adjustment(stats: stale, nowMs: nowMs)
+    #expect(negative >= AccessFrequencyRanker.minimumAdjustment)
+}
+
+@Test
+func accessFrequencyKeepsPublishedScoreInUnitInterval() {
+    let nowMs: Int64 = 1_700_000_000_000
+    var stats = FrameAccessStats(frameId: 1, nowMs: nowMs)
+    stats.accessCount = UInt32.max
+    let result = makeAccessRankingResult(frameId: 1, score: 0.99, preview: "boundary")
+
+    let ranked = AccessFrequencyRanker.rerank(
+        results: [result],
+        query: "boundary",
+        accessStats: [1: stats],
+        nowMs: nowMs,
+        maxWindow: 1
+    )
+
+    #expect(ranked[0].score >= 0)
+    #expect(ranked[0].score <= 1)
+}
+
+@Test
+func accessFrequencyStatsPersistAndReloadAtOrchestratorSeam() async throws {
+    try await TempFiles.withTempFile { url in
+        let nowMs: Int64 = 1_700_000_000_000
+        var config = TestHelpers.defaultMemoryConfig(vector: false)
+        config.enableAccessStatsScoring = true
+        config.rag.deterministicNowMs = nowMs
+
+        let memory = try await MemoryOrchestrator(at: url, config: config)
+        let remembered = try await memory.remember("access-frequency-persistence-token")
+        _ = try await memory.search(
+            query: "access-frequency-persistence-token",
+            mode: .textOnly,
+            topK: 1
+        )
+        try await memory.flush()
+        try await memory.close()
+
+        let reopened = try await MemoryOrchestrator(at: url, config: config)
+        let stats = await reopened.accessStatsSnapshot()
+        #expect(stats[remembered.frameId]?.accessCount == 1)
+        try await reopened.close()
+    }
+}
+
+private let hourMs: Int64 = 60 * 60 * 1000
+private let dayMs: Int64 = 24 * hourMs
+
+private func makeAccessRankingResult(
+    frameId: UInt64,
+    score: Float,
+    preview: String,
+    metadata: [String: String] = [:]
+) -> SearchResponse.Result {
+    SearchResponse.Result(
+        frameId: frameId,
+        score: score,
+        previewText: preview,
+        sources: [.text],
+        metadata: metadata
+    )
+}

--- a/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
+++ b/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
@@ -135,11 +135,11 @@ func accessFrequencyAdjustmentIsBoundedAgainstRichGetRicherAmplification() {
 }
 
 @Test
-func accessFrequencyKeepsPublishedScoreInUnitInterval() {
+func accessFrequencyPreservesPublishedScoreScale() {
     let nowMs: Int64 = 1_700_000_000_000
     var stats = FrameAccessStats(frameId: 1, nowMs: nowMs)
     stats.accessCount = UInt32.max
-    let result = makeAccessRankingResult(frameId: 1, score: 0.99, preview: "boundary")
+    let result = makeAccessRankingResult(frameId: 1, score: 4.0, preview: "boundary")
 
     let ranked = AccessFrequencyRanker.rerank(
         results: [result],
@@ -149,8 +149,8 @@ func accessFrequencyKeepsPublishedScoreInUnitInterval() {
         maxWindow: 1
     )
 
-    #expect(ranked[0].score >= 0)
-    #expect(ranked[0].score <= 1)
+    #expect(ranked[0].score > result.score)
+    #expect(ranked[0].score == result.score + AccessFrequencyRanker.maximumAdjustment)
 }
 
 @Test
@@ -165,6 +165,17 @@ func accessFrequencyCounterSaturatesAtUInt32Maximum() async {
     })
     await manager.recordAccess(frameId: 1, nowMs: 1_700_000_000_001)
     #expect(await manager.getStats(frameId: 1)?.accessCount == UInt32.max)
+}
+
+@Test
+func accessFrequencyPersistenceAcknowledgesOnlyTheSnapshotRevision() async {
+    let manager = AccessStatsManager()
+    await manager.recordAccess(frameId: 1, nowMs: 1_700_000_000_000)
+    let snapshot = await manager.exportStatsSnapshotIfDirty()
+    #expect(snapshot != nil)
+    await manager.recordAccess(frameId: 1, nowMs: 1_700_000_000_001)
+    #expect(await manager.markPersisted(ifRevision: snapshot?.revision ?? 0) == false)
+    #expect(await manager.exportStatsIfDirty() != nil)
 }
 
 @Test

--- a/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
+++ b/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
@@ -3,6 +3,12 @@ import Testing
 @testable import Wax
 
 @Test
+func accessFrequencyScoringIsEnabledByDefaultAtPublicConfig() {
+    #expect(Memory.Config.default.enableAccessStatsScoring)
+    #expect(OrchestratorConfig.default.enableAccessStatsScoring)
+}
+
+@Test
 func accessFrequencyDisabledModeLeavesCandidatesUntouched() {
     let results = [
         makeAccessRankingResult(frameId: 1, score: 0.40, preview: "alpha"),

--- a/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
+++ b/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
@@ -203,6 +203,46 @@ func accessFrequencyStatsPersistAndReloadAtOrchestratorSeam() async throws {
     }
 }
 
+@Test
+func accessFrequencyOverlappingFlushesPublishNewestRevision() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = TestHelpers.defaultMemoryConfig(vector: false)
+        config.enableAccessStatsScoring = true
+        config.liveSetRewriteSchedule = .disabled
+
+        let memory = try await MemoryOrchestrator(at: url, config: config)
+        let remembered = try await memory.remember("access-frequency-overlap-token")
+        _ = try await memory.search(
+            query: "access-frequency-overlap-token",
+            mode: .textOnly,
+            topK: 1
+        )
+
+        // Hold the first snapshot after it has been captured. The second
+        // search creates a newer revision while the first flush is suspended;
+        // clearing the hold lets the second flush race the older continuation.
+        await memory.setAccessStatsPersistenceHoldForTesting(.milliseconds(250))
+        let firstFlush = Task { try await memory.flush() }
+        try await Task.sleep(for: .milliseconds(40))
+        _ = try await memory.search(
+            query: "access-frequency-overlap-token",
+            mode: .textOnly,
+            topK: 1
+        )
+        await memory.setAccessStatsPersistenceHoldForTesting(nil)
+        let secondFlush = Task { try await memory.flush() }
+
+        try await firstFlush.value
+        try await secondFlush.value
+        try await memory.close()
+
+        let reopened = try await MemoryOrchestrator(at: url, config: config)
+        let stats = await reopened.accessStatsSnapshot()
+        #expect(stats[remembered.frameId]?.accessCount == 2)
+        try await reopened.close()
+    }
+}
+
 private let hourMs: Int64 = 60 * 60 * 1000
 private let dayMs: Int64 = 24 * hourMs
 

--- a/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
+++ b/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
@@ -154,6 +154,20 @@ func accessFrequencyKeepsPublishedScoreInUnitInterval() {
 }
 
 @Test
+func accessFrequencyCounterSaturatesAtUInt32Maximum() async {
+    let manager = AccessStatsManager()
+    await manager.importStats([
+        FrameAccessStats(frameId: 1, nowMs: 1_700_000_000_000)
+    ].map { stat in
+        var saturated = stat
+        saturated.accessCount = UInt32.max
+        return saturated
+    })
+    await manager.recordAccess(frameId: 1, nowMs: 1_700_000_000_001)
+    #expect(await manager.getStats(frameId: 1)?.accessCount == UInt32.max)
+}
+
+@Test
 func accessFrequencyStatsPersistAndReloadAtOrchestratorSeam() async throws {
     try await TempFiles.withTempFile { url in
         let nowMs: Int64 = 1_700_000_000_000

--- a/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
+++ b/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 @Test
 func accessFrequencyScoringIsEnabledByDefaultAtPublicConfig() {
@@ -188,11 +189,7 @@ func accessFrequencyStatsPersistAndReloadAtOrchestratorSeam() async throws {
 
         let memory = try await MemoryOrchestrator(at: url, config: config)
         let remembered = try await memory.remember("access-frequency-persistence-token")
-        _ = try await memory.search(
-            query: "access-frequency-persistence-token",
-            mode: .textOnly,
-            topK: 1
-        )
+        await memory.recordAccess(frameId: remembered.frameId)
         try await memory.flush()
         try await memory.close()
 
@@ -212,23 +209,16 @@ func accessFrequencyOverlappingFlushesPublishNewestRevision() async throws {
 
         let memory = try await MemoryOrchestrator(at: url, config: config)
         let remembered = try await memory.remember("access-frequency-overlap-token")
-        _ = try await memory.search(
-            query: "access-frequency-overlap-token",
-            mode: .textOnly,
-            topK: 1
-        )
+        await memory.recordAccess(frameId: remembered.frameId)
 
         // Hold the first snapshot after it has been captured. The second
-        // search creates a newer revision while the first flush is suspended;
-        // clearing the hold lets the second flush race the older continuation.
+        // explicit use creates a newer revision while the first flush is
+        // suspended; clearing the hold lets the second flush race the older
+        // continuation.
         await memory.setAccessStatsPersistenceHoldForTesting(.milliseconds(250))
         let firstFlush = Task { try await memory.flush() }
         try await Task.sleep(for: .milliseconds(40))
-        _ = try await memory.search(
-            query: "access-frequency-overlap-token",
-            mode: .textOnly,
-            topK: 1
-        )
+        await memory.recordAccess(frameId: remembered.frameId)
         await memory.setAccessStatsPersistenceHoldForTesting(nil)
         let secondFlush = Task { try await memory.flush() }
 
@@ -240,6 +230,106 @@ func accessFrequencyOverlappingFlushesPublishNewestRevision() async throws {
         let stats = await reopened.accessStatsSnapshot()
         #expect(stats[remembered.frameId]?.accessCount == 2)
         try await reopened.close()
+    }
+}
+
+@Test
+func accessFrequencyRecallDoesNotRecordOrPersistAccessStats() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = TestHelpers.defaultMemoryConfig(vector: false)
+        config.enableAccessStatsScoring = true
+        config.rag.deterministicNowMs = 1_700_000_000_000
+
+        let memory = try await MemoryOrchestrator(at: url, config: config)
+        let remembered = try await memory.remember("access-frequency-recall-nonmutating-token")
+        try await memory.flush()
+
+        let recall1 = try await memory.recall(query: "access-frequency-recall-nonmutating-token")
+        let recall2 = try await memory.recall(query: "access-frequency-recall-nonmutating-token")
+        #expect(recall1 == recall2)
+        #expect(await memory.accessStatsSnapshot().isEmpty)
+
+        _ = try await memory.search(
+            query: "access-frequency-recall-nonmutating-token",
+            mode: .textOnly,
+            topK: 1
+        )
+        try await memory.flush()
+        #expect(await memory.accessStatsSnapshot().isEmpty)
+        try await memory.close()
+
+        let wax = try await Wax.open(at: url)
+        let metas = await wax.frameMetas()
+        #expect(metas.contains { $0.id == remembered.frameId && $0.role == .document })
+        #expect(!metas.contains { $0.kind == "wax.internal.access_stats" })
+        #expect(metas.filter { $0.role == .document }.count == 1)
+        try await wax.close()
+    }
+}
+
+@Test
+func accessFrequencyExplicitUseChangesLaterSearchWithoutMutatingThatSearch() async throws {
+    try await TempFiles.withTempFile { url in
+        let nowMs: Int64 = 1_700_000_000_000
+        var config = TestHelpers.defaultMemoryConfig(vector: false)
+        config.enableAccessStatsScoring = true
+        config.rag.deterministicNowMs = nowMs
+
+        let memory = try await MemoryOrchestrator(at: url, config: config)
+        let remembered = try await memory.remember("access-frequency-explicit-use-token")
+        try await memory.flush()
+
+        let beforeUse = try await memory.search(
+            query: "access-frequency-explicit-use-token",
+            mode: .textOnly,
+            topK: 1
+        )
+        #expect(beforeUse.allSatisfy { !$0.explanations.contains("recently used") })
+
+        await memory.recordAccess(frameId: remembered.frameId)
+        let afterUse = try await memory.search(
+            query: "access-frequency-explicit-use-token",
+            mode: .textOnly,
+            topK: 1
+        )
+        let afterUseAgain = try await memory.search(
+            query: "access-frequency-explicit-use-token",
+            mode: .textOnly,
+            topK: 1
+        )
+        #expect(afterUse.contains { $0.explanations.contains("recently used") })
+        #expect(afterUse.map(\.score) == afterUseAgain.map(\.score))
+        #expect(afterUse.map(\.explanations) == afterUseAgain.map(\.explanations))
+        #expect(await memory.accessStatsSnapshot()[remembered.frameId]?.accessCount == 1)
+        try await memory.close()
+    }
+}
+
+@Test
+func accessFrequencyChunkHitsInheritDocumentAccessStats() async throws {
+    try await TempFiles.withTempFile { url in
+        let nowMs: Int64 = 1_700_000_000_000
+        var config = TestHelpers.defaultMemoryConfig(vector: false)
+        config.enableAccessStatsScoring = true
+        config.rag.deterministicNowMs = nowMs
+        config.chunking = .tokenCount(targetTokens: 4, overlapTokens: 0)
+
+        let memory = try await MemoryOrchestrator(at: url, config: config)
+        let remembered = try await memory.remember(
+            "access-frequency chunk inherit document ranking token sequence"
+        )
+        try await memory.flush()
+        await memory.recordAccess(frameId: remembered.frameId)
+
+        let hits = try await memory.search(
+            query: "access-frequency chunk inherit",
+            mode: .textOnly,
+            topK: 5
+        )
+        #expect(!hits.isEmpty)
+        #expect(hits.contains { $0.frameId != remembered.frameId })
+        #expect(hits.contains { $0.explanations.contains("recently used") })
+        try await memory.close()
     }
 }
 

--- a/Tests/WaxIntegrationTests/DeterministicRecallTests.swift
+++ b/Tests/WaxIntegrationTests/DeterministicRecallTests.swift
@@ -114,13 +114,14 @@ struct DeterministicRecallTests {
     @Test
     func injectedNowDrivesAccessRecencyExplanationWithinOneRequest() async throws {
         try await TempFiles.withTempFile { url in
+            let remembered: MemoryOrchestrator.RememberResult
             do {
                 let ingest = try await MemoryOrchestrator(
                     at: url,
                     config: TestHelpers.defaultMemoryConfig(),
                     embedder: DeterministicTextEmbedder()
                 )
-                try await ingest.remember("Waxfile delta tracks rollout status across regions.")
+                remembered = try await ingest.remember("Waxfile delta tracks rollout status across regions.")
                 try await ingest.flush()
                 try await ingest.close()
             }
@@ -144,8 +145,9 @@ struct DeterministicRecallTests {
                 )
             }
 
-            // First pass records access stats stamped with the injected clock.
-            _ = try await runSearch()
+            // Explicit use stamps access stats with the injected clock. Search
+            // itself does not record, so consecutive searches stay deterministic.
+            await orchestrator.recordAccess(frameId: remembered.frameId)
 
             // Same injected now: the previous access is <24h old, so the documented
             // "recently used" reason appears.

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorSessionGraphAndStatsTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorSessionGraphAndStatsTests.swift
@@ -61,10 +61,9 @@ func accessStatsPersistAsSystemFrameWhenEnabled() async throws {
     config.enableAccessStatsScoring = true
 
     let memory = try await MemoryOrchestrator(at: url, config: config)
-    try await memory.remember("ACCESS_STATS_PERSISTENCE_TOKEN")
+    let remembered = try await memory.remember("ACCESS_STATS_PERSISTENCE_TOKEN")
     try await memory.flush()
-
-    _ = try await memory.recall(query: "ACCESS_STATS_PERSISTENCE_TOKEN")
+    await memory.recordAccess(frameId: remembered.frameId)
     try await memory.flush()
     try await memory.close()
 
@@ -121,7 +120,7 @@ func legacyAccessStatsMarkerFrameIsSupersededAfterBootstrap() async throws {
     accessStatsConfig.enableAccessStatsScoring = true
 
     let reopened = try await MemoryOrchestrator(at: url, config: accessStatsConfig)
-    _ = try await reopened.recall(query: "ACCESS_STATS_LEGACY_BOOTSTRAP_TOKEN")
+    await reopened.recordAccess(frameId: documentID)
     try await reopened.flush()
     try await reopened.close()
 

--- a/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
+++ b/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
@@ -9,6 +9,9 @@ func singleChunkRememberAddsOneFrame() async throws {
         var config = OrchestratorConfig.default
         config.enableVectorSearch = false
         config.enableTextSearch = true
+        // This characterization test asserts document-frame writes; access
+        // statistics are persisted as a separate system frame when enabled.
+        config.enableAccessStatsScoring = false
 
         let content = "canary-7f3a91 single-chunk remember must add one frame"
         let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)

--- a/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
+++ b/Tests/WaxIntegrationTests/SingleChunkRememberTests.swift
@@ -9,9 +9,6 @@ func singleChunkRememberAddsOneFrame() async throws {
         var config = OrchestratorConfig.default
         config.enableVectorSearch = false
         config.enableTextSearch = true
-        // This characterization test asserts document-frame writes; access
-        // statistics are persisted as a separate system frame when enabled.
-        config.enableAccessStatsScoring = false
 
         let content = "canary-7f3a91 single-chunk remember must add one frame"
         let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)


### PR DESCRIPTION
## Summary
- Access frequency now affects retrieval order by default, with bounded adjustments that cannot displace exact/durable hits.
- Recall and search rank from a pre-call snapshot and do not record access. Stats accrue from explicit get/promote; chunk hits inherit the parent document.
- Persist access stats under a serialized flush so overlapping writes cannot promote a stale snapshot.
- Saturate counters and keep public scores as rank keys rather than clamped probabilities.
- Rebased onto `main` after #169.

## Test plan
- [x] `swift test --filter AccessFrequencyRankingTests`
- [x] `swift test --filter DeterministicRecallTests`
- [x] `swift test --filter singleChunkRememberAddsOneFrame`
- [ ] CI gates on `96be298c3`