### PR TITLE
fix: reject durable task_state and add copy-first migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Workflow rules:
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
-- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
+- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
 Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 
@@ -412,7 +412,7 @@ On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`
 
 Write as you go:
 - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).
-- `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run.
+- `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct complete-store copy after a dry run.
 - Long-term: `remember` with `scope: durable` (no `session_id`), type `decision` / `lesson` / `constraint` / `user_preference` / `fact` (corrections, decisions, standing prefs, stable repo facts).
 
 Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Workflow rules:
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
+- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
 Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 
@@ -411,6 +412,7 @@ On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`
 
 Write as you go:
 - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).
+- `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run.
 - Long-term: `remember` with `scope: durable` (no `session_id`), type `decision` / `lesson` / `constraint` / `user_preference` / `fact` (corrections, decisions, standing prefs, stable repo facts).
 
 Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.

--- a/Resources/hermes/wax-memory-plugin/README.md
+++ b/Resources/hermes/wax-memory-plugin/README.md
@@ -57,7 +57,7 @@ Default tools stay small to avoid schema bloat:
 
 | Tool | Description |
 |------|-------------|
-| `wax_remember` | Store memory (`memory_type`: note, task_state, user_preference, decision, lesson, handoff, constraint, fact) |
+| `wax_remember` | Store memory (`memory_type`: note, task_state, user_preference, decision, lesson, handoff, constraint, fact); task_state requires an active session and is always working |
 | `wax_recall` | RAG context recall |
 | `wax_search` | Ranked raw hits |
 | `wax_handoff` / `wax_handoff_latest` | Cross-session handoff |

--- a/Resources/hermes/wax-memory-plugin/skills/maintenance/SKILL.md
+++ b/Resources/hermes/wax-memory-plugin/skills/maintenance/SKILL.md
@@ -11,7 +11,7 @@ Use when the active Hermes memory provider is `wax-memory`.
 
 1. Confirm the broker is reachable: `hermes wax-memory doctor`
 2. Prefer `wax_recall` for assembled context and `wax_search` for raw hits
-3. Store durable facts with `wax_remember` and `memory_type` from `note`, `task_state`, `user_preference`, `decision`, `lesson`, `handoff`, `constraint`, `fact`
+3. Store durable facts with `wax_remember` and `memory_type` from `note`, `user_preference`, `decision`, `lesson`, `handoff`, `constraint`, `fact`; `task_state` is session-local working state and requires an active session
 4. Write session continuity with `wax_handoff`; do not dump raw transcripts
 5. Use structured tools (`wax_entity_upsert`, `wax_fact_assert`, `wax_facts_query`) only for stable knowledge-graph facts
 

--- a/Resources/npm/waxmcp/README.md
+++ b/Resources/npm/waxmcp/README.md
@@ -143,7 +143,7 @@ them in this order:
 | `npx -y waxmcp@latest --transport http ...` | Serve MCP over HTTP for multi-agent setups |
 | `npx -y waxmcp@latest mcp doctor` | Validate setup and run a tools/list smoke check |
 | `npx -y waxmcp@latest vector-health` | Check vector search status of the HTTP endpoint |
-| `npx -y waxmcp@latest task-state-migrate --arg destination_path=/tmp/repaired.wax --arg dry_run=true` | Report and repair legacy durable `task_state` frames into a distinct store |
+| `npx -y waxmcp@latest task-state-migrate --direct-store --store-path ~/.wax/memory.wax --destination-path /tmp/repaired.wax --dry-run` | Report and repair legacy durable `task_state` frames into a distinct, complete store copy |
 | `npx -y waxmcp@latest install` | Locate or build (`--build`) the `wax-mcp` binary |
 | `npx -y waxmcp@latest install-hermes-plugin` | Install the Hermes wax-memory plugin |
 | `npx -y waxmcp@latest install-openclaw-plugin` | Print OpenClaw plugin install steps |

--- a/Resources/npm/waxmcp/README.md
+++ b/Resources/npm/waxmcp/README.md
@@ -143,6 +143,7 @@ them in this order:
 | `npx -y waxmcp@latest --transport http ...` | Serve MCP over HTTP for multi-agent setups |
 | `npx -y waxmcp@latest mcp doctor` | Validate setup and run a tools/list smoke check |
 | `npx -y waxmcp@latest vector-health` | Check vector search status of the HTTP endpoint |
+| `npx -y waxmcp@latest task-state-migrate --arg destination_path=/tmp/repaired.wax --arg dry_run=true` | Report and repair legacy durable `task_state` frames into a distinct store |
 | `npx -y waxmcp@latest install` | Locate or build (`--build`) the `wax-mcp` binary |
 | `npx -y waxmcp@latest install-hermes-plugin` | Install the Hermes wax-memory plugin |
 | `npx -y waxmcp@latest install-openclaw-plugin` | Print OpenClaw plugin install steps |

--- a/Resources/npm/waxmcp/bin/waxmcp.js
+++ b/Resources/npm/waxmcp/bin/waxmcp.js
@@ -310,6 +310,13 @@ if (forwardedArgs[0] === "install-all-plugins") {
 }
 
 // --- Default: run MCP server ---
+// Maintenance commands that are exposed by wax-cli must be dispatched before
+// the MCP flag translation below. Otherwise the launcher would pass the
+// subcommand token to wax-mcp, which treats it as an unknown server argument.
+if (forwardedArgs[0] === "task-state-migrate") {
+  runBinary("wax-cli", forwardedArgs);
+}
+
 // Translate the legacy 'mcp' prefix to native wax-mcp flags
 const mcpFlags = [];
 let i = 0;

--- a/Resources/npm/waxmcp/plugins/hermes/README.md
+++ b/Resources/npm/waxmcp/plugins/hermes/README.md
@@ -57,7 +57,7 @@ Default tools stay small to avoid schema bloat:
 
 | Tool | Description |
 |------|-------------|
-| `wax_remember` | Store memory (`memory_type`: note, task_state, user_preference, decision, lesson, handoff, constraint, fact) |
+| `wax_remember` | Store memory (`memory_type`: note, task_state, user_preference, decision, lesson, handoff, constraint, fact); task_state requires an active session and is always working |
 | `wax_recall` | RAG context recall |
 | `wax_search` | Ranked raw hits |
 | `wax_handoff` / `wax_handoff_latest` | Cross-session handoff |

--- a/Resources/npm/waxmcp/plugins/hermes/skills/maintenance/SKILL.md
+++ b/Resources/npm/waxmcp/plugins/hermes/skills/maintenance/SKILL.md
@@ -11,7 +11,7 @@ Use when the active Hermes memory provider is `wax-memory`.
 
 1. Confirm the broker is reachable: `hermes wax-memory doctor`
 2. Prefer `wax_recall` for assembled context and `wax_search` for raw hits
-3. Store durable facts with `wax_remember` and `memory_type` from `note`, `task_state`, `user_preference`, `decision`, `lesson`, `handoff`, `constraint`, `fact`
+3. Store durable facts with `wax_remember` and `memory_type` from `note`, `user_preference`, `decision`, `lesson`, `handoff`, `constraint`, `fact`; `task_state` is session-local working state and requires an active session
 4. Write session continuity with `wax_handoff`; do not dump raw transcripts
 5. Use structured tools (`wax_entity_upsert`, `wax_fact_assert`, `wax_facts_query`) only for stable knowledge-graph facts
 

--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -28,7 +28,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - When you learn something durable, call `remember` with concise factual text.
    - For session-scoped writes, pass `session_id` as a **top-level** argument.
    - Never put `session_id` inside `metadata`.
-   - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run; choose quarantine (default) or drop for orphaned records.
+   - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a complete distinct-store copy after a dry run; choose quarantine (default) or drop for orphaned records.
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
@@ -62,7 +62,7 @@ Response guidance:
 | Stable entities in a knowledge graph | `entity_upsert` / `entity_resolve` |
 | Structured facts that can be retracted later | `fact_assert` / `fact_retract` / `facts_query` |
 | Natural-language knowledge capture (when available) | `knowledge_capture` |
-| Repair legacy durable task state | `task_state_migrate` (distinct destination, dry-run first) |
+| Repair legacy durable task state | `task_state_migrate` (complete distinct-store copy, dry-run first) |
 
 Write quality rules:
 

--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -28,6 +28,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - When you learn something durable, call `remember` with concise factual text.
    - For session-scoped writes, pass `session_id` as a **top-level** argument.
    - Never put `session_id` inside `metadata`.
+   - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run; choose quarantine (default) or drop for orphaned records.
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
@@ -61,6 +62,7 @@ Response guidance:
 | Stable entities in a knowledge graph | `entity_upsert` / `entity_resolve` |
 | Structured facts that can be retracted later | `fact_assert` / `fact_retract` / `facts_query` |
 | Natural-language knowledge capture (when available) | `knowledge_capture` |
+| Repair legacy durable task state | `task_state_migrate` (distinct destination, dry-run first) |
 
 Write quality rules:
 

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -60,6 +60,7 @@ On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`
 
 Write as you go:
 - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).
+- `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct complete-store copy after a dry run.
 - Long-term: `remember` with `scope: durable` (no `session_id`), type `decision` / `lesson` / `constraint` / `user_preference` / `fact` (corrections, decisions, standing prefs, stable repo facts).
 
 Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -24,6 +24,7 @@ Workflow rules:
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
+- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
 Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -24,7 +24,7 @@ Workflow rules:
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
-- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
+- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
 Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -28,7 +28,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - When you learn something durable, call `remember` with concise factual text.
    - For session-scoped writes, pass `session_id` as a **top-level** argument.
    - Never put `session_id` inside `metadata`.
-   - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run; choose quarantine (default) or drop for orphaned records.
+   - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a complete distinct-store copy after a dry run; choose quarantine (default) or drop for orphaned records.
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
@@ -62,7 +62,7 @@ Response guidance:
 | Stable entities in a knowledge graph | `entity_upsert` / `entity_resolve` |
 | Structured facts that can be retracted later | `fact_assert` / `fact_retract` / `facts_query` |
 | Natural-language knowledge capture (when available) | `knowledge_capture` |
-| Repair legacy durable task state | `task_state_migrate` (distinct destination, dry-run first) |
+| Repair legacy durable task state | `task_state_migrate` (complete distinct-store copy, dry-run first) |
 
 Write quality rules:
 

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -28,6 +28,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - When you learn something durable, call `remember` with concise factual text.
    - For session-scoped writes, pass `session_id` as a **top-level** argument.
    - Never put `session_id` inside `metadata`.
+   - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run; choose quarantine (default) or drop for orphaned records.
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
@@ -61,6 +62,7 @@ Response guidance:
 | Stable entities in a knowledge graph | `entity_upsert` / `entity_resolve` |
 | Structured facts that can be retracted later | `fact_assert` / `fact_retract` / `facts_query` |
 | Natural-language knowledge capture (when available) | `knowledge_capture` |
+| Repair legacy durable task state | `task_state_migrate` (distinct destination, dry-run first) |
 
 Write quality rules:
 

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -60,6 +60,7 @@ On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`
 
 Write as you go:
 - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).
+- `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct complete-store copy after a dry run.
 - Long-term: `remember` with `scope: durable` (no `session_id`), type `decision` / `lesson` / `constraint` / `user_preference` / `fact` (corrections, decisions, standing prefs, stable repo facts).
 
 Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -24,6 +24,7 @@ Workflow rules:
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
+- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
 Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -24,7 +24,7 @@ Workflow rules:
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
-- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
+- `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
 Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 

--- a/Sources/Wax/Broker/AgentBrokerClient.swift
+++ b/Sources/Wax/Broker/AgentBrokerClient.swift
@@ -347,8 +347,12 @@ package enum AgentBrokerClient {
         }
 
         let payload = try JSONEncoder().encode(request)
-        try writeAll(fd, payload)
-        try writeAll(fd, Data([0x0A]))
+        do {
+            try writeAll(fd, payload)
+            try writeAll(fd, Data([0x0A]))
+        } catch let error as BrokerClientError where treatTimeoutAsUnavailable && error.isTransientDisconnect {
+            return nil
+        }
         shutdown(fd, socketShutdownWrite)
 
         guard let line = try readSocketResponseLine(
@@ -375,12 +379,18 @@ package enum AgentBrokerClient {
                 if count < 0 {
                     if errno == EINTR { continue }
                     if errno == EPIPE {
-                        throw BrokerClientError("Broker closed the connection while sending request")
+                        throw BrokerClientError(
+                            "Broker closed the connection while sending request",
+                            isTransientDisconnect: true
+                        )
                     }
                     throw BrokerClientError("Broker request write failed: \(String(cString: strerror(errno)))")
                 }
                 if count == 0 {
-                    throw BrokerClientError("Broker closed the connection while sending request")
+                    throw BrokerClientError(
+                        "Broker closed the connection while sending request",
+                        isTransientDisconnect: true
+                    )
                 }
                 sent += count
             }
@@ -468,9 +478,11 @@ package enum AgentBrokerClient {
 
 private struct BrokerClientError: LocalizedError {
     let message: String
+    let isTransientDisconnect: Bool
 
-    init(_ message: String) {
+    init(_ message: String, isTransientDisconnect: Bool = false) {
         self.message = message
+        self.isTransientDisconnect = isTransientDisconnect
     }
 
     var errorDescription: String? { message }

--- a/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
+++ b/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
@@ -74,8 +74,8 @@ package enum AgentBrokerCommandSurface {
         ]),
         Entry(canonicalName: "memory_health", acceptedArgumentKeys: []),
         Entry(canonicalName: "knowledge_capture", acceptedArgumentKeys: [
-            "content", "metadata", "memory_type", "durability", "project", "repo", "confidence", "reviewed",
-            "locked", "subject", "kind", "aliases", "predicate", "object", "cwd",
+            "content", "session_id", "scope", "metadata", "memory_type", "durability", "project", "repo",
+            "confidence", "reviewed", "locked", "subject", "kind", "aliases", "predicate", "object", "cwd",
         ], requiresStructuredMemory: true),
         Entry(canonicalName: "corpus_search", acceptedArgumentKeys: ["query", "rebuild", "recursive", "mode", "alpha", "topK"]),
         Entry(canonicalName: "stats", acceptedArgumentKeys: ["session_id", "verbosity"]),
@@ -89,6 +89,10 @@ package enum AgentBrokerCommandSurface {
         Entry(canonicalName: "compact_context", acceptedArgumentKeys: ["query", "session_id", "token_budget", "max_items", "mode", "alpha"]),
         Entry(canonicalName: "markdown_export", acceptedArgumentKeys: ["output_dir", "session_id", "project", "all_projects", "cwd"]),
         Entry(canonicalName: "markdown_sync", acceptedArgumentKeys: ["root_dir", "dry_run"]),
+        Entry(
+            canonicalName: "task_state_migrate",
+            acceptedArgumentKeys: ["destination_path", "dry_run", "orphan_policy", "overwrite_destination"]
+        ),
         Entry(canonicalName: "entity_upsert", acceptedArgumentKeys: ["key", "kind", "aliases"], requiresStructuredMemory: true),
         Entry(canonicalName: "fact_assert", acceptedArgumentKeys: ["subject", "predicate", "object", "relation", "valid_from", "valid_to", "evidence"], requiresStructuredMemory: true),
         Entry(canonicalName: "fact_retract", acceptedArgumentKeys: ["fact_id", "at_ms"], requiresStructuredMemory: true),

--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -216,7 +216,7 @@ extension AgentBrokerService {
             )
 
             if proposal.shouldWrite {
-                let normalized = approvedDreamMetadata(metadata: metadata, proposal: proposal)
+                let normalized = try approvedDreamMetadata(metadata: metadata, proposal: proposal)
                 try validateDurableWriteContent(content: entry.text, metadata: normalized)
                 counts.approvedDreams += 1
                 approvedFingerprints.insert(fingerprint)
@@ -250,7 +250,7 @@ extension AgentBrokerService {
     private func approvedDreamMetadata(
         metadata: [String: String],
         proposal: BrokerPromotionProposal
-    ) -> [String: String] {
+    ) throws -> [String: String] {
         let semantics = MemoryWriteSemantics(
             type: proposal.suggestedType,
             durability: proposal.suggestedDurability,
@@ -265,12 +265,21 @@ extension AgentBrokerService {
             inferredScope: scopeContext,
             nowMs: Self.nowMs()
         )
-        return MemorySemantics.approvedPromotionMetadata(
+        let approved = MemorySemantics.approvedPromotionMetadata(
             metadata: normalized,
             semantics: semantics,
             suggestedType: proposal.suggestedType,
             suggestedDurability: proposal.suggestedDurability,
             suggestedConfidence: proposal.confidence
+        )
+        return try MemorySemantics.validatedWriteMetadata(
+            metadata: approved,
+            semantics: semantics,
+            sessionID: nil,
+            scope: "durable",
+            activeSession: false,
+            inferredScope: scopeContext,
+            nowMs: Self.nowMs()
         )
     }
 
@@ -301,6 +310,18 @@ extension AgentBrokerService {
             }
             let existing = existingByMarker ?? existingByHash
             let semantics = semanticsForEntry(entry, existing)
+
+            // Validate before the unchanged fast path too: a legacy task_state
+            // diary must not remain silently accepted by Markdown sync.
+            _ = try MemorySemantics.validatedWriteMetadata(
+                metadata: existing?.metadata ?? [:],
+                semantics: semantics,
+                sessionID: nil,
+                scope: sourceKind == .memory ? "durable" : nil,
+                activeSession: false,
+                inferredScope: scopeContext,
+                nowMs: Self.nowMs()
+            )
 
             if let existing {
                 let existingInfo = MemorySemantics.parse(metadata: existing.metadata, nowMs: Self.nowMs())
@@ -436,7 +457,7 @@ extension AgentBrokerService {
         let beforeDocuments = try await longTermMemory.corpusSourceDocuments()
         let beforeIDs = Set(beforeDocuments.map { $0.frameId })
 
-        let normalized = managedDocumentMetadata(
+        let normalized = try managedDocumentMetadata(
             content: content,
             entry: entry,
             sourcePath: sourcePath,
@@ -487,7 +508,7 @@ extension AgentBrokerService {
         semantics: MemoryWriteSemantics,
         existing: MemoryOrchestrator.CorpusSourceDocument?
     ) throws {
-        let normalized = managedDocumentMetadata(
+        let normalized = try managedDocumentMetadata(
             content: content,
             entry: entry,
             sourcePath: sourcePath,
@@ -507,7 +528,7 @@ extension AgentBrokerService {
         dateKey: String?,
         semantics: MemoryWriteSemantics,
         existing: MemoryOrchestrator.CorpusSourceDocument?
-    ) -> [String: String] {
+    ) throws -> [String: String] {
         var baseMetadata = existing?.metadata ?? [:]
         baseMetadata[MemoryMetadataKeys.sourcePath] = sourcePath
         baseMetadata[MemoryMetadataKeys.sourceLine] = String(entry.lineNumber)
@@ -521,10 +542,12 @@ extension AgentBrokerService {
             baseMetadata[MemoryMetadataKeys.sourceMemoryID] = markerMemoryID
         }
 
-        return MemorySemantics.normalizeWriteMetadata(
+        return try MemorySemantics.validatedWriteMetadata(
             metadata: baseMetadata,
             semantics: semantics,
             sessionID: nil,
+            scope: sourceKind == .memory ? "durable" : nil,
+            activeSession: false,
             inferredScope: scopeContext,
             nowMs: Self.nowMs()
         )

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -243,6 +243,9 @@ package actor AgentBrokerService {
             case .markdownExport(let command):
                 payload = try await markdownExport(command)
                 shouldExit = false
+            case .taskStateMigrate(let command):
+                payload = try await taskStateMigrate(command)
+                shouldExit = false
             case .factsQuery(let command):
                 payload = try await factsQuery(command)
                 shouldExit = false
@@ -308,10 +311,12 @@ extension AgentBrokerService {
         if let sessionID {
             _ = try await memory(for: sessionID)
         }
-        let metadata = MemorySemantics.normalizeWriteMetadata(
+        let metadata = try MemorySemantics.validatedWriteMetadata(
             metadata: command.metadata,
             semantics: command.writeSemantics,
             sessionID: sessionID,
+            scope: command.writeScope?.rawValue,
+            activeSession: sessionID != nil,
             inferredScope: writeScope(for: sessionID, clientCWD: command.cwd),
             nowMs: Self.nowMs()
         )
@@ -787,6 +792,15 @@ extension AgentBrokerService {
                 suggestedDurability: proposal.suggestedDurability,
                 suggestedConfidence: proposal.confidence
             )
+            normalizedMetadata = try MemorySemantics.validatedWriteMetadata(
+                metadata: normalizedMetadata,
+                semantics: writeSemantics,
+                sessionID: nil,
+                scope: "durable",
+                activeSession: false,
+                inferredScope: writeScope(for: resolvedPromotionSessionID, clientCWD: command.cwd),
+                nowMs: Self.nowMs()
+            )
             try validateDurableWriteContent(content: content, metadata: normalizedMetadata)
             try await longTermMemory.remember(content, metadata: normalizedMetadata)
             try await longTermMemory.flush()
@@ -843,11 +857,16 @@ extension AgentBrokerService {
     }
 
     func knowledgeCapture(_ command: BrokerCommand.KnowledgeCapture) async throws -> AgentBrokerValue {
-        let metadata = MemorySemantics.normalizeWriteMetadata(
+        if let sessionID = command.sessionID {
+            _ = try await memory(for: sessionID)
+        }
+        let metadata = try MemorySemantics.validatedWriteMetadata(
             metadata: command.metadata,
             semantics: command.writeSemantics,
-            sessionID: nil,
-            inferredScope: writeScope(for: nil, clientCWD: command.cwd),
+            sessionID: command.sessionID,
+            scope: command.writeScope?.rawValue,
+            activeSession: command.sessionID != nil,
+            inferredScope: writeScope(for: command.sessionID, clientCWD: command.cwd),
             nowMs: Self.nowMs()
         )
         try validateDurableWriteContent(content: command.content, metadata: metadata)
@@ -858,7 +877,8 @@ extension AgentBrokerService {
         let aliases = command.aliases
         let parsedObject = try command.object.map { try parseFactValue($0) }
 
-        try await longTermMemory.remember(command.content, metadata: metadata)
+        let memory = try await memory(for: command.sessionID)
+        try await memory.remember(command.content, metadata: metadata)
 
         var entityID: Int64?
         if let subject {
@@ -892,7 +912,21 @@ extension AgentBrokerService {
             ).rawValue
         }
 
+        try await memory.flush()
         try await longTermMemory.flush()
+
+        if let sessionID = command.sessionID {
+            try await refreshSessionManifest(sessionID)
+            try await appendSessionEvent(
+                sessionID: sessionID,
+                kind: .remembered,
+                payload: [
+                    "content_hash": Self.stableHash(command.content),
+                    "memory_type": metadata[MemoryMetadataKeys.type] ?? MemoryType.note.rawValue,
+                    "durability": metadata[MemoryMetadataKeys.durability] ?? MemoryDurability.working.rawValue,
+                ]
+            )
+        }
 
         return .object([
             "status": .string("ok"),

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -142,6 +142,17 @@ package actor AgentBrokerService {
     }
 
     package func handle(_ request: AgentBrokerRequest) async -> AgentBrokerResponse {
+        if Self.isTaskStateMigrationRequest(request) {
+            // Migration snapshots and mutates a copy of the long-term store. It
+            // must hold both locks: remember intentionally uses its own mutex so
+            // deferred embedding waits do not block reads, but a migration must
+            // not race that writer while hashing or copying the source.
+            return await commandMutex.withLock { [self] in
+                await rememberMutex.withLock { [self] in
+                    await handleSerialized(request)
+                }
+            }
+        }
         let mutex = Self.isRememberRequest(request) ? rememberMutex : commandMutex
         return await mutex.withLock { [self] in
             await handleSerialized(request)
@@ -156,6 +167,19 @@ package actor AgentBrokerService {
             return false
         }
         if case .remember = command {
+            return true
+        }
+        return false
+    }
+
+    private static func isTaskStateMigrationRequest(_ request: AgentBrokerRequest) -> Bool {
+        guard let command = try? BrokerCommand.decode(
+            command: request.command,
+            arguments: request.arguments
+        ) else {
+            return false
+        }
+        if case .taskStateMigrate = command {
             return true
         }
         return false

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -901,8 +901,16 @@ extension AgentBrokerService {
         let aliases = command.aliases
         let parsedObject = try command.object.map { try parseFactValue($0) }
 
-        let memory = try await memory(for: command.sessionID)
-        try await memory.remember(command.content, metadata: metadata)
+        let isSessionTaskState =
+            metadata[MemoryMetadataKeys.type] == MemoryType.taskState.rawValue
+            && command.sessionID != nil
+        if isSessionTaskState, let sessionID = command.sessionID {
+            let sessionMemory = try await memory(for: sessionID)
+            try await sessionMemory.remember(command.content, metadata: metadata)
+            try await sessionMemory.flush()
+        } else {
+            try await longTermMemory.remember(command.content, metadata: metadata)
+        }
 
         var entityID: Int64?
         if let subject {
@@ -936,7 +944,6 @@ extension AgentBrokerService {
             ).rawValue
         }
 
-        try await memory.flush()
         try await longTermMemory.flush()
 
         if let sessionID = command.sessionID {

--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -30,6 +30,7 @@ package enum BrokerCommand: Sendable, Equatable {
     case sessionOpen(SessionOpen)
     case compactContext(CompactContext)
     case markdownExport(MarkdownExport)
+    case taskStateMigrate(TaskStateMigrate)
     case factsQuery(FactsQuery)
     case memoryPromote(MemoryPromote)
     case promote(MemoryPromote)
@@ -152,6 +153,8 @@ package enum BrokerCommand: Sendable, Equatable {
 
     package struct KnowledgeCapture: Sendable, Equatable {
         package var content: String
+        package var sessionID: UUID?
+        package var writeScope: RememberWriteScope?
         package var metadata: [String: String]
         package var writeSemantics: MemoryWriteSemantics
         package var cwd: String?
@@ -193,6 +196,13 @@ package enum BrokerCommand: Sendable, Equatable {
         package var project: String?
         package var allProjects: Bool
         package var cwd: String?
+    }
+
+    package struct TaskStateMigrate: Sendable, Equatable {
+        package var destinationPath: String
+        package var dryRun: Bool
+        package var orphanPolicy: TaskStateOrphanPolicy
+        package var overwriteDestination: Bool
     }
 
     package struct FactsQuery: Sendable, Equatable {
@@ -295,6 +305,8 @@ package enum BrokerCommand: Sendable, Equatable {
             return .compactContext(try CompactContext.decode(args))
         case "markdown_export":
             return .markdownExport(try MarkdownExport.decode(args))
+        case "task_state_migrate":
+            return .taskStateMigrate(try TaskStateMigrate.decode(args))
         case "facts_query":
             return .factsQuery(try FactsQuery.decode(args))
         case "memory_promote":
@@ -561,16 +573,36 @@ extension BrokerCommand.SessionSynthesize {
 
 extension BrokerCommand.KnowledgeCapture {
     package static func decode(_ args: BrokerArguments) throws -> Self {
+        let sessionID = try BrokerCommand.parseOptionalSessionID(args)
+        let writeScope = try BrokerCommand.parseRememberWriteScope(args)
+        if let writeScope {
+            switch writeScope {
+            case .session:
+                guard sessionID != nil else {
+                    throw BrokerValidationError.invalid("scope session requires session_id")
+                }
+            case .durable:
+                if sessionID != nil {
+                    throw BrokerValidationError.invalid("scope durable forbids session_id")
+                }
+            }
+        }
         var writeSemantics = try BrokerCommand.parseWriteSemantics(args)
-        if !writeSemantics.lock, writeSemantics.durability == nil {
+        if !writeSemantics.lock, writeSemantics.durability == nil, sessionID == nil {
             writeSemantics.durability = .durable
+        }
+        let metadata = try BrokerCommand.coerceMetadata(try args.optionalObject("metadata"))
+        if metadata["session_id"] != nil {
+            throw BrokerValidationError.invalid("metadata.session_id is reserved; use top-level session_id")
         }
         return Self(
             content: try args.requiredStringPreservingWhitespace(
                 "content",
                 maxBytes: BrokerLimits.maxContentBytes
             ),
-            metadata: try BrokerCommand.coerceMetadata(try args.optionalObject("metadata")),
+            sessionID: sessionID,
+            writeScope: writeScope,
+            metadata: metadata,
             writeSemantics: writeSemantics,
             cwd: try args.optionalString("cwd"),
             subject: try args.optionalString("subject"),
@@ -649,6 +681,23 @@ extension BrokerCommand.MarkdownExport {
             project: try args.optionalString("project"),
             allProjects: try args.optionalBool("all_projects") ?? false,
             cwd: try args.optionalString("cwd")
+        )
+    }
+}
+
+extension BrokerCommand.TaskStateMigrate {
+    package static func decode(_ args: BrokerArguments) throws -> Self {
+        let rawPolicy = try args.optionalString("orphan_policy") ?? TaskStateOrphanPolicy.quarantine.rawValue
+        guard let orphanPolicy = TaskStateOrphanPolicy(rawValue: rawPolicy.lowercased()) else {
+            throw BrokerValidationError.invalid(
+                "orphan_policy must be one of: \(TaskStateOrphanPolicy.allCases.map(\.rawValue).joined(separator: ", "))"
+            )
+        }
+        return Self(
+            destinationPath: try args.requiredString("destination_path", maxBytes: BrokerLimits.maxPathBytes),
+            dryRun: try args.optionalBool("dry_run") ?? false,
+            orphanPolicy: orphanPolicy,
+            overwriteDestination: try args.optionalBool("overwrite_destination") ?? false
         )
     }
 }

--- a/Sources/Wax/Broker/TaskStateMigration.swift
+++ b/Sources/Wax/Broker/TaskStateMigration.swift
@@ -1,0 +1,450 @@
+import Foundation
+import WaxCore
+
+/// Policy for task-state records that no longer have valid session provenance.
+package enum TaskStateOrphanPolicy: String, CaseIterable, Codable, Sendable, Equatable {
+    /// Preserve the text as working, non-task-state memory with an audit marker.
+    case quarantine
+    /// Omit the orphan record from the repaired destination.
+    case drop
+}
+
+/// Auditable result of a copy-first task-state repair.
+package struct TaskStateMigrationReport: Codable, Sendable, Equatable {
+    package var schemaVersion: Int
+    package var sourcePath: String
+    package var destinationPath: String
+    package var orphanPolicy: TaskStateOrphanPolicy
+    package var sourceHash: String
+    package var destinationHash: String?
+    package var sourcePreserved: Bool
+    package var verified: Bool
+    package var idempotent: Bool
+    package var sourceDocumentCount: Int
+    package var copiedDocumentCount: Int
+    package var rehomedDocumentCount: Int
+    package var quarantinedDocumentCount: Int
+    package var droppedDocumentCount: Int
+
+    package init(
+        schemaVersion: Int = 1,
+        sourcePath: String,
+        destinationPath: String,
+        orphanPolicy: TaskStateOrphanPolicy,
+        sourceHash: String,
+        destinationHash: String? = nil,
+        sourcePreserved: Bool = false,
+        verified: Bool = false,
+        idempotent: Bool = false,
+        sourceDocumentCount: Int,
+        copiedDocumentCount: Int,
+        rehomedDocumentCount: Int,
+        quarantinedDocumentCount: Int,
+        droppedDocumentCount: Int
+    ) {
+        self.schemaVersion = schemaVersion
+        self.sourcePath = sourcePath
+        self.destinationPath = destinationPath
+        self.orphanPolicy = orphanPolicy
+        self.sourceHash = sourceHash
+        self.destinationHash = destinationHash
+        self.sourcePreserved = sourcePreserved
+        self.verified = verified
+        self.idempotent = idempotent
+        self.sourceDocumentCount = sourceDocumentCount
+        self.copiedDocumentCount = copiedDocumentCount
+        self.rehomedDocumentCount = rehomedDocumentCount
+        self.quarantinedDocumentCount = quarantinedDocumentCount
+        self.droppedDocumentCount = droppedDocumentCount
+    }
+}
+
+package extension AgentBrokerService {
+    private static let taskStateMigrationSchema = "task_state_v1"
+    private static let taskStateMigrationManifestSuffix = ".task-state-migration.json"
+
+    /// Copy the live long-term document set into a distinct destination while
+    /// repairing task-state records. The source is flushed and hashed before
+    /// copying, and is never opened for write by this operation.
+    func taskStateMigrate(_ command: BrokerCommand.TaskStateMigrate) async throws -> AgentBrokerValue {
+        try await longTermMemory.flush()
+
+        let sourceURL = longTermStoreURL.standardizedFileURL
+        let destinationURL = URL(
+            fileURLWithPath: AgentBrokerPathing.expandPath(command.destinationPath)
+        ).standardizedFileURL
+        guard sourceURL != destinationURL else {
+            throw BrokerValidationError.invalid("task_state migration destination must differ from the source store")
+        }
+
+        let sourceHash = try Self.sha256File(at: sourceURL)
+        let manifestURL = Self.taskStateMigrationManifestURL(for: destinationURL)
+        let sourceDocuments = try await longTermMemory.corpusSourceDocuments()
+
+        if !command.dryRun,
+           let existing = try Self.loadTaskStateMigrationManifest(at: manifestURL),
+           existing.sourcePath == sourceURL.path,
+           existing.destinationPath == destinationURL.path,
+           existing.sourceHash == sourceHash,
+           existing.orphanPolicy == command.orphanPolicy,
+           FileManager.default.fileExists(atPath: destinationURL.path) {
+            let verified = try await Self.verifyTaskStateMigrationDestination(
+                at: destinationURL,
+                expectedDocumentCount: existing.copiedDocumentCount
+            )
+            guard verified else {
+                throw BrokerValidationError.invalid(
+                    "task_state migration manifest does not match a verified destination; pass overwrite_destination=true"
+                )
+            }
+            var idempotent = existing
+            idempotent.destinationHash = try Self.sha256File(at: destinationURL)
+            idempotent.sourcePreserved = try Self.sha256File(at: sourceURL) == sourceHash
+            idempotent.verified = true
+            idempotent.idempotent = true
+            return Self.taskStateMigrationPayload(idempotent)
+        }
+
+        let plan = try makeTaskStateMigrationPlan(
+            documents: sourceDocuments,
+            sourceHash: sourceHash,
+            destinationURL: destinationURL,
+            orphanPolicy: command.orphanPolicy
+        )
+        if command.dryRun {
+            var report = plan.report
+            // The source has not been opened for write during a dry run; the
+            // pre-copy hash therefore already proves source preservation.
+            report.sourcePreserved = true
+            return Self.taskStateMigrationPayload(report)
+        }
+
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            guard command.overwriteDestination else {
+                throw BrokerValidationError.invalid(
+                    "task_state migration destination already exists; pass overwrite_destination=true to replace it"
+                )
+            }
+        }
+
+        let buildURL = destinationURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(destinationURL.deletingPathExtension().lastPathComponent)-task-state-migration-\(UUID().uuidString)")
+            .appendingPathExtension("wax")
+        if fileManager.fileExists(atPath: buildURL.path) {
+            try fileManager.removeItem(at: buildURL)
+        }
+
+        var config = OrchestratorConfig.default
+        config.enableTextSearch = true
+        config.enableVectorSearch = false
+        config.enableStructuredMemory = false
+        config.enableAccessStatsScoring = false
+
+        let target = try await MemoryOrchestrator(at: buildURL, config: config)
+        do {
+            try await target.ingestCorpusDocumentsTextOnly(plan.documents)
+            try await target.flush()
+            try await target.close()
+        } catch {
+            try? await target.close()
+            try? fileManager.removeItem(at: buildURL)
+            throw error
+        }
+
+        let verifiedBuild: Bool
+        do {
+            verifiedBuild = try await Self.verifyTaskStateMigrationDestination(
+                at: buildURL,
+                expectedDocumentCount: plan.copiedDocumentCount
+            )
+        } catch {
+            try? fileManager.removeItem(at: buildURL)
+            throw error
+        }
+        guard verifiedBuild else {
+            try? fileManager.removeItem(at: buildURL)
+            throw BrokerValidationError.invalid("task_state migration destination failed deep verification")
+        }
+        guard try Self.sha256File(at: sourceURL) == sourceHash else {
+            try? fileManager.removeItem(at: buildURL)
+            throw BrokerValidationError.invalid("task_state migration source changed during copy")
+        }
+
+        do {
+            try Self.installTaskStateMigrationBuild(
+                buildURL,
+                at: destinationURL,
+                overwrite: command.overwriteDestination
+            )
+        } catch {
+            try? fileManager.removeItem(at: buildURL)
+            throw error
+        }
+
+        let destinationHash = try Self.sha256File(at: destinationURL)
+        let sourcePreserved = try Self.sha256File(at: sourceURL) == sourceHash
+        guard sourcePreserved else {
+            throw BrokerValidationError.invalid("task_state migration source changed during copy")
+        }
+
+        var report = plan.report
+        report.destinationHash = destinationHash
+        report.sourcePreserved = true
+        report.verified = true
+        report.idempotent = false
+        try Self.saveTaskStateMigrationManifest(report, at: manifestURL)
+        return Self.taskStateMigrationPayload(report)
+    }
+
+    private struct TaskStateMigrationPlan {
+        var report: TaskStateMigrationReport
+        var documents: [MemoryOrchestrator.CorpusTargetDocument]
+
+        var sourcePath: String { report.sourcePath }
+        var destinationPath: String { report.destinationPath }
+        var orphanPolicy: TaskStateOrphanPolicy { report.orphanPolicy }
+        var sourceHash: String { report.sourceHash }
+        var destinationHash: String? { report.destinationHash }
+        var sourcePreserved: Bool { report.sourcePreserved }
+        var verified: Bool { report.verified }
+        var idempotent: Bool { report.idempotent }
+        var sourceDocumentCount: Int { report.sourceDocumentCount }
+        var copiedDocumentCount: Int { report.copiedDocumentCount }
+        var rehomedDocumentCount: Int { report.rehomedDocumentCount }
+        var quarantinedDocumentCount: Int { report.quarantinedDocumentCount }
+        var droppedDocumentCount: Int { report.droppedDocumentCount }
+    }
+
+    private func makeTaskStateMigrationPlan(
+        documents: [MemoryOrchestrator.CorpusSourceDocument],
+        sourceHash: String,
+        destinationURL: URL,
+        orphanPolicy: TaskStateOrphanPolicy
+    ) throws -> TaskStateMigrationPlan {
+        var targets: [MemoryOrchestrator.CorpusTargetDocument] = []
+        targets.reserveCapacity(documents.count)
+        var rehomed = 0
+        var quarantined = 0
+        var dropped = 0
+
+        for document in documents {
+            let contentHash = Self.sha256Text(document.text)
+            let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
+            let provenance = taskStateSessionID(in: document.metadata)
+            let hasTaskState = info.type == .taskState
+            let validSession = if let provenance {
+                validSessionProvenance(provenance)
+            } else {
+                false
+            }
+
+            var metadata = document.metadata
+            metadata[MemoryMetadataKeys.migrationSchema] = Self.taskStateMigrationSchema
+            metadata[MemoryMetadataKeys.migrationSourceFrameID] = String(document.frameId)
+            metadata[MemoryMetadataKeys.migrationSourceContentHash] = contentHash
+            metadata[MemoryMetadataKeys.migrationSourceStoreHash] = sourceHash
+
+            if hasTaskState {
+                if validSession, let provenance {
+                    metadata[MemoryMetadataKeys.type] = MemoryType.taskState.rawValue
+                    metadata[MemoryMetadataKeys.durability] = MemoryDurability.working.rawValue
+                    metadata["session_id"] = provenance.uuidString
+                    metadata[MemoryMetadataKeys.migrationAction] = "rehome"
+                    rehomed += 1
+                } else {
+                    switch orphanPolicy {
+                    case .drop:
+                        dropped += 1
+                        continue
+                    case .quarantine:
+                        metadata[MemoryMetadataKeys.migrationAction] = "quarantine"
+                        metadata[MemoryMetadataKeys.migrationOriginalMemoryType] = info.type.rawValue
+                        if let provenance {
+                            metadata[MemoryMetadataKeys.migrationOriginalSessionID] = provenance.uuidString
+                        } else if let rawSessionID = document.metadata["session_id"] {
+                            metadata[MemoryMetadataKeys.migrationOriginalSessionID] = rawSessionID
+                        }
+                        metadata.removeValue(forKey: "session_id")
+                        metadata.removeValue(forKey: MemoryMetadataKeys.promotedFromSession)
+                        metadata[MemoryMetadataKeys.type] = MemoryType.note.rawValue
+                        metadata[MemoryMetadataKeys.durability] = MemoryDurability.working.rawValue
+                        quarantined += 1
+                    }
+                }
+            } else {
+                metadata[MemoryMetadataKeys.migrationAction] = "copy"
+            }
+
+            targets.append(
+                MemoryOrchestrator.CorpusTargetDocument(
+                    timestampMs: document.timestampMs,
+                    text: document.text,
+                    metadata: metadata
+                )
+            )
+        }
+
+        let report = TaskStateMigrationReport(
+            sourcePath: longTermStoreURL.path,
+            destinationPath: destinationURL.path,
+            orphanPolicy: orphanPolicy,
+            sourceHash: sourceHash,
+            sourceDocumentCount: documents.count,
+            copiedDocumentCount: targets.count,
+            rehomedDocumentCount: rehomed,
+            quarantinedDocumentCount: quarantined,
+            droppedDocumentCount: dropped
+        )
+        return TaskStateMigrationPlan(report: report, documents: targets)
+    }
+
+    private func validSessionProvenance(_ sessionID: UUID) -> Bool {
+        guard let manifest = try? BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRootURL,
+            sessionID: sessionID
+        ), manifest.sessionID == sessionID,
+        manifest.status == .active || manifest.status == .ended else {
+            return false
+        }
+        let storeURL = URL(fileURLWithPath: AgentBrokerPathing.expandPath(manifest.storePath))
+        return FileManager.default.fileExists(atPath: storeURL.path)
+    }
+
+    private func taskStateSessionID(in metadata: [String: String]) -> UUID? {
+        for raw in [metadata["session_id"], metadata[MemoryMetadataKeys.promotedFromSession]].compactMap({ $0 }) {
+            if let sessionID = UUID(uuidString: raw) {
+                return sessionID
+            }
+        }
+        return nil
+    }
+}
+
+private extension AgentBrokerService {
+    static func taskStateMigrationManifestURL(for destinationURL: URL) -> URL {
+        URL(fileURLWithPath: destinationURL.path + taskStateMigrationManifestSuffix)
+    }
+
+    static func loadTaskStateMigrationManifest(at url: URL) throws -> TaskStateMigrationReport? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try JSONDecoder().decode(TaskStateMigrationReport.self, from: Data(contentsOf: url))
+    }
+
+    static func saveTaskStateMigrationManifest(_ report: TaskStateMigrationReport, at url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(report).write(to: url, options: .atomic)
+    }
+
+    static func sha256Text(_ text: String) -> String {
+        SHA256Checksum.digest(Data(text.utf8)).hexString
+    }
+
+    static func sha256File(at url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var checksum = SHA256Checksum()
+        while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+            checksum.update(data)
+        }
+        return checksum.finalize().hexString
+    }
+
+    static func verifyTaskStateMigrationDestination(
+        at url: URL,
+        expectedDocumentCount: Int
+    ) async throws -> Bool {
+        var config = OrchestratorConfig.default
+        config.enableTextSearch = true
+        config.enableVectorSearch = false
+        config.enableStructuredMemory = false
+        config.enableAccessStatsScoring = false
+        let memory = try await MemoryOrchestrator(at: url, config: config)
+        do {
+            try await memory.wax.verify(deep: true)
+            let documents = try await memory.corpusSourceDocuments()
+            var valid = documents.count == expectedDocumentCount
+            var sourceFrameIDs = Set<String>()
+            for document in documents {
+                let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
+                if info.type == .taskState,
+                   !(info.durability == .working && UUID(uuidString: document.metadata["session_id"] ?? "") != nil) {
+                    valid = false
+                }
+                let hasMigrationSchema = document.metadata[MemoryMetadataKeys.migrationSchema] == taskStateMigrationSchema
+                let hasContentHash = document.metadata[MemoryMetadataKeys.migrationSourceContentHash] == sha256Text(document.text)
+                let hasUniqueFrameID: Bool
+                if let sourceFrameID = document.metadata[MemoryMetadataKeys.migrationSourceFrameID] {
+                    hasUniqueFrameID = sourceFrameIDs.insert(sourceFrameID).inserted
+                } else {
+                    hasUniqueFrameID = false
+                }
+                if !(hasMigrationSchema && hasContentHash && hasUniqueFrameID) {
+                    valid = false
+                }
+            }
+            try await memory.close()
+            return valid
+        } catch {
+            try? await memory.close()
+            throw error
+        }
+    }
+
+    static func installTaskStateMigrationBuild(
+        _ buildURL: URL,
+        at destinationURL: URL,
+        overwrite: Bool
+    ) throws {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: destinationURL.path) else {
+            try fileManager.moveItem(at: buildURL, to: destinationURL)
+            return
+        }
+        guard overwrite else {
+            throw BrokerValidationError.invalid("task_state migration destination already exists")
+        }
+        let backupURL = destinationURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(destinationURL.lastPathComponent)-backup-\(UUID().uuidString)")
+        try fileManager.moveItem(at: destinationURL, to: backupURL)
+        do {
+            try fileManager.moveItem(at: buildURL, to: destinationURL)
+            try? fileManager.removeItem(at: backupURL)
+        } catch {
+            if !fileManager.fileExists(atPath: destinationURL.path) {
+                try? fileManager.moveItem(at: backupURL, to: destinationURL)
+            }
+            throw error
+        }
+    }
+
+    static func taskStateMigrationPayload(_ report: TaskStateMigrationReport) -> AgentBrokerValue {
+        .object([
+            "status": .string("ok"),
+            "schema_version": .from(report.schemaVersion),
+            "source_path": .string(report.sourcePath),
+            "destination_path": .string(report.destinationPath),
+            "orphan_policy": .string(report.orphanPolicy.rawValue),
+            "source_hash": .string(report.sourceHash),
+            "destination_hash": .from(report.destinationHash),
+            "source_preserved": .bool(report.sourcePreserved),
+            "verified": .bool(report.verified),
+            "idempotent": .bool(report.idempotent),
+            "source_document_count": .from(report.sourceDocumentCount),
+            "copied_document_count": .from(report.copiedDocumentCount),
+            "rehomed_document_count": .from(report.rehomedDocumentCount),
+            "quarantined_document_count": .from(report.quarantinedDocumentCount),
+            "dropped_document_count": .from(report.droppedDocumentCount),
+            "display_text": .string(
+                "Task-state migration \(report.idempotent ? "already applied" : report.verified ? "verified" : "planned"): " +
+                    "\(report.rehomedDocumentCount) rehomed, \(report.quarantinedDocumentCount) quarantined, " +
+                    "\(report.droppedDocumentCount) dropped."
+            ),
+        ])
+    }
+}

--- a/Sources/Wax/Broker/TaskStateMigration.swift
+++ b/Sources/Wax/Broker/TaskStateMigration.swift
@@ -9,6 +9,31 @@ package enum TaskStateOrphanPolicy: String, CaseIterable, Codable, Sendable, Equ
     case drop
 }
 
+package enum TaskStateMigrationAction: String, Codable, Sendable, Equatable {
+    case rehome
+    case quarantine
+    case drop
+}
+
+package struct TaskStateMigrationEntry: Codable, Sendable, Equatable {
+    package var sourceFrameID: UInt64
+    package var sourceContentHash: String
+    package var action: TaskStateMigrationAction
+    package var destinationFrameID: UInt64?
+
+    package init(
+        sourceFrameID: UInt64,
+        sourceContentHash: String,
+        action: TaskStateMigrationAction,
+        destinationFrameID: UInt64? = nil
+    ) {
+        self.sourceFrameID = sourceFrameID
+        self.sourceContentHash = sourceContentHash
+        self.action = action
+        self.destinationFrameID = destinationFrameID
+    }
+}
+
 /// Auditable result of a copy-first task-state repair.
 package struct TaskStateMigrationReport: Codable, Sendable, Equatable {
     package var schemaVersion: Int
@@ -25,9 +50,15 @@ package struct TaskStateMigrationReport: Codable, Sendable, Equatable {
     package var rehomedDocumentCount: Int
     package var quarantinedDocumentCount: Int
     package var droppedDocumentCount: Int
+    package var sourceFrameCount: Int
+    package var destinationFrameCount: Int?
+    package var preservedFrameHash: String
+    package var sourceVectorIndexPresent: Bool
+    package var destinationVectorIndexPresent: Bool?
+    package var entries: [TaskStateMigrationEntry]
 
     package init(
-        schemaVersion: Int = 1,
+        schemaVersion: Int = 2,
         sourcePath: String,
         destinationPath: String,
         orphanPolicy: TaskStateOrphanPolicy,
@@ -40,7 +71,13 @@ package struct TaskStateMigrationReport: Codable, Sendable, Equatable {
         copiedDocumentCount: Int,
         rehomedDocumentCount: Int,
         quarantinedDocumentCount: Int,
-        droppedDocumentCount: Int
+        droppedDocumentCount: Int,
+        sourceFrameCount: Int = 0,
+        destinationFrameCount: Int? = nil,
+        preservedFrameHash: String = "",
+        sourceVectorIndexPresent: Bool = false,
+        destinationVectorIndexPresent: Bool? = nil,
+        entries: [TaskStateMigrationEntry] = []
     ) {
         self.schemaVersion = schemaVersion
         self.sourcePath = sourcePath
@@ -56,41 +93,118 @@ package struct TaskStateMigrationReport: Codable, Sendable, Equatable {
         self.rehomedDocumentCount = rehomedDocumentCount
         self.quarantinedDocumentCount = quarantinedDocumentCount
         self.droppedDocumentCount = droppedDocumentCount
+        self.sourceFrameCount = sourceFrameCount
+        self.destinationFrameCount = destinationFrameCount
+        self.preservedFrameHash = preservedFrameHash
+        self.sourceVectorIndexPresent = sourceVectorIndexPresent
+        self.destinationVectorIndexPresent = destinationVectorIndexPresent
+        self.entries = entries
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case sourcePath
+        case destinationPath
+        case orphanPolicy
+        case sourceHash
+        case destinationHash
+        case sourcePreserved
+        case verified
+        case idempotent
+        case sourceDocumentCount
+        case copiedDocumentCount
+        case rehomedDocumentCount
+        case quarantinedDocumentCount
+        case droppedDocumentCount
+        case sourceFrameCount
+        case destinationFrameCount
+        case preservedFrameHash
+        case sourceVectorIndexPresent
+        case destinationVectorIndexPresent
+        case entries
+    }
+
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+        sourcePath = try container.decode(String.self, forKey: .sourcePath)
+        destinationPath = try container.decode(String.self, forKey: .destinationPath)
+        orphanPolicy = try container.decode(TaskStateOrphanPolicy.self, forKey: .orphanPolicy)
+        sourceHash = try container.decode(String.self, forKey: .sourceHash)
+        destinationHash = try container.decodeIfPresent(String.self, forKey: .destinationHash)
+        sourcePreserved = try container.decodeIfPresent(Bool.self, forKey: .sourcePreserved) ?? false
+        verified = try container.decodeIfPresent(Bool.self, forKey: .verified) ?? false
+        idempotent = try container.decodeIfPresent(Bool.self, forKey: .idempotent) ?? false
+        sourceDocumentCount = try container.decodeIfPresent(Int.self, forKey: .sourceDocumentCount) ?? 0
+        copiedDocumentCount = try container.decodeIfPresent(Int.self, forKey: .copiedDocumentCount) ?? 0
+        rehomedDocumentCount = try container.decodeIfPresent(Int.self, forKey: .rehomedDocumentCount) ?? 0
+        quarantinedDocumentCount = try container.decodeIfPresent(Int.self, forKey: .quarantinedDocumentCount) ?? 0
+        droppedDocumentCount = try container.decodeIfPresent(Int.self, forKey: .droppedDocumentCount) ?? 0
+        sourceFrameCount = try container.decodeIfPresent(Int.self, forKey: .sourceFrameCount) ?? 0
+        destinationFrameCount = try container.decodeIfPresent(Int.self, forKey: .destinationFrameCount)
+        preservedFrameHash = try container.decodeIfPresent(String.self, forKey: .preservedFrameHash) ?? ""
+        sourceVectorIndexPresent = try container.decodeIfPresent(Bool.self, forKey: .sourceVectorIndexPresent) ?? false
+        destinationVectorIndexPresent = try container.decodeIfPresent(Bool.self, forKey: .destinationVectorIndexPresent)
+        entries = try container.decodeIfPresent([TaskStateMigrationEntry].self, forKey: .entries) ?? []
     }
 }
 
 package extension AgentBrokerService {
-    private static let taskStateMigrationSchema = "task_state_v1"
+    private static let taskStateMigrationSchema = "task_state_v2"
+    private static let taskStateMigrationSchemaVersion = 2
     private static let taskStateMigrationManifestSuffix = ".task-state-migration.json"
 
-    /// Copy the live long-term document set into a distinct destination while
-    /// repairing task-state records. The source is flushed and hashed before
-    /// copying, and is never opened for write by this operation.
+    /// Copy the complete long-term store into a distinct destination while repairing
+    /// task-state records in the copy. The source is flushed and hashed before the
+    /// copy, and is never opened for write by this operation.
     func taskStateMigrate(_ command: BrokerCommand.TaskStateMigrate) async throws -> AgentBrokerValue {
         try await longTermMemory.flush()
 
-        let sourceURL = longTermStoreURL.standardizedFileURL
-        let destinationURL = URL(
-            fileURLWithPath: AgentBrokerPathing.expandPath(command.destinationPath)
-        ).standardizedFileURL
-        guard sourceURL != destinationURL else {
-            throw BrokerValidationError.invalid("task_state migration destination must differ from the source store")
-        }
-
+        let sourceURL = try Self.validatedSourceStoreURL(longTermStoreURL)
+        let destinationURL = try Self.validatedMigrationDestinationURL(
+            URL(fileURLWithPath: AgentBrokerPathing.expandPath(command.destinationPath)),
+            sourceURL: sourceURL
+        )
+        let fileManager = FileManager.default
         let sourceHash = try Self.sha256File(at: sourceURL)
         let manifestURL = Self.taskStateMigrationManifestURL(for: destinationURL)
+        let sourceFrameMetas = await longTermMemory.wax.frameMetas()
         let sourceDocuments = try await longTermMemory.corpusSourceDocuments()
+        let sourceVectorIndexPresent = await longTermMemory.wax.committedVecIndexManifest() != nil
+        let affectedSourceFrameIDs = Self.taskStateAffectedFrameIDs(
+            documents: sourceDocuments,
+            frameMetas: sourceFrameMetas
+        )
+        let preservedFrameHash = try await Self.frameStateDigest(
+            wax: longTermMemory.wax,
+            frameMetas: sourceFrameMetas,
+            excluding: affectedSourceFrameIDs
+        )
+        let plan = try makeTaskStateMigrationPlan(
+            documents: sourceDocuments,
+            frameMetas: sourceFrameMetas,
+            sourceURL: sourceURL,
+            destinationURL: destinationURL,
+            sourceHash: sourceHash,
+            preservedFrameHash: preservedFrameHash,
+            sourceVectorIndexPresent: sourceVectorIndexPresent,
+            orphanPolicy: command.orphanPolicy
+        )
 
         if !command.dryRun,
-           let existing = try Self.loadTaskStateMigrationManifest(at: manifestURL),
+           let existing = try? Self.loadTaskStateMigrationManifest(at: manifestURL),
+           existing.schemaVersion == Self.taskStateMigrationSchemaVersion,
            existing.sourcePath == sourceURL.path,
            existing.destinationPath == destinationURL.path,
            existing.sourceHash == sourceHash,
            existing.orphanPolicy == command.orphanPolicy,
-           FileManager.default.fileExists(atPath: destinationURL.path) {
-            let verified = try await Self.verifyTaskStateMigrationDestination(
+           existing.preservedFrameHash == preservedFrameHash,
+           fileManager.fileExists(atPath: destinationURL.path) {
+            let verified = try await verifyTaskStateMigrationDestination(
                 at: destinationURL,
-                expectedDocumentCount: existing.copiedDocumentCount
+                report: existing,
+                sourceFrameMetas: sourceFrameMetas,
+                sourceAffectedFrameIDs: affectedSourceFrameIDs
             )
             guard verified else {
                 throw BrokerValidationError.invalid(
@@ -98,209 +212,314 @@ package extension AgentBrokerService {
                 )
             }
             var idempotent = existing
+            // Re-opening a Wax file may legitimately refresh its recovery
+            // header, so destinationHash is informational. Deep frame/index
+            // verification below detects actual data changes without treating
+            // a header-only rewrite as tampering.
             idempotent.destinationHash = try Self.sha256File(at: destinationURL)
             idempotent.sourcePreserved = try Self.sha256File(at: sourceURL) == sourceHash
-            idempotent.verified = true
-            idempotent.idempotent = true
+            idempotent.verified = idempotent.sourcePreserved
+            idempotent.idempotent = idempotent.sourcePreserved
+            guard idempotent.sourcePreserved else {
+                throw BrokerValidationError.invalid("task_state migration source changed after its manifest")
+            }
+            try Self.saveTaskStateMigrationManifest(idempotent, at: manifestURL)
             return Self.taskStateMigrationPayload(idempotent)
         }
 
-        let plan = try makeTaskStateMigrationPlan(
-            documents: sourceDocuments,
-            sourceHash: sourceHash,
-            destinationURL: destinationURL,
-            orphanPolicy: command.orphanPolicy
-        )
         if command.dryRun {
             var report = plan.report
-            // The source has not been opened for write during a dry run; the
-            // pre-copy hash therefore already proves source preservation.
             report.sourcePreserved = true
             return Self.taskStateMigrationPayload(report)
         }
 
-        let fileManager = FileManager.default
-        try fileManager.createDirectory(
-            at: destinationURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        if fileManager.fileExists(atPath: destinationURL.path) {
-            guard command.overwriteDestination else {
+        if plan.hasStoreMutations, sourceVectorIndexPresent {
+            let sourceRuntime = await longTermMemory.runtimeStats()
+            guard sourceRuntime.vectorSearchEnabled, sourceRuntime.queryEmbedderReady else {
                 throw BrokerValidationError.invalid(
-                    "task_state migration destination already exists; pass overwrite_destination=true to replace it"
+                    "task_state migration would alter a vector-indexed store, but its matching embedder is unavailable"
                 )
             }
         }
 
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.validateDestinationSlot(
+            at: destinationURL,
+            sourceURL: sourceURL,
+            overwrite: command.overwriteDestination
+        )
+
         let buildURL = destinationURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(destinationURL.deletingPathExtension().lastPathComponent)-task-state-migration-\(UUID().uuidString)")
+            .appendingPathComponent(
+                ".\(destinationURL.deletingPathExtension().lastPathComponent)-task-state-migration-\(UUID().uuidString)"
+            )
             .appendingPathExtension("wax")
         if fileManager.fileExists(atPath: buildURL.path) {
             try fileManager.removeItem(at: buildURL)
         }
 
-        var config = OrchestratorConfig.default
-        config.enableTextSearch = true
-        config.enableVectorSearch = false
-        config.enableStructuredMemory = false
-        config.enableAccessStatsScoring = false
-
-        let target = try await MemoryOrchestrator(at: buildURL, config: config)
         do {
-            try await target.ingestCorpusDocumentsTextOnly(plan.documents)
-            try await target.flush()
-            try await target.close()
-        } catch {
-            try? await target.close()
-            try? fileManager.removeItem(at: buildURL)
-            throw error
-        }
+            // The raw file copy retains every frame, structured record, and committed
+            // text/vector index. Only the task-state trees listed in the plan change.
+            try fileManager.copyItem(at: sourceURL, to: buildURL)
+            var report = plan.report
+            let target = try await openTaskStateMigrationMemory(at: buildURL)
+            do {
+                let targetRuntime = await target.runtimeStats()
+                if plan.hasStoreMutations, sourceVectorIndexPresent {
+                    guard targetRuntime.vectorSearchEnabled, targetRuntime.queryEmbedderReady else {
+                        throw BrokerValidationError.invalid(
+                            "task_state migration could not open the matching embedder for vector preservation"
+                        )
+                    }
+                }
 
-        let verifiedBuild: Bool
-        do {
-            verifiedBuild = try await Self.verifyTaskStateMigrationDestination(
+                for (index, operation) in plan.operations.enumerated() {
+                    switch operation.action {
+                    case .drop:
+                        try await deleteTaskStateTree(
+                            operation.sourceTreeFrameIDs,
+                            from: target
+                        )
+                    case .rehome, .quarantine:
+                        guard let metadata = operation.replacementMetadata else {
+                            throw BrokerValidationError.invalid("task_state migration produced an incomplete replacement plan")
+                        }
+                        let replacement = try await target.remember(
+                            operation.source.text,
+                            metadata: metadata
+                        )
+                        report.entries[index].destinationFrameID = replacement.frameId
+                        try await deleteTaskStateTree(
+                            operation.sourceTreeFrameIDs,
+                            from: target
+                        )
+                    }
+                }
+                try await target.flush()
+                try await target.close()
+            } catch {
+                try? await target.close()
+                throw error
+            }
+
+            let verifiedBuild = try await verifyTaskStateMigrationDestination(
                 at: buildURL,
-                expectedDocumentCount: plan.copiedDocumentCount
+                report: report,
+                sourceFrameMetas: sourceFrameMetas,
+                sourceAffectedFrameIDs: affectedSourceFrameIDs
             )
-        } catch {
-            try? fileManager.removeItem(at: buildURL)
-            throw error
-        }
-        guard verifiedBuild else {
-            try? fileManager.removeItem(at: buildURL)
-            throw BrokerValidationError.invalid("task_state migration destination failed deep verification")
-        }
-        guard try Self.sha256File(at: sourceURL) == sourceHash else {
-            try? fileManager.removeItem(at: buildURL)
-            throw BrokerValidationError.invalid("task_state migration source changed during copy")
-        }
+            guard verifiedBuild else {
+                throw BrokerValidationError.invalid("task_state migration destination failed deep verification")
+            }
+            report.destinationFrameCount = try await Self.frameCount(at: buildURL)
+            report.destinationVectorIndexPresent = try await Self.vectorIndexPresent(at: buildURL)
+            guard try Self.sha256File(at: sourceURL) == sourceHash else {
+                throw BrokerValidationError.invalid("task_state migration source changed during copy")
+            }
 
-        do {
-            try Self.installTaskStateMigrationBuild(
+            let backupURL = try Self.installTaskStateMigrationBuild(
                 buildURL,
                 at: destinationURL,
+                sourceURL: sourceURL,
                 overwrite: command.overwriteDestination
             )
+            do {
+                let verifiedInstalled = try await verifyTaskStateMigrationDestination(
+                    at: destinationURL,
+                    report: report,
+                    sourceFrameMetas: sourceFrameMetas,
+                    sourceAffectedFrameIDs: affectedSourceFrameIDs
+                )
+                guard verifiedInstalled else {
+                    throw BrokerValidationError.invalid(
+                        "task_state migration destination failed post-install verification"
+                    )
+                }
+                guard try Self.sha256File(at: sourceURL) == sourceHash else {
+                    throw BrokerValidationError.invalid("task_state migration source changed during install")
+                }
+                if let backupURL {
+                    // Keep the rollback copy until the installed destination has
+                    // passed deep verification and the source hash is rechecked.
+                    try? fileManager.removeItem(at: backupURL)
+                }
+            } catch {
+                try? fileManager.removeItem(at: destinationURL)
+                if let backupURL, fileManager.fileExists(atPath: backupURL.path) {
+                    try? fileManager.moveItem(at: backupURL, to: destinationURL)
+                }
+                throw error
+            }
+
+            report.destinationHash = try Self.sha256File(at: destinationURL)
+            report.sourcePreserved = try Self.sha256File(at: sourceURL) == sourceHash
+            guard report.sourcePreserved else {
+                throw BrokerValidationError.invalid("task_state migration source changed during copy")
+            }
+            report.verified = true
+            report.idempotent = false
+            try Self.saveTaskStateMigrationManifest(report, at: manifestURL)
+            return Self.taskStateMigrationPayload(report)
         } catch {
             try? fileManager.removeItem(at: buildURL)
             throw error
         }
+    }
 
-        let destinationHash = try Self.sha256File(at: destinationURL)
-        let sourcePreserved = try Self.sha256File(at: sourceURL) == sourceHash
-        guard sourcePreserved else {
-            throw BrokerValidationError.invalid("task_state migration source changed during copy")
-        }
-
-        var report = plan.report
-        report.destinationHash = destinationHash
-        report.sourcePreserved = true
-        report.verified = true
-        report.idempotent = false
-        try Self.saveTaskStateMigrationManifest(report, at: manifestURL)
-        return Self.taskStateMigrationPayload(report)
+    private struct TaskStateMigrationOperation {
+        var source: MemoryOrchestrator.CorpusSourceDocument
+        var action: TaskStateMigrationAction
+        var replacementMetadata: [String: String]?
+        var sourceContentHash: String
+        var sourceTreeFrameIDs: [UInt64]
     }
 
     private struct TaskStateMigrationPlan {
         var report: TaskStateMigrationReport
-        var documents: [MemoryOrchestrator.CorpusTargetDocument]
+        var operations: [TaskStateMigrationOperation]
 
-        var sourcePath: String { report.sourcePath }
-        var destinationPath: String { report.destinationPath }
-        var orphanPolicy: TaskStateOrphanPolicy { report.orphanPolicy }
-        var sourceHash: String { report.sourceHash }
-        var destinationHash: String? { report.destinationHash }
-        var sourcePreserved: Bool { report.sourcePreserved }
-        var verified: Bool { report.verified }
-        var idempotent: Bool { report.idempotent }
-        var sourceDocumentCount: Int { report.sourceDocumentCount }
-        var copiedDocumentCount: Int { report.copiedDocumentCount }
-        var rehomedDocumentCount: Int { report.rehomedDocumentCount }
-        var quarantinedDocumentCount: Int { report.quarantinedDocumentCount }
-        var droppedDocumentCount: Int { report.droppedDocumentCount }
+        var hasStoreMutations: Bool { !operations.isEmpty }
     }
 
     private func makeTaskStateMigrationPlan(
         documents: [MemoryOrchestrator.CorpusSourceDocument],
-        sourceHash: String,
+        frameMetas: [FrameMeta],
+        sourceURL: URL,
         destinationURL: URL,
+        sourceHash: String,
+        preservedFrameHash: String,
+        sourceVectorIndexPresent: Bool,
         orphanPolicy: TaskStateOrphanPolicy
     ) throws -> TaskStateMigrationPlan {
-        var targets: [MemoryOrchestrator.CorpusTargetDocument] = []
-        targets.reserveCapacity(documents.count)
+        let taskStateDocuments = documents.filter {
+            MemorySemantics.parse(metadata: $0.metadata, nowMs: Self.nowMs()).type == .taskState
+        }
+        var operations: [TaskStateMigrationOperation] = []
+        operations.reserveCapacity(taskStateDocuments.count)
+        var entries: [TaskStateMigrationEntry] = []
+        entries.reserveCapacity(taskStateDocuments.count)
         var rehomed = 0
         var quarantined = 0
         var dropped = 0
 
-        for document in documents {
+        for document in taskStateDocuments {
             let contentHash = Self.sha256Text(document.text)
             let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
             let provenance = taskStateSessionID(in: document.metadata)
-            let hasTaskState = info.type == .taskState
             let validSession = if let provenance {
                 validSessionProvenance(provenance)
             } else {
                 false
             }
+            let action: TaskStateMigrationAction
+            var replacementMetadata: [String: String]?
 
-            var metadata = document.metadata
-            metadata[MemoryMetadataKeys.migrationSchema] = Self.taskStateMigrationSchema
-            metadata[MemoryMetadataKeys.migrationSourceFrameID] = String(document.frameId)
-            metadata[MemoryMetadataKeys.migrationSourceContentHash] = contentHash
-            metadata[MemoryMetadataKeys.migrationSourceStoreHash] = sourceHash
-
-            if hasTaskState {
-                if validSession, let provenance {
-                    metadata[MemoryMetadataKeys.type] = MemoryType.taskState.rawValue
-                    metadata[MemoryMetadataKeys.durability] = MemoryDurability.working.rawValue
-                    metadata["session_id"] = provenance.uuidString
-                    metadata[MemoryMetadataKeys.migrationAction] = "rehome"
-                    rehomed += 1
-                } else {
-                    switch orphanPolicy {
-                    case .drop:
-                        dropped += 1
-                        continue
-                    case .quarantine:
-                        metadata[MemoryMetadataKeys.migrationAction] = "quarantine"
-                        metadata[MemoryMetadataKeys.migrationOriginalMemoryType] = info.type.rawValue
-                        if let provenance {
-                            metadata[MemoryMetadataKeys.migrationOriginalSessionID] = provenance.uuidString
-                        } else if let rawSessionID = document.metadata["session_id"] {
-                            metadata[MemoryMetadataKeys.migrationOriginalSessionID] = rawSessionID
-                        }
-                        metadata.removeValue(forKey: "session_id")
-                        metadata.removeValue(forKey: MemoryMetadataKeys.promotedFromSession)
-                        metadata[MemoryMetadataKeys.type] = MemoryType.note.rawValue
-                        metadata[MemoryMetadataKeys.durability] = MemoryDurability.working.rawValue
-                        quarantined += 1
-                    }
-                }
+            if validSession, let provenance {
+                action = .rehome
+                var metadata = document.metadata
+                metadata[MemoryMetadataKeys.migrationSchema] = Self.taskStateMigrationSchema
+                metadata[MemoryMetadataKeys.migrationSourceFrameID] = String(document.frameId)
+                metadata[MemoryMetadataKeys.migrationSourceContentHash] = contentHash
+                metadata[MemoryMetadataKeys.migrationSourceStoreHash] = sourceHash
+                metadata[MemoryMetadataKeys.migrationAction] = action.rawValue
+                metadata[MemoryMetadataKeys.type] = MemoryType.taskState.rawValue
+                metadata[MemoryMetadataKeys.durability] = MemoryDurability.working.rawValue
+                metadata["session_id"] = provenance.uuidString
+                replacementMetadata = metadata
+                rehomed += 1
             } else {
-                metadata[MemoryMetadataKeys.migrationAction] = "copy"
+                action = orphanPolicy == .drop ? .drop : .quarantine
+                switch action {
+                case .drop:
+                    dropped += 1
+                case .quarantine:
+                    var metadata = document.metadata
+                    metadata[MemoryMetadataKeys.migrationSchema] = Self.taskStateMigrationSchema
+                    metadata[MemoryMetadataKeys.migrationSourceFrameID] = String(document.frameId)
+                    metadata[MemoryMetadataKeys.migrationSourceContentHash] = contentHash
+                    metadata[MemoryMetadataKeys.migrationSourceStoreHash] = sourceHash
+                    metadata[MemoryMetadataKeys.migrationAction] = action.rawValue
+                    metadata[MemoryMetadataKeys.migrationOriginalMemoryType] = info.type.rawValue
+                    if let provenance {
+                        metadata[MemoryMetadataKeys.migrationOriginalSessionID] = provenance.uuidString
+                    } else if let rawSessionID = document.metadata["session_id"] {
+                        metadata[MemoryMetadataKeys.migrationOriginalSessionID] = rawSessionID
+                    }
+                    metadata.removeValue(forKey: "session_id")
+                    metadata.removeValue(forKey: MemoryMetadataKeys.promotedFromSession)
+                    metadata[MemoryMetadataKeys.type] = MemoryType.note.rawValue
+                    metadata[MemoryMetadataKeys.durability] = MemoryDurability.working.rawValue
+                    replacementMetadata = metadata
+                    quarantined += 1
+                case .rehome:
+                    throw BrokerValidationError.invalid("task_state migration produced an invalid orphan action")
+                }
             }
 
-            targets.append(
-                MemoryOrchestrator.CorpusTargetDocument(
-                    timestampMs: document.timestampMs,
-                    text: document.text,
-                    metadata: metadata
+            entries.append(
+                TaskStateMigrationEntry(
+                    sourceFrameID: document.frameId,
+                    sourceContentHash: contentHash,
+                    action: action
+                )
+            )
+            operations.append(
+                TaskStateMigrationOperation(
+                    source: document,
+                    action: action,
+                    replacementMetadata: replacementMetadata,
+                    sourceContentHash: contentHash,
+                    sourceTreeFrameIDs: Self.taskStateTreeFrameIDs(
+                        rootFrameID: document.frameId,
+                        frameMetas: frameMetas
+                    )
                 )
             )
         }
 
         let report = TaskStateMigrationReport(
-            sourcePath: longTermStoreURL.path,
+            sourcePath: sourceURL.path,
             destinationPath: destinationURL.path,
             orphanPolicy: orphanPolicy,
             sourceHash: sourceHash,
             sourceDocumentCount: documents.count,
-            copiedDocumentCount: targets.count,
+            copiedDocumentCount: documents.count - dropped,
             rehomedDocumentCount: rehomed,
             quarantinedDocumentCount: quarantined,
-            droppedDocumentCount: dropped
+            droppedDocumentCount: dropped,
+            sourceFrameCount: frameMetas.count,
+            preservedFrameHash: preservedFrameHash,
+            sourceVectorIndexPresent: sourceVectorIndexPresent,
+            entries: entries
         )
-        return TaskStateMigrationPlan(report: report, documents: targets)
+        return TaskStateMigrationPlan(report: report, operations: operations)
+    }
+
+    private func openTaskStateMigrationMemory(at url: URL) async throws -> MemoryOrchestrator {
+        var config = longTermMemory.config
+        config.enableAsyncEnrichment = false
+        config.liveSetRewriteSchedule = .disabled
+        return try await EmbeddingReadinessBinding.openOrchestrator(
+            at: url,
+            config: config,
+            request: embeddingRequest,
+            waxOptions: CommandLineEmbedderFactory.waxOptions(),
+            readiness: readiness,
+            factoryOverride: factoryOverride
+        )
+    }
+
+    private func deleteTaskStateTree(
+        _ frameIDs: [UInt64],
+        from memory: MemoryOrchestrator
+    ) async throws {
+        for frameID in frameIDs.sorted(by: >) {
+            try await memory.delete(frameId: frameID)
+        }
     }
 
     private func validSessionProvenance(_ sessionID: UUID) -> Bool {
@@ -341,11 +560,123 @@ private extension AgentBrokerService {
         try encoder.encode(report).write(to: url, options: .atomic)
     }
 
+    static func validatedSourceStoreURL(_ sourceURL: URL) throws -> URL {
+        let standardized = sourceURL.standardizedFileURL
+        guard fileType(at: standardized) == .typeRegular else {
+            throw BrokerValidationError.invalid("task_state migration source store must be a regular file")
+        }
+        return canonicalURL(standardized)
+    }
+
+    static func validatedMigrationDestinationURL(_ rawURL: URL, sourceURL: URL) throws -> URL {
+        let standardized = rawURL.standardizedFileURL
+        let parent = standardized.deletingLastPathComponent()
+        guard !hasSymlinkComponent(in: parent) else {
+            throw BrokerValidationError.invalid(
+                "task_state migration destination must not use a symlinked parent path"
+            )
+        }
+        let canonical = canonicalURL(standardized)
+        guard canonical != sourceURL else {
+            throw BrokerValidationError.invalid("task_state migration destination must differ from the source store")
+        }
+        if let destinationType = fileType(at: standardized) {
+            guard destinationType == .typeRegular else {
+                throw BrokerValidationError.invalid(
+                    "task_state migration destination must be a regular file, not a directory, symlink, or special file"
+                )
+            }
+            guard !sameFileIdentity(standardized, sourceURL) else {
+                throw BrokerValidationError.invalid("task_state migration destination must not alias the source store")
+            }
+        }
+        return canonical
+    }
+
+    static func validateDestinationSlot(
+        at destinationURL: URL,
+        sourceURL: URL,
+        overwrite: Bool
+    ) throws {
+        guard !sameFileIdentityIfPresent(destinationURL, sourceURL) else {
+            throw BrokerValidationError.invalid("task_state migration destination must not alias the source store")
+        }
+        guard let destinationType = fileType(at: destinationURL) else { return }
+        guard destinationType == .typeRegular else {
+            throw BrokerValidationError.invalid(
+                "task_state migration destination must be a regular file, not a directory, symlink, or special file"
+            )
+        }
+        guard overwrite else {
+            throw BrokerValidationError.invalid(
+                "task_state migration destination already exists; pass overwrite_destination=true to replace it"
+            )
+        }
+    }
+
+    static func fileType(at url: URL) -> FileAttributeType? {
+        (try? FileManager.default.attributesOfItem(atPath: url.path))?[.type] as? FileAttributeType
+    }
+
+    static func sameFileIdentityIfPresent(_ lhs: URL, _ rhs: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: lhs.path),
+              fileType(at: lhs) == .typeRegular,
+              fileType(at: rhs) == .typeRegular else {
+            return false
+        }
+        return sameFileIdentity(lhs, rhs)
+    }
+
+    static func sameFileIdentity(_ lhs: URL, _ rhs: URL) -> Bool {
+        guard let left = fileIdentity(at: lhs), let right = fileIdentity(at: rhs) else {
+            return false
+        }
+        return left.device == right.device && left.inode == right.inode
+    }
+
+    static func fileIdentity(at url: URL) -> (device: UInt64, inode: UInt64)? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+            return nil
+        }
+        let device = (attributes[.systemNumber] as? NSNumber)?.uint64Value
+        let inode = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+        guard let device, let inode else { return nil }
+        return (device: device, inode: inode)
+    }
+
+    static func hasSymlinkComponent(in url: URL) -> Bool {
+        var current = url.standardizedFileURL
+        while true {
+            // macOS exposes /tmp and /var as stable system aliases. They do
+            // not let a caller redirect a destination into an arbitrary tree;
+            // nested symlink components remain rejected below.
+            let isStableSystemAlias = current.path == "/tmp" || current.path == "/var"
+            if !isStableSystemAlias, fileType(at: current) == .typeSymbolicLink {
+                return true
+            }
+            if current.path == "/" {
+                return false
+            }
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                return false
+            }
+            current = parent
+        }
+    }
+
+    static func canonicalURL(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
     static func sha256Text(_ text: String) -> String {
         SHA256Checksum.digest(Data(text.utf8)).hexString
     }
 
     static func sha256File(at url: URL) throws -> String {
+        guard fileType(at: url) == .typeRegular else {
+            throw BrokerValidationError.invalid("cannot hash a non-regular migration store")
+        }
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         var checksum = SHA256Checksum()
@@ -355,41 +686,241 @@ private extension AgentBrokerService {
         return checksum.finalize().hexString
     }
 
-    static func verifyTaskStateMigrationDestination(
-        at url: URL,
-        expectedDocumentCount: Int
-    ) async throws -> Bool {
+    static func taskStateAffectedFrameIDs(
+        documents: [MemoryOrchestrator.CorpusSourceDocument],
+        frameMetas: [FrameMeta]
+    ) -> Set<UInt64> {
+        taskStateAffectedFrameIDs(
+            roots: Set(documents.filter {
+                MemorySemantics.parse(metadata: $0.metadata, nowMs: Self.nowMs()).type == .taskState
+            }.map(\.frameId)),
+            frameMetas: frameMetas
+        )
+    }
+
+    static func taskStateAffectedFrameIDs(
+        roots: Set<UInt64>,
+        frameMetas: [FrameMeta]
+    ) -> Set<UInt64> {
+        var affected = roots
+        var changed = true
+        while changed {
+            changed = false
+            for frame in frameMetas where !affected.contains(frame.id) {
+                if let parentID = frame.parentId, affected.contains(parentID) {
+                    affected.insert(frame.id)
+                    changed = true
+                }
+            }
+        }
+        return affected
+    }
+
+    static func taskStateTreeFrameIDs(
+        rootFrameID: UInt64,
+        frameMetas: [FrameMeta]
+    ) -> [UInt64] {
+        Array(taskStateAffectedFrameIDs(roots: [rootFrameID], frameMetas: frameMetas)).sorted(by: >)
+    }
+
+    static func frameStateDigest(
+        wax: Wax,
+        frameMetas: [FrameMeta],
+        excluding excludedIDs: Set<UInt64>
+    ) async throws -> String {
+        var checksum = SHA256Checksum()
+        for frame in frameMetas.sorted(by: { $0.id < $1.id }) where !excludedIDs.contains(frame.id) {
+            checksum.update(Data(frameFingerprint(frame).utf8))
+            checksum.update(try await wax.frameContent(frameId: frame.id))
+        }
+        return checksum.finalize().hexString
+    }
+
+    static func frameFingerprint(_ frame: FrameMeta) -> String {
+        let metadata = (frame.metadata?.entries ?? [:])
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: "&")
+        let tags = frame.tags.map { "\($0.key)=\($0.value)" }.joined(separator: "&")
+        let checksum = frame.checksum.map { String(format: "%02x", $0) }.joined()
+        let storedChecksum = frame.storedChecksum?.map { String(format: "%02x", $0) }.joined() ?? ""
+        let fields: [String] = [
+            String(frame.id), String(frame.timestamp), String(describing: frame.anchorTs), frame.kind ?? "",
+            frame.track ?? "", frame.uri ?? "", frame.title ?? "", String(frame.canonicalEncoding.rawValue),
+            String(describing: frame.canonicalLength), checksum, storedChecksum, frame.searchText ?? "",
+            tags, frame.labels.joined(separator: "&"), frame.contentDates.joined(separator: "&"),
+            String(frame.role.rawValue), String(describing: frame.parentId), String(describing: frame.chunkIndex),
+            String(describing: frame.chunkCount), frame.chunkManifest?.base64EncodedString() ?? "",
+            String(frame.status.rawValue), String(describing: frame.supersedes), String(describing: frame.supersededBy),
+            metadata, "\n",
+        ]
+        return fields.joined(separator: "|")
+    }
+
+    static func frameCount(at url: URL) async throws -> Int {
+        let memory = try await MemoryOrchestrator(at: url, config: migrationVerificationConfig())
+        do {
+            let count = await memory.wax.frameMetas().count
+            try await memory.close()
+            return count
+        } catch {
+            try? await memory.close()
+            throw error
+        }
+    }
+
+    static func vectorIndexPresent(at url: URL) async throws -> Bool {
+        let memory = try await MemoryOrchestrator(at: url, config: migrationVerificationConfig())
+        do {
+            let present = await memory.wax.committedVecIndexManifest() != nil
+            try await memory.close()
+            return present
+        } catch {
+            try? await memory.close()
+            throw error
+        }
+    }
+
+    static func migrationVerificationConfig() -> OrchestratorConfig {
         var config = OrchestratorConfig.default
         config.enableTextSearch = true
         config.enableVectorSearch = false
-        config.enableStructuredMemory = false
+        config.enableStructuredMemory = true
         config.enableAccessStatsScoring = false
-        let memory = try await MemoryOrchestrator(at: url, config: config)
+        config.liveSetRewriteSchedule = .disabled
+        return config
+    }
+
+    func verifyTaskStateMigrationDestination(
+        at url: URL,
+        report: TaskStateMigrationReport,
+        sourceFrameMetas: [FrameMeta],
+        sourceAffectedFrameIDs: Set<UInt64>
+    ) async throws -> Bool {
+        let memory = try await openTaskStateMigrationMemory(at: url)
         do {
             try await memory.wax.verify(deep: true)
             let documents = try await memory.corpusSourceDocuments()
-            var valid = documents.count == expectedDocumentCount
-            var sourceFrameIDs = Set<String>()
-            for document in documents {
-                let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Int64(Date().timeIntervalSince1970 * 1000))
-                if info.type == .taskState,
-                   !(info.durability == .working && UUID(uuidString: document.metadata["session_id"] ?? "") != nil) {
-                    valid = false
+            guard documents.count == report.copiedDocumentCount else {
+                try await memory.close()
+                return false
+            }
+            let documentBySourceID: [String: MemoryOrchestrator.CorpusSourceDocument] = Dictionary(
+                uniqueKeysWithValues: documents.compactMap { document in
+                    guard let sourceID = document.metadata[MemoryMetadataKeys.migrationSourceFrameID] else {
+                        return nil
+                    }
+                    return (sourceID, document)
                 }
-                let hasMigrationSchema = document.metadata[MemoryMetadataKeys.migrationSchema] == taskStateMigrationSchema
-                let hasContentHash = document.metadata[MemoryMetadataKeys.migrationSourceContentHash] == sha256Text(document.text)
-                let hasUniqueFrameID: Bool
-                if let sourceFrameID = document.metadata[MemoryMetadataKeys.migrationSourceFrameID] {
-                    hasUniqueFrameID = sourceFrameIDs.insert(sourceFrameID).inserted
-                } else {
-                    hasUniqueFrameID = false
+            )
+            var seenSourceIDs = Set<UInt64>()
+            for entry in report.entries {
+                guard seenSourceIDs.insert(entry.sourceFrameID).inserted else {
+                    try await memory.close()
+                    return false
                 }
-                if !(hasMigrationSchema && hasContentHash && hasUniqueFrameID) {
-                    valid = false
+                if let document = documentBySourceID[String(entry.sourceFrameID)] {
+                    let metadata = document.metadata
+                    guard metadata[MemoryMetadataKeys.migrationSchema] == Self.taskStateMigrationSchema,
+                          metadata[MemoryMetadataKeys.migrationSourceStoreHash] == report.sourceHash,
+                          metadata[MemoryMetadataKeys.migrationSourceContentHash] == entry.sourceContentHash,
+                          metadata[MemoryMetadataKeys.migrationAction] == entry.action.rawValue,
+                          Self.sha256Text(document.text) == entry.sourceContentHash,
+                          entry.destinationFrameID == document.frameId else {
+                        try await memory.close()
+                        return false
+                    }
+                    let info = MemorySemantics.parse(metadata: metadata, nowMs: Self.nowMs())
+                    switch entry.action {
+                    case .rehome:
+                        guard info.type == MemoryType.taskState,
+                              info.durability == MemoryDurability.working,
+                              UUID(uuidString: metadata["session_id"] ?? "") != nil else {
+                            try await memory.close()
+                            return false
+                        }
+                    case .quarantine:
+                        guard info.type == MemoryType.note,
+                              info.durability == MemoryDurability.working,
+                              metadata["session_id"] == nil,
+                              metadata[MemoryMetadataKeys.promotedFromSession] == nil else {
+                            try await memory.close()
+                            return false
+                        }
+                    case .drop:
+                        try await memory.close()
+                        return false
+                    }
+                } else if entry.action != .drop {
+                    try await memory.close()
+                    return false
                 }
             }
+            guard documents.allSatisfy({ document in
+                let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
+                return info.type != .taskState || (
+                    info.durability == .working && UUID(uuidString: document.metadata["session_id"] ?? "") != nil
+                )
+            }) else {
+                try await memory.close()
+                return false
+            }
+
+            let destinationFrameMetas = await memory.wax.frameMetas()
+            let sourceIDs = Set(sourceFrameMetas.map(\.id))
+            let replacementRootIDs = Set(report.entries.compactMap(\.destinationFrameID))
+            for frame in destinationFrameMetas where !sourceIDs.contains(frame.id) {
+                guard var parentID = frame.parentId else {
+                    guard replacementRootIDs.contains(frame.id) else {
+                        try await memory.close()
+                        return false
+                    }
+                    continue
+                }
+                var visited = Set<UInt64>()
+                while !sourceIDs.contains(parentID) {
+                    guard visited.insert(parentID).inserted,
+                          let parent = destinationFrameMetas.first(where: { $0.id == parentID }),
+                          let next = parent.parentId else {
+                        break
+                    }
+                    parentID = next
+                }
+                guard replacementRootIDs.contains(parentID) else {
+                    try await memory.close()
+                    return false
+                }
+            }
+
+            for sourceFrame in sourceFrameMetas where !sourceAffectedFrameIDs.contains(sourceFrame.id) {
+                guard let destinationFrame = destinationFrameMetas.first(where: { $0.id == sourceFrame.id }),
+                      Self.frameFingerprint(destinationFrame) == Self.frameFingerprint(sourceFrame) else {
+                    try await memory.close()
+                    return false
+                }
+                let sourceContent = try await longTermMemory.wax.frameContent(frameId: sourceFrame.id)
+                let destinationContent = try await memory.wax.frameContent(frameId: destinationFrame.id)
+                guard sourceContent == destinationContent else {
+                    try await memory.close()
+                    return false
+                }
+            }
+            let preservedHash = try await Self.frameStateDigest(
+                wax: longTermMemory.wax,
+                frameMetas: sourceFrameMetas,
+                excluding: sourceAffectedFrameIDs
+            )
+            guard preservedHash == report.preservedFrameHash else {
+                try await memory.close()
+                return false
+            }
+            let destinationVectorIndexPresent = await memory.wax.committedVecIndexManifest() != nil
+            guard report.destinationVectorIndexPresent == nil || report.destinationVectorIndexPresent == destinationVectorIndexPresent else {
+                try await memory.close()
+                return false
+            }
             try await memory.close()
-            return valid
+            return true
         } catch {
             try? await memory.close()
             throw error
@@ -399,28 +930,58 @@ private extension AgentBrokerService {
     static func installTaskStateMigrationBuild(
         _ buildURL: URL,
         at destinationURL: URL,
+        sourceURL: URL,
         overwrite: Bool
-    ) throws {
+    ) throws -> URL? {
         let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: destinationURL.path) else {
-            try fileManager.moveItem(at: buildURL, to: destinationURL)
-            return
+        guard fileType(at: buildURL) == .typeRegular,
+              !sameFileIdentityIfPresent(buildURL, sourceURL),
+              !hasSymlinkComponent(in: buildURL.deletingLastPathComponent()) else {
+            throw BrokerValidationError.invalid("task_state migration build must be a distinct regular file in a non-symlinked directory")
         }
-        guard overwrite else {
-            throw BrokerValidationError.invalid("task_state migration destination already exists")
+        // Re-probe immediately before the rename/backup sequence to close the
+        // preflight TOCTOU window. A path that changed into a symlink, directory,
+        // special file, or source alias is never overwritten.
+        guard !hasSymlinkComponent(in: destinationURL.deletingLastPathComponent()) else {
+            throw BrokerValidationError.invalid("task_state migration destination must not use a symlinked parent path")
         }
-        let backupURL = destinationURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(destinationURL.lastPathComponent)-backup-\(UUID().uuidString)")
-        try fileManager.moveItem(at: destinationURL, to: backupURL)
-        do {
-            try fileManager.moveItem(at: buildURL, to: destinationURL)
-            try? fileManager.removeItem(at: backupURL)
-        } catch {
-            if !fileManager.fileExists(atPath: destinationURL.path) {
-                try? fileManager.moveItem(at: backupURL, to: destinationURL)
+        // Capture one final lstat-style probe and use that result for the
+        // backup decision. A second path lookup after this point could race a
+        // replacement and accidentally treat a source hard-link as disposable.
+        let destinationType = fileType(at: destinationURL)
+        if let destinationType {
+            guard destinationType == .typeRegular else {
+                throw BrokerValidationError.invalid(
+                    "task_state migration destination must be a regular file, not a directory, symlink, or special file"
+                )
             }
-            throw error
+            guard !sameFileIdentityIfPresent(destinationURL, sourceURL) else {
+                throw BrokerValidationError.invalid("task_state migration destination must not alias the source store")
+            }
+            guard try StoreLockProbe.tryExclusiveAccess(at: destinationURL) else {
+                throw BrokerValidationError.invalid("task_state migration destination is locked by another process")
+            }
+            guard overwrite else {
+                throw BrokerValidationError.invalid("task_state migration destination must be an existing regular file when overwriting")
+            }
+            let backupURL = destinationURL.deletingLastPathComponent()
+                .appendingPathComponent(".\(destinationURL.lastPathComponent)-backup-\(UUID().uuidString)")
+            guard fileType(at: backupURL) == nil else {
+                throw BrokerValidationError.invalid("task_state migration backup path unexpectedly exists")
+            }
+            try fileManager.moveItem(at: destinationURL, to: backupURL)
+            do {
+                try fileManager.moveItem(at: buildURL, to: destinationURL)
+                return backupURL
+            } catch {
+                if fileManager.fileExists(atPath: backupURL.path), !fileManager.fileExists(atPath: destinationURL.path) {
+                    try? fileManager.moveItem(at: backupURL, to: destinationURL)
+                }
+                throw error
+            }
         }
+        try fileManager.moveItem(at: buildURL, to: destinationURL)
+        return nil
     }
 
     static func taskStateMigrationPayload(_ report: TaskStateMigrationReport) -> AgentBrokerValue {
@@ -440,6 +1001,11 @@ private extension AgentBrokerService {
             "rehomed_document_count": .from(report.rehomedDocumentCount),
             "quarantined_document_count": .from(report.quarantinedDocumentCount),
             "dropped_document_count": .from(report.droppedDocumentCount),
+            "source_frame_count": .from(report.sourceFrameCount),
+            "destination_frame_count": .from(report.destinationFrameCount),
+            "preserved_frame_hash": .string(report.preservedFrameHash),
+            "source_vector_index_present": .bool(report.sourceVectorIndexPresent),
+            "destination_vector_index_present": .from(report.destinationVectorIndexPresent),
             "display_text": .string(
                 "Task-state migration \(report.idempotent ? "already applied" : report.verified ? "verified" : "planned"): " +
                     "\(report.rehomedDocumentCount) rehomed, \(report.quarantinedDocumentCount) quarantined, " +

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -459,9 +459,13 @@ package enum MemorySemantics {
     }
 
     package static func classifyCandidate(text: String, metadata: [String: String]) -> MemoryType {
+        // Implicit `note` is the default stamp for unclassified session writes.
+        // Treat it like `task_state`: ignore the stored type so text cues such as
+        // "Decision:" can still promote. Explicit types stay trusted.
         if let raw = metadata[MemoryMetadataKeys.type],
            let typed = MemoryType(rawValue: raw),
-           typed != .taskState {
+           typed != .taskState,
+           typed != .note {
             return typed
         }
         let lower = text.lowercased()

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -99,6 +99,15 @@ package enum MemoryMetadataKeys {
     package static let sourceDate = "wax.source_date"
     package static let sourceMemoryID = "wax.source_memory_id"
     package static let sourceManaged = "wax.source_managed"
+    // Copy-first migration provenance. These keys are intentionally namespaced so
+    // a repaired store can be audited without changing source frame identities.
+    package static let migrationSchema = "wax.migration.schema"
+    package static let migrationAction = "wax.migration.action"
+    package static let migrationSourceFrameID = "wax.migration.source_frame_id"
+    package static let migrationSourceContentHash = "wax.migration.source_content_hash"
+    package static let migrationSourceStoreHash = "wax.migration.source_store_hash"
+    package static let migrationOriginalSessionID = "wax.migration.original_session_id"
+    package static let migrationOriginalMemoryType = "wax.migration.original_memory_type"
 }
 
 package enum SecretHeuristics {
@@ -200,6 +209,76 @@ package enum MemorySemantics {
             normalized[MemoryMetadataKeys.expiresAtMs] = String(expiresAtMs)
         }
         return normalized
+    }
+
+    /// Validates the broker write contract and returns normalized metadata.
+    ///
+    /// `task_state` is session-local state. It must never be written without a
+    /// live virtual session and it cannot be promoted into the durable horizon.
+    /// A session task-state write is always represented as `working`; an omitted
+    /// or legacy `ephemeral` durability is upgraded, while an explicit durable
+    /// or locked request is rejected so callers cannot silently lose intent.
+    package static func validatedWriteMetadata(
+        metadata: [String: String],
+        semantics: MemoryWriteSemantics,
+        sessionID: UUID?,
+        scope: String?,
+        activeSession: Bool,
+        inferredScope: MemoryScopeContext?,
+        nowMs: Int64
+    ) throws -> [String: String] {
+        let metadataType = metadata[MemoryMetadataKeys.type].flatMap(MemoryType.init(rawValue:))
+        let resolvedType = semantics.type ?? metadataType ?? defaultMemoryType(
+            sessionID: sessionID,
+            existing: metadata
+        )
+        let metadataDurability = metadata[MemoryMetadataKeys.durability]
+            .flatMap(MemoryDurability.init(rawValue:))
+        let requestedDurability = semantics.lock
+            ? MemoryDurability.locked
+            : semantics.durability ?? metadataDurability
+
+        guard resolvedType == .taskState else {
+            return normalizeWriteMetadata(
+                metadata: metadata,
+                semantics: semantics,
+                sessionID: sessionID,
+                inferredScope: inferredScope,
+                nowMs: nowMs
+            )
+        }
+
+        guard activeSession, let sessionID else {
+            throw BrokerValidationError.invalid(
+                "task_state requires an active session_id; durable task diaries are not supported"
+            )
+        }
+        if scope?.lowercased() == "durable" {
+            throw BrokerValidationError.invalid(
+                "task_state cannot use scope durable; use scope session with an active session_id"
+            )
+        }
+        if semantics.lock ||
+            requestedDurability == .durable ||
+            requestedDurability == .locked ||
+            metadataDurability == .durable ||
+            metadataDurability == .locked {
+            throw BrokerValidationError.invalid(
+                "task_state cannot use durability durable or locked; use working session memory"
+            )
+        }
+
+        var sessionSemantics = semantics
+        sessionSemantics.type = .taskState
+        sessionSemantics.durability = .working
+        sessionSemantics.lock = false
+        return normalizeWriteMetadata(
+            metadata: metadata,
+            semantics: sessionSemantics,
+            sessionID: sessionID,
+            inferredScope: inferredScope,
+            nowMs: nowMs
+        )
     }
 
     package static func approvedPromotionMetadata(

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -527,13 +527,12 @@ package enum MemorySemantics {
         }
     }
 
-    private static func defaultMemoryType(sessionID: UUID?, existing metadata: [String: String]) -> MemoryType {
+    private static func defaultMemoryType(sessionID _: UUID?, existing metadata: [String: String]) -> MemoryType {
         if let raw = metadata[MemoryMetadataKeys.type], let typed = MemoryType(rawValue: raw) {
             return typed
         }
-        if sessionID != nil || metadata["session_id"] != nil {
-            return .taskState
-        }
+        // Session presence does not imply task_state. Ordinary session notes stay
+        // notes so the task_state safety contract applies only when requested.
         return .note
     }
 

--- a/Sources/WaxCLI/BrokerForwardingCommands.swift
+++ b/Sources/WaxCLI/BrokerForwardingCommands.swift
@@ -286,7 +286,82 @@ struct TaskStateMigrateCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(commandName: "task-state-migrate", abstract: "Copy and repair legacy durable task-state memory")
     @OptionGroup var store: VectorStoreOptions
     @OptionGroup var forwarded: BrokerForwardOptions
+
+    @Option(
+        name: .customLong("destination-path"),
+        help: "Distinct destination .wax path for the repaired copy"
+    )
+    var destinationPath: String?
+
+    @Option(
+        name: .customLong("orphan-policy"),
+        help: "Orphan handling policy: quarantine (default) or drop"
+    )
+    var orphanPolicy: String?
+
+    @Flag(name: .customLong("dry-run"), help: "Report the migration without creating a destination")
+    var dryRun = false
+
+    @Flag(
+        name: .customLong("overwrite-destination"),
+        help: "Replace an existing destination only when its migration manifest does not match"
+    )
+    var overwriteDestination = false
+
     func runAsync() async throws {
-        try await runBrokerForwardedCommand("task_state_migrate", store: store, forwarded: forwarded)
+        var arguments = try forwarded.values()
+        if let destinationPath {
+            arguments["destination_path"] = .string(destinationPath)
+        }
+        if dryRun {
+            arguments["dry_run"] = .bool(true)
+        }
+        if let orphanPolicy {
+            arguments["orphan_policy"] = .string(orphanPolicy)
+        }
+        if overwriteDestination {
+            arguments["overwrite_destination"] = .bool(true)
+        }
+        guard arguments["destination_path"]?.stringValue != nil else {
+            throw CLIError("--destination-path is required")
+        }
+
+        let response: AgentBrokerResponse
+        if store.directStore {
+            response = try await performDirectTaskStateMigration(arguments: arguments)
+        } else {
+            response = try await AgentBrokerCLI.perform(
+                command: "task_state_migrate",
+                arguments: arguments,
+                storePath: store.storePath,
+                embedderChoice: store.embedder.rawValue,
+                noEmbedder: store.noEmbedder,
+                requireVector: store.requireVector,
+                embedderTuning: store.embedderTuning
+            )
+        }
+        printBrokerResponse(response, format: store.format)
+    }
+
+    private func performDirectTaskStateMigration(
+        arguments: [String: AgentBrokerValue]
+    ) async throws -> AgentBrokerResponse {
+        let expandedStorePath = AgentBrokerPathing.expandPath(store.storePath)
+        let service = try await AgentBrokerService(
+            storePath: expandedStorePath,
+            sessionRootPath: AgentBrokerPathing.resolveSessionRootPath(storePath: expandedStorePath),
+            noEmbedder: store.noEmbedder,
+            embedderChoice: store.embedder.rawValue,
+            requireVector: store.requireVector,
+            embedderTuning: store.embedderTuning
+        )
+        let response = await service.handle(
+            AgentBrokerRequest(command: "task_state_migrate", arguments: arguments)
+        )
+        try await service.close()
+        guard response.ok else {
+            throw CLIError(response.error ?? "Broker command failed")
+        }
+        return response
     }
 }

--- a/Sources/WaxCLI/BrokerForwardingCommands.swift
+++ b/Sources/WaxCLI/BrokerForwardingCommands.swift
@@ -281,3 +281,12 @@ struct MarkdownSyncCommand: AsyncParsableCommand {
     @OptionGroup var forwarded: BrokerForwardOptions
     func runAsync() async throws { try await runBrokerForwardedCommand("markdown_sync", store: store, forwarded: forwarded) }
 }
+
+struct TaskStateMigrateCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "task-state-migrate", abstract: "Copy and repair legacy durable task-state memory")
+    @OptionGroup var store: VectorStoreOptions
+    @OptionGroup var forwarded: BrokerForwardOptions
+    func runAsync() async throws {
+        try await runBrokerForwardedCommand("task_state_migrate", store: store, forwarded: forwarded)
+    }
+}

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -768,7 +768,7 @@ enum WaxMCPAgentPlaybook {
         - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
         - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
         - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
-        - `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
+        - `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
         Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 
@@ -801,7 +801,7 @@ enum WaxMCPAgentPlaybook {
 
         Write as you go:
         - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).
-        - `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run.
+        - `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct complete-store copy after a dry run.
         - Long-term: `remember` with `scope: durable` (no `session_id`), type `decision` / `lesson` / `constraint` / `user_preference` / `fact` (corrections, decisions, standing prefs, stable repo facts).
 
         Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -36,6 +36,7 @@ struct WaxCLI: ParsableCommand {
             CompactContextCommand.self,
             MarkdownExportCommand.self,
             MarkdownSyncCommand.self,
+            TaskStateMigrateCommand.self,
             EntityUpsertCommand.self,
             EntityResolveCommand.self,
             FactAssertCommand.self,
@@ -767,6 +768,7 @@ enum WaxMCPAgentPlaybook {
         - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
         - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
         - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
+        - `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
 
         Canonical verbs: `session_open`, `remember`, `recall`, `session_close`, `stats`.
 
@@ -799,6 +801,7 @@ enum WaxMCPAgentPlaybook {
 
         Write as you go:
         - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).
+        - `task_state` requires an active session and is always working; never request durable or locked task state. Repair legacy records with `task_state_migrate` into a distinct destination after a dry run.
         - Long-term: `remember` with `scope: durable` (no `session_id`), type `decision` / `lesson` / `constraint` / `user_preference` / `fact` (corrections, decisions, standing prefs, stable repo facts).
 
         Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -14,6 +14,7 @@ enum MCPAgentInstructions {
         3) When you learn durable facts, call remember with concise factual content. Prefer scope=session|durable; session requires top-level session_id; durable forbids session_id. Never put session_id inside metadata.
         4) Near session end, prefer session_close(session_id, content, optional project/pending_tasks) for atomic handoff+end. Keep content to a concise state summary; put unfinished work only in pending_tasks and never store transcripts. Or call handoff then session_end. session_end/session_close `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
         5) A persisted session_id survives broker hops: remember/recall/handoff rebind that UUID when the manifest is still active. Ended/unknown UUIDs return structured inactive errors (resumable=false).
+        6) task_state is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with task_state_migrate into a distinct destination after a dry run; choose quarantine (default) or drop for orphaned records.
 
         Canonical verbs: session_open, remember, recall, session_close, stats.
 

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -119,6 +119,11 @@ enum ToolSchemas {
             description: "Import and reconcile managed Markdown projections like MEMORY.md, daily notes, and DREAMS.md back into Wax.",
             inputSchema: waxMarkdownSync
         ),
+        Tool(
+            name: "task_state_migrate",
+            description: "Copy the long-term store into a distinct destination while repairing legacy durable task_state frames; reports source preservation and deep verification.",
+            inputSchema: waxTaskStateMigrate
+        ),
         ]
 
         let structuredTools: [Tool] = [
@@ -604,6 +609,15 @@ enum ToolSchemas {
                 "description": "Natural-language durable knowledge to store.",
                 "maxLength": .int(maxContentBytes),
             ],
+            "session_id": [
+                "type": "string",
+                "description": "Optional active session UUID for session-local task_state or working knowledge.",
+            ],
+            "scope": [
+                "type": "string",
+                "description": "Write horizon. session requires session_id; durable forbids session_id.",
+                "enum": ["session", "durable"],
+            ],
             "metadata": [
                 "type": "object",
                 "description": "Optional metadata map. Scalar values are coerced to strings.",
@@ -736,6 +750,28 @@ enum ToolSchemas {
             "dry_run": ["type": "boolean", "description": "When true, report projected create/update/delete counts without mutating Wax state."],
         ],
         required: ["root_dir"]
+    )
+    static let waxTaskStateMigrate: Value = objectSchema(
+        properties: [
+            "destination_path": [
+                "type": "string",
+                "description": "Distinct destination .wax path for the repaired copy. The source store is never overwritten.",
+            ],
+            "dry_run": [
+                "type": "boolean",
+                "description": "Report the planned rehome/quarantine/drop counts without creating the destination.",
+            ],
+            "orphan_policy": [
+                "type": "string",
+                "description": "How task_state frames without valid session provenance are handled. Default: quarantine.",
+                "enum": ["quarantine", "drop"],
+            ],
+            "overwrite_destination": [
+                "type": "boolean",
+                "description": "Allow replacing an existing destination when its migration manifest does not match. Default: false.",
+            ],
+        ],
+        required: ["destination_path"]
     )
 
     static let waxEntityUpsert: Value = objectSchema(

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -245,6 +245,7 @@ private extension WaxMCPTools {
         case "wax_compact_context": return "compact_context"
         case "wax_markdown_export": return "markdown_export"
         case "wax_markdown_sync": return "markdown_sync"
+        case "wax_task_state_migrate": return "task_state_migrate"
         case "wax_entity_upsert": return "entity_upsert"
         case "wax_fact_assert": return "fact_assert"
         case "wax_fact_retract": return "fact_retract"

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -365,6 +365,47 @@ struct WaxCLIMemoryTests {
         #expect(queryOutput.stdout.contains("..open]"))
     }
 
+    @Test func directTaskStateMigrationUsesNativeFlags() throws {
+        let executable = URL(fileURLWithPath: try builtProductPath(named: "wax-cli"))
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-cli-task-state-migrate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceURL = tempDir.appendingPathComponent("source.wax")
+        let destinationURL = tempDir.appendingPathComponent("repaired.wax")
+
+        let seed = try runProcess(
+            executableURL: executable,
+            arguments: [
+                "remember",
+                "--direct-store",
+                "--no-embedder",
+                "--store-path", sourceURL.path,
+                "--metadata", "wax.memory_type=task_state",
+                "--metadata", "wax.durability=durable",
+                "legacy task state",
+            ],
+            timeout: 20
+        )
+        #expect(seed.status == EXIT_SUCCESS, "seed remember should succeed: \(seed.stderr)")
+
+        let dryRun = try runProcess(
+            executableURL: executable,
+            arguments: [
+                "task-state-migrate",
+                "--direct-store",
+                "--no-embedder",
+                "--store-path", sourceURL.path,
+                "--destination-path", destinationURL.path,
+                "--dry-run",
+            ],
+            timeout: 30
+        )
+        #expect(dryRun.status == EXIT_SUCCESS, "task-state-migrate should accept native flags: \(dryRun.stderr)")
+        #expect(dryRun.stdout.contains("quarantined_document_count"))
+        #expect(!FileManager.default.fileExists(atPath: destinationURL.path))
+    }
+
     @Test func directStatsAndFlushHonorRequireVectorWithNoEmbedder() throws {
         let executable = URL(fileURLWithPath: try builtProductPath(named: "wax-cli"))
         let tempDir = FileManager.default.temporaryDirectory

--- a/Tests/WaxIntegrationTests/READMEExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/READMEExamplesTests.swift
@@ -47,6 +47,34 @@ func npmReadmeLocalDevelopmentUsesRepoRootPackagePath() throws {
     #expect(readme.contains("npx --yes ./Resources/npm/waxmcp mcp doctor"))
 }
 
+@Test
+func npmTaskStateMigrationDocsMatchNativeLauncherDispatch() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let readme = try String(
+        contentsOf: repoRoot.appendingPathComponent("Resources/npm/waxmcp/README.md"),
+        encoding: .utf8
+    )
+    let launcher = try String(
+        contentsOf: repoRoot.appendingPathComponent("Resources/npm/waxmcp/bin/waxmcp.js"),
+        encoding: .utf8
+    )
+    let cliSource = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/WaxCLI/BrokerForwardingCommands.swift"),
+        encoding: .utf8
+    )
+
+    #expect(readme.contains("task-state-migrate --direct-store --store-path"))
+    #expect(readme.contains("--destination-path /tmp/repaired.wax --dry-run"))
+    #expect(launcher.contains("forwardedArgs[0] === \"task-state-migrate\""))
+    #expect(launcher.contains("runBinary(\"wax-cli\", forwardedArgs)"))
+    #expect(cliSource.contains("customLong(\"destination-path\")"))
+    #expect(cliSource.contains("customLong(\"dry-run\")"))
+    #expect(cliSource.contains("customLong(\"overwrite-destination\")"))
+}
+
 // MARK: - Test Embedder for README examples
 
 private actor TestReadmeEmbedder: EmbeddingProvider {

--- a/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
+++ b/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Testing
+@testable import Wax
+
+#if MCPServer
+import MCP
+@testable import wax_mcp
+
+private func withTaskStateBroker<T>(
+    _ body: (AgentBrokerService, URL) async throws -> T
+) async throws -> T {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-task-state-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        let result = try await body(service, rootURL)
+        try await service.close()
+        return result
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+@Test
+func taskStateWritesRequireSessionAndWorkingDurability() async throws {
+    try await withTaskStateBroker { service, _ in
+        let missingSession = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("orphan task state"),
+                "memory_type": .string("task_state"),
+            ]
+        ))
+        #expect(!missingSession.ok)
+        #expect((missingSession.error ?? "").contains("task_state"))
+
+        let started = await service.handle(.init(command: "session_start"))
+        let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
+        let durable = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("durable diary is forbidden"),
+                "session_id": .string(sessionID),
+                "memory_type": .string("task_state"),
+                "durability": .string("durable"),
+            ]
+        ))
+        #expect(!durable.ok)
+
+        let locked = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("locked diary is forbidden"),
+                "session_id": .string(sessionID),
+                "memory_type": .string("task_state"),
+                "locked": .bool(true),
+            ]
+        ))
+        #expect(!locked.ok)
+
+        let scopeDurable = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("durable scope is forbidden"),
+                "session_id": .string(sessionID),
+                "scope": .string("durable"),
+                "memory_type": .string("task_state"),
+            ]
+        ))
+        #expect(!scopeDurable.ok)
+
+        let valid = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("working task state"),
+                "session_id": .string(sessionID),
+                "memory_type": .string("task_state"),
+                "durability": .string("ephemeral"),
+            ]
+        ))
+        #expect(valid.ok)
+        #expect(valid.payload?.objectValue?["durability"]?.stringValue == "working")
+
+        let session = try await service.memory(for: UUID(uuidString: sessionID))
+        let documents = try await session.corpusSourceDocuments()
+        #expect(documents.count == 1)
+        let metadata = try #require(documents.first?.metadata)
+        #expect(metadata[MemoryMetadataKeys.type] == MemoryType.taskState.rawValue)
+        #expect(metadata[MemoryMetadataKeys.durability] == MemoryDurability.working.rawValue)
+        #expect(metadata["session_id"] == sessionID)
+    }
+}
+
+@Test
+func knowledgeCaptureTaskStateUsesSessionLane() async throws {
+    try await withTaskStateBroker { service, _ in
+        let rejected = await service.handle(.init(
+            command: "knowledge_capture",
+            arguments: [
+                "content": .string("knowledge diary without session"),
+                "memory_type": .string("task_state"),
+            ]
+        ))
+        #expect(!rejected.ok)
+
+        let started = await service.handle(.init(command: "session_start"))
+        let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
+        let captured = await service.handle(.init(
+            command: "knowledge_capture",
+            arguments: [
+                "content": .string("knowledge task state"),
+                "session_id": .string(sessionID),
+                "scope": .string("session"),
+                "memory_type": .string("task_state"),
+            ]
+        ))
+        #expect(captured.ok)
+        let session = try await service.memory(for: UUID(uuidString: sessionID))
+        let documents = try await session.corpusSourceDocuments()
+        #expect(documents.count == 1)
+        #expect(documents.first?.metadata[MemoryMetadataKeys.durability] == MemoryDurability.working.rawValue)
+    }
+}
+
+@Test
+func markdownTaskStateImportIsRejectedBeforeDurableWrite() async throws {
+    try await withTaskStateBroker { service, rootURL in
+        let text = "legacy Markdown task state"
+        let marker = MarkdownProjectionMarker(
+            sourceKind: MarkdownProjectionKind.memory.rawValue,
+            hash: AgentBrokerService.stableHash(text),
+            memoryType: MemoryType.taskState.rawValue,
+            durability: MemoryDurability.durable.rawValue
+        )
+        let renderedLine = await service.renderManagedMarkdownLine(text: text, marker: marker)
+        let markdown = "## task_state\n\(renderedLine)\n"
+        let memoryURL = rootURL.appendingPathComponent("MEMORY.md")
+        try markdown.write(to: memoryURL, atomically: true, encoding: .utf8)
+
+        let response = await service.handle(.init(
+            command: "markdown_sync",
+            arguments: ["root_dir": .string(rootURL.path)]
+        ))
+        #expect(!response.ok)
+        #expect((response.error ?? "").contains("task_state"))
+        #expect(try await service.longTermMemory.corpusSourceDocuments().isEmpty)
+    }
+}
+
+@Test
+func taskStateMigrationIsCopyFirstAuditedAndIdempotent() async throws {
+    try await withTaskStateBroker { service, rootURL in
+        let started = await service.handle(.init(command: "session_start"))
+        let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
+        let sessionUUID = try #require(UUID(uuidString: sessionID))
+        try await service.longTermMemory.remember(
+            "legacy task state with valid provenance",
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.taskState.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                "session_id": sessionID,
+            ]
+        )
+        try await service.longTermMemory.remember(
+            "legacy orphan task state",
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.taskState.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.locked.rawValue,
+                "session_id": UUID().uuidString,
+            ]
+        )
+        try await service.longTermMemory.remember(
+            "ordinary durable memory",
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.decision.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+            ]
+        )
+        try await service.longTermMemory.flush()
+
+        let destination = rootURL.appendingPathComponent("repaired.wax")
+        let dryRun = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: [
+                "destination_path": .string(destination.path),
+                "dry_run": .bool(true),
+            ]
+        ))
+        #expect(dryRun.ok)
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+        #expect(dryRun.payload?.objectValue?["rehomed_document_count"]?.intValue == 1)
+        #expect(dryRun.payload?.objectValue?["quarantined_document_count"]?.intValue == 1)
+
+        let migrated = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: ["destination_path": .string(destination.path)]
+        ))
+        #expect(migrated.ok)
+        #expect(migrated.payload?.objectValue?["verified"]?.boolValue == true)
+        #expect(migrated.payload?.objectValue?["source_preserved"]?.boolValue == true)
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        config.enableStructuredMemory = false
+        let repaired = try await MemoryOrchestrator(at: destination, config: config)
+        let repairedDocuments = try await repaired.corpusSourceDocuments()
+        #expect(repairedDocuments.count == 3)
+        #expect(repairedDocuments.contains {
+            $0.metadata[MemoryMetadataKeys.type] == MemoryType.taskState.rawValue &&
+                $0.metadata[MemoryMetadataKeys.durability] == MemoryDurability.working.rawValue &&
+                $0.metadata["session_id"] == sessionUUID.uuidString
+        })
+        #expect(repairedDocuments.contains {
+            $0.metadata[MemoryMetadataKeys.migrationAction] == "quarantine" &&
+                $0.metadata[MemoryMetadataKeys.type] == MemoryType.note.rawValue
+        })
+        try await repaired.close()
+
+        let second = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: ["destination_path": .string(destination.path)]
+        ))
+        #expect(second.ok)
+        #expect(second.payload?.objectValue?["idempotent"]?.boolValue == true)
+
+        let dropDestination = rootURL.appendingPathComponent("repaired-drop.wax")
+        let dropped = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: [
+                "destination_path": .string(dropDestination.path),
+                "orphan_policy": .string("drop"),
+            ]
+        ))
+        #expect(dropped.ok)
+        #expect(dropped.payload?.objectValue?["dropped_document_count"]?.intValue == 1)
+        #expect(dropped.payload?.objectValue?["quarantined_document_count"]?.intValue == 0)
+    }
+}
+#endif

--- a/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
+++ b/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
@@ -105,6 +105,53 @@ func taskStateWritesRequireSessionAndWorkingDurability() async throws {
 }
 
 @Test
+func unclassifiedSessionWritesStayWorkingNotesNotTaskState() async throws {
+    try await withTaskStateBroker { service, _ in
+        let started = await service.handle(.init(command: "session_start"))
+        let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
+
+        let durable = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Durable memory anchor: Wax is the long-term source of truth."),
+                "memory_type": .string("decision"),
+                "durability": .string("durable"),
+            ]
+        ))
+        #expect(durable.ok)
+        #expect(durable.payload?.objectValue?["memory_id"]?.stringValue == "durable:0")
+
+        let appended = await service.handle(.init(
+            command: "memory_append",
+            arguments: [
+                "content": .string("Working memory anchor: current task is OpenClaw adapter implementation."),
+                "session_id": .string(sessionID),
+            ]
+        ))
+        #expect(appended.ok)
+        #expect(appended.payload?.objectValue?["memory_type"]?.stringValue == MemoryType.note.rawValue)
+        #expect(appended.payload?.objectValue?["durability"]?.stringValue == MemoryDurability.working.rawValue)
+        let workingID = try #require(appended.payload?.objectValue?["memory_id"]?.stringValue)
+        #expect(workingID.hasPrefix("working:\(sessionID):"))
+
+        let search = await service.handle(.init(
+            command: "memory_search",
+            arguments: [
+                "query": .string("anchor"),
+                "session_id": .string(sessionID),
+                "topK": .int(6),
+                "mode": .string("text"),
+            ]
+        ))
+        #expect(search.ok)
+        let results = try #require(search.payload?.objectValue?["results"]?.arrayValue)
+        #expect(results.contains { $0.objectValue?["horizon"]?.stringValue == "working" })
+        #expect(results.contains { $0.objectValue?["horizon"]?.stringValue == "durable" })
+        #expect(results.contains { $0.objectValue?["memory_id"]?.stringValue == workingID })
+    }
+}
+
+@Test
 func knowledgeCaptureTaskStateUsesSessionLane() async throws {
     try await withTaskStateBroker { service, _ in
         let rejected = await service.handle(.init(

--- a/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
+++ b/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import Wax
+import WaxCore
 
 #if MCPServer
 import MCP
@@ -160,11 +161,97 @@ func markdownTaskStateImportIsRejectedBeforeDurableWrite() async throws {
 }
 
 @Test
+func taskStateMigrationRejectsUnsafeDestinationPaths() async throws {
+    try await withTaskStateBroker { service, rootURL in
+        let directoryDestination = rootURL.appendingPathComponent("destination", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryDestination, withIntermediateDirectories: false)
+        let directoryResponse = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: ["destination_path": .string(directoryDestination.path)]
+        ))
+        #expect(!directoryResponse.ok)
+
+        let symlinkTarget = rootURL.appendingPathComponent("symlink-target", isDirectory: true)
+        let symlinkParent = rootURL.appendingPathComponent("symlink-parent", isDirectory: true)
+        try FileManager.default.createDirectory(at: symlinkTarget, withIntermediateDirectories: false)
+        try FileManager.default.createSymbolicLink(at: symlinkParent, withDestinationURL: symlinkTarget)
+        let symlinkResponse = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: [
+                "destination_path": .string(
+                    symlinkParent.appendingPathComponent("repaired.wax").path
+                )
+            ]
+        ))
+        #expect(!symlinkResponse.ok)
+        #expect(!FileManager.default.fileExists(
+            atPath: symlinkTarget.appendingPathComponent("repaired.wax").path
+        ))
+
+        let sourceURL = rootURL.appendingPathComponent("memory.wax")
+        let sourceAlias = rootURL.appendingPathComponent("source-alias.wax")
+        try FileManager.default.linkItem(at: sourceURL, to: sourceAlias)
+        let aliasResponse = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: [
+                "destination_path": .string(sourceAlias.path),
+                "overwrite_destination": .bool(true),
+            ]
+        ))
+        #expect(!aliasResponse.ok)
+
+        let symlinkDestinationTarget = rootURL.appendingPathComponent("destination-target.wax")
+        let symlinkDestination = rootURL.appendingPathComponent("destination-link.wax")
+        try Data("sentinel".utf8).write(to: symlinkDestinationTarget)
+        try FileManager.default.createSymbolicLink(
+            at: symlinkDestination,
+            withDestinationURL: symlinkDestinationTarget
+        )
+        let destinationSymlinkResponse = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: [
+                "destination_path": .string(symlinkDestination.path),
+                "overwrite_destination": .bool(true),
+            ]
+        ))
+        #expect(!destinationSymlinkResponse.ok)
+        #expect(String(data: try Data(contentsOf: symlinkDestinationTarget), encoding: .utf8) == "sentinel")
+
+        let lockedDestination = rootURL.appendingPathComponent("locked-destination.wax")
+        let lockedContents = Data("locked-sentinel".utf8)
+        try lockedContents.write(to: lockedDestination)
+        let lock = try FileLock.acquire(at: lockedDestination, mode: .exclusive)
+        let lockedResponse = await service.handle(.init(
+            command: "task_state_migrate",
+            arguments: [
+                "destination_path": .string(lockedDestination.path),
+                "overwrite_destination": .bool(true),
+            ]
+        ))
+        try lock.release()
+        #expect(!lockedResponse.ok)
+        #expect(try Data(contentsOf: lockedDestination) == lockedContents)
+    }
+}
+
+@Test
 func taskStateMigrationIsCopyFirstAuditedAndIdempotent() async throws {
     try await withTaskStateBroker { service, rootURL in
         let started = await service.handle(.init(command: "session_start"))
         let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
         let sessionUUID = try #require(UUID(uuidString: sessionID))
+        let retainedEntity = EntityKey("project:wax")
+        let retainedPredicate = PredicateKey("status")
+        _ = try await service.longTermMemory.upsertEntity(
+            key: retainedEntity,
+            kind: "project",
+            aliases: ["Wax"]
+        )
+        _ = try await service.longTermMemory.assertFact(
+            subject: retainedEntity,
+            predicate: retainedPredicate,
+            object: .string("active")
+        )
         try await service.longTermMemory.remember(
             "legacy task state with valid provenance",
             metadata: [
@@ -213,7 +300,7 @@ func taskStateMigrationIsCopyFirstAuditedAndIdempotent() async throws {
 
         var config = OrchestratorConfig.default
         config.enableVectorSearch = false
-        config.enableStructuredMemory = false
+        config.enableStructuredMemory = true
         let repaired = try await MemoryOrchestrator(at: destination, config: config)
         let repairedDocuments = try await repaired.corpusSourceDocuments()
         #expect(repairedDocuments.count == 3)
@@ -225,6 +312,18 @@ func taskStateMigrationIsCopyFirstAuditedAndIdempotent() async throws {
         #expect(repairedDocuments.contains {
             $0.metadata[MemoryMetadataKeys.migrationAction] == "quarantine" &&
                 $0.metadata[MemoryMetadataKeys.type] == MemoryType.note.rawValue
+        })
+        #expect(try await repaired.entity(forKey: retainedEntity)?.key == retainedEntity)
+        let retainedFacts = try await repaired.facts(
+            about: retainedEntity,
+            predicate: retainedPredicate,
+            limit: 20
+        )
+        #expect(retainedFacts.hits.contains { hit in
+            if case .string(let value) = hit.fact.object {
+                return value == "active"
+            }
+            return false
         })
         try await repaired.close()
 

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -376,7 +376,7 @@ private final class UnixStatsResponder: @unchecked Sendable {
 
     private func handle(client: Int32) {
         var descriptor = pollfd(fd: client, events: Int16(POLLIN), revents: 0)
-        let pollResult = poll(&descriptor, 1, 200)
+        let pollResult = poll(&descriptor, 1, 2_000)
         if pollResult <= 0 {
             close(client)
             return

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -445,6 +445,7 @@ func toolsListContainsExpectedTools() {
     #expect(names.contains("compact_context"))
     #expect(names.contains("markdown_export"))
     #expect(names.contains("markdown_sync"))
+    #expect(names.contains("task_state_migrate"))
     #expect(names.contains("entity_upsert"))
     #expect(names.contains("fact_assert"))
     #expect(names.contains("fact_retract"))
@@ -523,7 +524,7 @@ func toolSchemaRegression() {
     }
 
     // Core tools must be present (regression: renaming or removing breaks clients)
-    let requiredTools = ["memory_append", "memory_search", "memory_get", "remember", "recall", "search", "session_synthesize", "memory_promote", "promote", "memory_health", "knowledge_capture", "corpus_search", "stats", "session_resume", "compact_context", "markdown_export", "markdown_sync"]
+    let requiredTools = ["memory_append", "memory_search", "memory_get", "remember", "recall", "search", "session_synthesize", "memory_promote", "promote", "memory_health", "knowledge_capture", "corpus_search", "stats", "session_resume", "compact_context", "markdown_export", "markdown_sync", "task_state_migrate"]
     for required in requiredTools {
         #expect(uniqueNames.contains(required), "Required tool '\(required)' is missing from schema")
     }
@@ -554,6 +555,7 @@ func toolSchemaRegression() {
         ("compact_context", ToolSchemas.waxCompactContext, true),
         ("markdown_export", ToolSchemas.waxMarkdownExport, true),
         ("markdown_sync", ToolSchemas.waxMarkdownSync, true),
+        ("task_state_migrate", ToolSchemas.waxTaskStateMigrate, true),
         ("entity_upsert", ToolSchemas.waxEntityUpsert, true),
         ("fact_assert", ToolSchemas.waxFactAssert, true),
         ("fact_retract", ToolSchemas.waxFactRetract, true),
@@ -4025,7 +4027,7 @@ func brokerMarkdownExportSkipsActiveSessionsOwnedByOtherBrokers() async throws {
 }
 
 @Test
-func brokerMarkdownExportUsesStoredMemoryTypeForSections() async throws {
+func brokerRememberRejectsDurableTaskStateBeforeMarkdownExport() async throws {
     try await withAgentBrokerService { service, _ in
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("wax-markdown-stored-type-\(UUID().uuidString)", isDirectory: true)
@@ -4041,7 +4043,8 @@ func brokerMarkdownExportUsesStoredMemoryTypeForSections() async throws {
                 "reviewed": .bool(true),
             ]
         ))
-        #expect(remember.ok == true)
+        #expect(remember.ok == false)
+        #expect((remember.error ?? "").contains("task_state"))
 
         let export = await service.handle(.init(
             command: "markdown_export",
@@ -4053,9 +4056,8 @@ func brokerMarkdownExportUsesStoredMemoryTypeForSections() async throws {
         let payload = try #require(export.payload?.objectValue)
         let memoryPath = try #require(payload["memory_md_path"]?.stringValue)
         let markdown = try String(contentsOfFile: memoryPath, encoding: .utf8)
-        #expect(markdown.contains("## task_state"))
-        #expect(!markdown.contains("## decision"))
-        #expect(markdown.contains(content))
+        #expect(!markdown.contains("## task_state"))
+        #expect(!markdown.contains(content))
     }
 }
 

--- a/Tests/WaxTests/MemorySemanticsClassifyTests.swift
+++ b/Tests/WaxTests/MemorySemanticsClassifyTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import Wax
+
+@Suite("Memory semantics classify")
+struct MemorySemanticsClassifyTests {
+    @Test
+    func implicitNoteWithDecisionPrefixClassifiesAsDecision() {
+        #expect(
+            MemorySemantics.classifyCandidate(
+                text: "Decision: keep session notes promotable.",
+                metadata: [MemoryMetadataKeys.type: MemoryType.note.rawValue]
+            ) == .decision
+        )
+    }
+
+    @Test
+    func implicitNoteWithoutCueStaysNote() {
+        #expect(
+            MemorySemantics.classifyCandidate(
+                text: "scratch reminder about the build.",
+                metadata: [MemoryMetadataKeys.type: MemoryType.note.rawValue]
+            ) == .note
+        )
+    }
+
+    @Test
+    func taskStateWithDecisionPrefixStillClassifiesAsDecision() {
+        #expect(
+            MemorySemantics.classifyCandidate(
+                text: "Decision: promote this diary.",
+                metadata: [MemoryMetadataKeys.type: MemoryType.taskState.rawValue]
+            ) == .decision
+        )
+    }
+
+    @Test
+    func explicitDecisionTypeIsTrustedEvenWithoutCue() {
+        #expect(
+            MemorySemantics.classifyCandidate(
+                text: "not a decision at all",
+                metadata: [MemoryMetadataKeys.type: MemoryType.decision.rawValue]
+            ) == .decision
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Reject `task_state` without an active session, and reject durable/locked task-state writes. Valid session writes coerce to `working`.
- Add copy-first `task_state_migrate` (broker / MCP / CLI) with dry-run, quarantine, verification, and rollback.
- Keep npm/CLI playbooks in lockstep so the migration command actually routes to `wax-cli`.

Independent of reconcile, but it overlaps `AgentBrokerService.swift` and `MemorySemantics.swift`. Merge after reconcile, or expect a rebase.

## Test plan
- [ ] `swift test --traits MCPServer --filter TaskStateSafetyTests`
- [ ] `swift test --filter projectRulesPlaybookStaysInLockstepWithDocs`
- [ ] Confirm `npx waxmcp task-state-migrate --help` routes to `wax-cli`


Made with [Cursor](https://cursor.com)