### PR TITLE
fix(search): route exact names and IDs to lexical retrieval

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1758,9 +1758,18 @@ package actor MemoryOrchestrator {
         requestedMode: SearchMode?
     ) async throws -> RecallExecution {
         let recallConfig = ragConfigForRecall()
-        let resolvedRequestedMode = requestedMode ?? recallConfig.searchMode
-        let embeddingPolicy = requestedMode.map(Self.queryEmbeddingPolicy(for:)) ?? .ifAvailable
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let implicitExactIntent = requestedMode == nil
+            && RuleBasedQueryClassifier.isExactIntentQuery(trimmedQuery)
+        let resolvedRequestedMode = requestedMode
+            ?? (implicitExactIntent ? .textOnly : recallConfig.searchMode)
+        let embeddingPolicy: QueryEmbeddingPolicy = if let requestedMode {
+            Self.queryEmbeddingPolicy(for: requestedMode)
+        } else if implicitExactIntent {
+            .never
+        } else {
+            .ifAvailable
+        }
         guard !trimmedQuery.isEmpty else {
             return RecallExecution(
                 context: RAGContext(query: query, items: [], totalTokens: 0),

--- a/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
+++ b/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
@@ -57,13 +57,26 @@ package enum RuleBasedQueryClassifier {
         guard tokens.count == 1 else { return false }
         let token = tokens[0]
         guard !token.isEmpty else { return false }
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        // Keep this intentionally narrow to one token: ordinary bare words stay
+        // exploratory, while IDs that use common path/name punctuation can take
+        // the lexical lane. MatchPlan still controls how the token is planned for
+        // FTS and preserves '-'/'_' glue for the #166 path.
+        let identifierPunctuation = CharacterSet(charactersIn: "-_.:/@#%+")
+        let allowed = CharacterSet.alphanumerics.union(identifierPunctuation)
         guard token.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return false }
 
-        let identifierPunctuation = CharacterSet(charactersIn: "-_.")
         let hasDigit = token.unicodeScalars.contains { CharacterSet.decimalDigits.contains($0) }
         let hasIdentifierPunctuation = token.unicodeScalars.contains { identifierPunctuation.contains($0) }
         if hasDigit || hasIdentifierPunctuation {
+            return true
+        }
+
+        // CamelCase identifiers are common exact lookups (for example,
+        // `AgentBrokerClient`) but a leading-capital human name such as
+        // `Swift` or `Noah` is still ordinary prose. Require an uppercase
+        // transition after the first scalar before treating letters-only text
+        // as an implicit exact query.
+        if token.unicodeScalars.dropFirst().contains(where: { CharacterSet.uppercaseLetters.contains($0) }) {
             return true
         }
 
@@ -71,5 +84,19 @@ package enum RuleBasedQueryClassifier {
         // Length 8 avoids English hex-words (`facade`, `decade`).
         return token.count >= 8 && token.unicodeScalars.allSatisfy { hexScalars.contains($0) }
     }
-}
 
+    /// Whether an omitted retrieval mode should use the lexical lane.
+    ///
+    /// An explicit identifier (including UUIDs, dotted/underscored names, and
+    /// path-like IDs) or a quoted phrase is an exact-intent lookup. Plain bare
+    /// words and ordinary prose remain on the configured default mode so this
+    /// does not turn every name-like word into a lexical query.
+    package static func isExactIntentQuery(_ query: String) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        if isLexicalIdentifierQuery(trimmed) {
+            return true
+        }
+        return !MatchPlan.rawQuotedPhrases(from: trimmed).isEmpty
+    }
+}

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -59,10 +59,10 @@ extension Wax {
             includeVector = true
         }
 
-        // Identifier overfetch + exact-match rerank are text-lane only.
-        // vectorOnly must not widen the pending window or promote a buried exact frame.
-        let identifierWindow: Int? = (
-            includeText && (trimmedQuery.map(RuleBasedQueryClassifier.isLexicalIdentifierQuery) ?? false)
+        // Exact-intent overfetch + rerank are text-lane only. vectorOnly must not
+        // widen the pending window or promote a buried lexical frame.
+        let exactIntentWindow: Int? = (
+            includeText && (trimmedQuery.map(RuleBasedQueryClassifier.isExactIntentQuery) ?? false)
         ) ? min(max(Self.boundedMultiply(requestedTopK, by: 3), 12), 48) : nil
 
         let candidateLimit = Self.candidateLimit(for: requestedTopK, filter: filter)
@@ -472,7 +472,7 @@ extension Wax {
         }
 
         var pendingResults: [PendingResult] = []
-        let pendingLimit = identifierWindow ?? requestedTopK
+        let pendingLimit = exactIntentWindow ?? requestedTopK
         pendingResults.reserveCapacity(min(pendingLimit, baseResults.count))
 
         if !baseResults.isEmpty {
@@ -602,11 +602,11 @@ extension Wax {
             nowMs: semanticNowMs,
             maxWindow: min(max(Self.boundedMultiply(request.topK, by: 3), 12), 48)
         )
-        if let identifierWindow, let trimmedQuery {
+        if let exactIntentWindow, let trimmedQuery {
             filtered = Self.identifierExactMatchRerank(
                 results: filtered,
                 query: trimmedQuery,
-                maxWindow: identifierWindow
+                maxWindow: exactIntentWindow
             )
         }
         if filtered.count > requestedTopK {
@@ -747,10 +747,13 @@ extension Wax {
         return combined
     }
 
-    /// Query-side exact-substring boost for identifier-like queries (caps, hyphens, few tokens).
-    /// FTS `unicode61` splits hyphens, so similar prose can beat the unique token on BM25;
-    /// same-repo/project semantic rerank can then lift a neighbor. This pass runs after
-    /// semantic rerank so an exact phrase hit stays rank 1. Vector-only ranking is unchanged.
+    /// Query-side exact-intent boost for identifiers and quoted phrases.
+    /// FTS `unicode61` splits identifier punctuation, so similar prose can beat a
+    /// unique token on BM25; same-repo/project semantic rerank can then lift a
+    /// neighbor. A token-boundary match receives the strong bonus, while a
+    /// substring match receives only a small lexical nudge. This pass runs after
+    /// semantic rerank so an exact phrase hit stays rank 1. Vector-only ranking
+    /// is unchanged.
     private static func identifierExactMatchRerank(
         results: [SearchResponse.Result],
         query: String,
@@ -759,32 +762,39 @@ extension Wax {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { return results }
         let cappedWindow = min(max(0, maxWindow), results.count)
-        // Window 1 still publishes the bonus so a lone exact hit outranks
-        // OR-fallback name matches from another store after corpus merge.
         guard cappedWindow > 0 else { return results }
 
-        let lowerNeedle = needle.lowercased()
-        // Larger than same-repo (0.9) + same-project (0.7) + decision (0.45) + durable (0.25).
-        let exactMatchBonus: Float = 5.0
+        let needles = exactIntentNeedles(from: needle)
+        guard !needles.isEmpty else { return results }
 
-        let scoredHead = results.prefix(cappedWindow).enumerated().map { index, result -> (index: Int, composite: Float, matched: Bool, result: SearchResponse.Result) in
+        // Larger than same-repo (0.9) + same-project (0.7) + decision (0.45) + durable (0.25).
+        let exactTokenBonus: Float = 5.0
+        let substringBonus: Float = 0.5
+
+        let scoredHead = results.prefix(cappedWindow).enumerated().map { index, result -> (index: Int, composite: Float, strength: ExactIntentMatchStrength, result: SearchResponse.Result) in
             let haystack = dehighlightedPreviewText(result.previewText ?? "").lowercased()
-            let matched = !haystack.isEmpty && haystack.contains(lowerNeedle)
+            let strength = bestExactIntentMatch(in: haystack, needles: needles)
             var updated = result
-            if matched {
+            switch strength {
+            case .token:
                 updated.explanations = dedupedExplanations(result.explanations + ["exact identifier match"])
+            case .substring:
+                updated.explanations = dedupedExplanations(result.explanations + ["identifier substring match"])
+            case .none:
+                break
             }
             return (
                 index: index,
-                composite: result.score + (matched ? exactMatchBonus : 0),
-                matched: matched,
+                composite: result.score + strength.bonus(exactTokenBonus: exactTokenBonus, substringBonus: substringBonus),
+                strength: strength,
                 result: updated
             )
         }
 
-        guard scoredHead.contains(where: \.matched) else { return results }
+        guard scoredHead.contains(where: { $0.strength != .none }) else { return results }
 
         let rankedHead = scoredHead.sorted { lhs, rhs in
+            if lhs.strength != rhs.strength { return lhs.strength.rawValue > rhs.strength.rawValue }
             if lhs.composite != rhs.composite { return lhs.composite > rhs.composite }
             if lhs.result.score != rhs.result.score { return lhs.result.score > rhs.result.score }
             return lhs.index < rhs.index
@@ -801,6 +811,154 @@ extension Wax {
         combined.reserveCapacity(results.count)
         combined.append(contentsOf: results.dropFirst(cappedWindow))
         return combined
+    }
+
+    private enum ExactIntentMatchStrength: Int, Equatable {
+        case none = 0
+        case substring = 1
+        case token = 2
+
+        func bonus(exactTokenBonus: Float, substringBonus: Float) -> Float {
+            switch self {
+            case .none: 0
+            case .substring: substringBonus
+            case .token: exactTokenBonus
+            }
+        }
+    }
+
+    /// Quoted phrases carry the exact target inside a natural-language query;
+    /// identifier queries use the whole trimmed value. Preserve all quoted
+    /// phrases so a result matching any explicit target can be promoted.
+    private static func exactIntentNeedles(from query: String) -> [String] {
+        let phrases = MatchPlan.rawQuotedPhrases(from: query).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.filter { !$0.isEmpty }
+        return phrases.isEmpty ? [query] : phrases
+    }
+
+    private static func bestExactIntentMatch(
+        in haystack: String,
+        needles: [String]
+    ) -> ExactIntentMatchStrength {
+        guard !haystack.isEmpty else { return .none }
+        var best: ExactIntentMatchStrength = .none
+        for needle in needles {
+            let candidate = needle.lowercased()
+            guard !candidate.isEmpty else { continue }
+            let strength = exactIntentMatchStrength(needle: candidate, in: haystack)
+            if strength.rawValue > best.rawValue {
+                best = strength
+                if best == .token { break }
+            }
+        }
+        return best
+    }
+
+    /// Classify a case-insensitive occurrence by the characters immediately
+    /// around it. Identifier glue is treated as part of the token when it
+    /// continues into another identifier scalar, while hyphen/underscore glue
+    /// remains strict for the #166 path. This preserves UUID/dot/path equality
+    /// without making sentence punctuation defeat a quoted name.
+    private static func exactIntentMatchStrength(
+        needle: String,
+        in haystack: String
+    ) -> ExactIntentMatchStrength {
+        let identifierGlue = CharacterSet(charactersIn: "-_.:/@#%+")
+        var searchStart = haystack.startIndex
+        var best: ExactIntentMatchStrength = .none
+
+        while searchStart < haystack.endIndex,
+              let range = haystack.range(of: needle, options: [.literal], range: searchStart..<haystack.endIndex)
+        {
+            let before = range.lowerBound > haystack.startIndex
+                ? haystack.index(before: range.lowerBound)
+                : nil
+            let after = range.upperBound < haystack.endIndex
+                ? range.upperBound
+                : nil
+            let hasTokenBoundaries = isExactIntentBoundary(
+                at: before,
+                direction: .before,
+                in: haystack,
+                glue: identifierGlue
+            ) && isExactIntentBoundary(
+                at: after,
+                direction: .after,
+                in: haystack,
+                glue: identifierGlue
+            )
+            if hasTokenBoundaries {
+                return .token
+            }
+            best = .substring
+            searchStart = range.upperBound
+        }
+        return best
+    }
+
+    private enum ExactIntentBoundaryDirection {
+        case before
+        case after
+    }
+
+    private static func isExactIntentBoundary(
+        at index: String.Index?,
+        direction: ExactIntentBoundaryDirection,
+        in haystack: String,
+        glue: CharacterSet
+    ) -> Bool {
+        guard let index else { return true }
+        let character = haystack[index]
+        let scalarView = character.unicodeScalars
+        if scalarView.contains(where: { CharacterSet.letters.contains($0) || CharacterSet.decimalDigits.contains($0) }) {
+            return false
+        }
+        // Hyphen and underscore are always identifier glue. A quoted phrase
+        // such as "Ada Lovelace" must not treat "Ada Lovelace-Foundation"
+        // as an equal token sequence merely because the query itself has no
+        // identifier punctuation.
+        if scalarView.contains(where: { $0 == "-" || $0 == "_" }) {
+            return false
+        }
+        guard scalarView.contains(where: glue.contains) else {
+            return true
+        }
+
+        // Punctuation in an identifier can also be ordinary sentence
+        // punctuation (for example, `build.agent_v2.`). Walk through a glue
+        // run and only reject the boundary when it continues into another
+        // identifier scalar. This keeps `build.agent_v2.extra` as a prefix
+        // distractor while allowing a terminal period after the exact ID.
+        var cursor: String.Index
+        switch direction {
+        case .before:
+            guard index > haystack.startIndex else { return true }
+            cursor = haystack.index(before: index)
+        case .after:
+            guard index < haystack.endIndex else { return true }
+            cursor = haystack.index(after: index)
+        }
+        while cursor < haystack.endIndex {
+            let adjacent = haystack[cursor]
+            let adjacentScalars = adjacent.unicodeScalars
+            if adjacentScalars.contains(where: {
+                CharacterSet.letters.contains($0) || CharacterSet.decimalDigits.contains($0)
+            }) {
+                return false
+            }
+            guard adjacentScalars.contains(where: glue.contains) else {
+                return true
+            }
+            switch direction {
+            case .before:
+                guard cursor > haystack.startIndex else { return true }
+                cursor = haystack.index(before: cursor)
+            case .after:
+                cursor = haystack.index(after: cursor)
+            }
+        }
+        return true
     }
 
     private static func baseExplanations(

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -5805,17 +5805,19 @@ func defaultRecallUsesHybridWhenVectorCoverageIsPartial() async throws {
     do {
         #expect((await hybrid.handle(.init(
             command: "remember",
-            arguments: ["content": .string("HYBRID_DEFAULT_QUERY_MARKER")]
+            arguments: ["content": .string("hybrid default query marker for partial vector coverage")]
         ))).ok == true)
 
         let stats = try #require((await hybrid.handle(.init(command: "stats"))).payload?.objectValue)
         #expect(stats["embeddingStatus"]?.stringValue == "degraded")
         #expect(stats["queryEmbeddingAvailable"]?.boolValue == true)
 
+        // Ordinary prose, not a SCREAMING_SNAKE identifier. Omitted-mode
+        // recall must still request hybrid when vector coverage is partial.
         let recalled = await hybrid.handle(.init(
             command: "recall",
             arguments: [
-                "query": .string("HYBRID_DEFAULT_QUERY_MARKER"),
+                "query": .string("hybrid default query marker"),
                 "scope": .string("global"),
                 "limit": .int(5),
             ]

--- a/Tests/WaxTests/ExactIntentRoutingTests.swift
+++ b/Tests/WaxTests/ExactIntentRoutingTests.swift
@@ -94,6 +94,7 @@ func exactIntentClassifierCoversIdentifiersAndQuotedNamesWithoutBareWordPromotio
         "arch/f1fd967c/T2",
         "#PR-145",
         "AgentBrokerClient",
+        "HYBRID_DEFAULT_QUERY_MARKER",
     ]
     for query in identifiers {
         #expect(RuleBasedQueryClassifier.isExactIntentQuery(query))

--- a/Tests/WaxTests/ExactIntentRoutingTests.swift
+++ b/Tests/WaxTests/ExactIntentRoutingTests.swift
@@ -1,0 +1,290 @@
+import Foundation
+import Testing
+@testable import Wax
+
+private struct ExactIntentTestEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 4
+    let normalize = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "ExactIntentTests",
+        model: "Deterministic",
+        dimensions: 4,
+        normalized: true
+    )
+
+    func embed(_ text: String) async throws -> [Float] {
+        let lower = text.lowercased()
+        if lower.contains("agentbroker") {
+            return [1, 0, 0, 0]
+        }
+        return [0, 1, 0, 0]
+    }
+}
+
+private func withExactIntentMemory<T>(
+    _ body: (MemoryOrchestrator) async throws -> T
+) async throws -> T {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-exact-intent-" + UUID().uuidString)
+        .appendingPathExtension("wax")
+    var config = OrchestratorConfig.default
+    config.enableTextSearch = true
+    config.enableVectorSearch = true
+    config.enableStructuredMemory = false
+    config.rag.searchMode = .hybrid(alpha: 0.5)
+
+    let memory = try await MemoryOrchestrator(
+        at: url,
+        config: config,
+        embedder: ExactIntentTestEmbedder()
+    )
+    do {
+        let result = try await body(memory)
+        try await memory.close()
+        try? FileManager.default.removeItem(at: url)
+        return result
+    } catch {
+        try? await memory.close()
+        try? FileManager.default.removeItem(at: url)
+        throw error
+    }
+}
+
+private func withTextOnlyBroker<T>(
+    _ body: (AgentBrokerService) async throws -> T
+) async throws -> T {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-exact-intent-broker-" + UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let service = try await AgentBrokerService(
+        storePath: root.appendingPathComponent("memory.wax").path,
+        sessionRootPath: root.appendingPathComponent("sessions").path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false,
+        orchestratorConfig: {
+            var config = OrchestratorConfig.default
+            config.enableVectorSearch = false
+            config.enableTextSearch = true
+            config.rag.searchMode = .hybrid(alpha: 0.5)
+            return config
+        }()
+    )
+    do {
+        let result = try await body(service)
+        try await service.close()
+        try? FileManager.default.removeItem(at: root)
+        return result
+    } catch {
+        try? await service.close()
+        try? FileManager.default.removeItem(at: root)
+        throw error
+    }
+}
+
+private func requireObject(_ value: AgentBrokerValue?) throws -> [String: AgentBrokerValue] {
+    try #require(value?.objectValue)
+}
+
+@Test
+func exactIntentClassifierCoversIdentifiersAndQuotedNamesWithoutBareWordPromotion() {
+    let identifiers = [
+        "550E8400-E29B-41D4-A716-446655440000",
+        "build.agent_v2",
+        "arch/f1fd967c/T2",
+        "#PR-145",
+        "AgentBrokerClient",
+    ]
+    for query in identifiers {
+        #expect(RuleBasedQueryClassifier.isExactIntentQuery(query))
+    }
+
+    #expect(RuleBasedQueryClassifier.isExactIntentQuery(#""Ada Lovelace""#))
+    #expect(RuleBasedQueryClassifier.isExactIntentQuery("'Ada Lovelace'"))
+    #expect(!RuleBasedQueryClassifier.isExactIntentQuery("Swift"))
+    #expect(!RuleBasedQueryClassifier.isExactIntentQuery("Noah Lovelace"))
+    #expect(!RuleBasedQueryClassifier.isExactIntentQuery("tell me about AgentBrokerClient"))
+}
+
+@Test
+func omittedRecallRoutesExactIntentToTextAndExplicitHybridRemainsHybrid() async throws {
+    try await withExactIntentMemory { memory in
+        try await memory.remember("Canonical AgentBrokerClient identifier.")
+        try await memory.flush()
+
+        let implicit = try await memory.recallExecution(query: "AgentBrokerClient", topK: 5)
+        #expect(implicit.requestedMode == .textOnly)
+        #expect(implicit.effectiveMode == .textOnly)
+        #expect(implicit.queryEmbeddingState == .notRequested)
+
+        let quoted = try await memory.recallExecution(query: #""Ada Lovelace""#, topK: 5)
+        #expect(quoted.requestedMode == .textOnly)
+        #expect(quoted.effectiveMode == .textOnly)
+        #expect(quoted.queryEmbeddingState == .notRequested)
+
+        let generic = try await memory.recallExecution(query: "actors", topK: 5)
+        #expect(generic.requestedMode == .hybrid(alpha: 0.5))
+        #expect(generic.effectiveMode == .hybrid(alpha: 0.5))
+        #expect(generic.queryEmbeddingState == .available)
+
+        let explicit = try await memory.recallExecution(
+            query: "AgentBrokerClient",
+            mode: .hybrid(alpha: 0.25),
+            topK: 5
+        )
+        #expect(explicit.requestedMode == .hybrid(alpha: 0.25))
+        #expect(explicit.effectiveMode == .hybrid(alpha: 0.25))
+        #expect(explicit.queryEmbeddingState == .available)
+
+        let explicitVector = try await memory.recallExecution(
+            query: "AgentBrokerClient",
+            mode: .vectorOnly,
+            topK: 5
+        )
+        #expect(explicitVector.requestedMode == .vectorOnly)
+        #expect(explicitVector.effectiveMode == .vectorOnly)
+        #expect(explicitVector.queryEmbeddingState == .available)
+    }
+}
+
+@Test
+func exactTokenMatchBeatsPrefixAndSupportsCaseInsensitiveNames() async throws {
+    try await withExactIntentMemory { memory in
+        let prefix = try await memory.remember(
+            "The AgentBroker-Client prefix distractor is not canonical."
+        )
+        let exact = try await memory.remember(
+            "The AgentBroker record is the canonical client name."
+        )
+        try await memory.flush()
+
+        let results = try await memory.searchExecution(
+            query: "aGeNtBrOkEr",
+            mode: .textOnly,
+            topK: 5
+        )
+        #expect(results.hits.first?.frameId == exact.frameId)
+        #expect(results.hits.first?.frameId != prefix.frameId)
+        #expect(results.hits.first?.explanations.contains("exact identifier match") == true)
+    }
+}
+
+@Test
+func quotedMultiTokenNameBeatsHyphenatedPrefix() async throws {
+    try await withExactIntentMemory { memory in
+        let prefix = try await memory.remember(
+            "Ada Lovelace-Foundation notes are a related but different name."
+        )
+        let exact = try await memory.remember(
+            "The canonical profile is Ada Lovelace, mathematician and author."
+        )
+        try await memory.flush()
+
+        let results = try await memory.searchExecution(
+            query: #""Ada Lovelace""#,
+            mode: .textOnly,
+            topK: 5
+        )
+        #expect(results.hits.first?.frameId == exact.frameId)
+        #expect(results.hits.first?.frameId != prefix.frameId)
+    }
+}
+
+@Test
+func exactIdentifiersWithUuidDotsUnderscoresAndPunctuationBeatPrefixes() async throws {
+    try await withExactIntentMemory { memory in
+        let cases = [
+            "550E8400-E29B-41D4-A716-446655440000",
+            "build.agent_v2",
+            "arch/f1fd967c/T2",
+            "#PR-145",
+        ]
+        for identifier in cases {
+            let prefix = try await memory.remember("Prefix " + identifier + "-extra distractor.")
+            let exact = try await memory.remember("Canonical identifier " + identifier + ". record.")
+            try await memory.flush()
+
+            let results = try await memory.searchExecution(
+                query: identifier,
+                mode: .textOnly,
+                topK: 8
+            )
+            #expect(results.hits.first?.frameId == exact.frameId)
+            #expect(results.hits.first?.frameId != prefix.frameId)
+        }
+    }
+}
+
+@Test
+func sessionOpenRecallUsesSafeImplicitExactRoutingAndMergedRanking() async throws {
+    try await withTextOnlyBroker { service in
+        let exact = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Canonical AgentBroker name from durable memory."),
+                "metadata": .object([
+                    MemoryMetadataKeys.project: .string("exact-intent"),
+                    MemoryMetadataKeys.repo: .string("exact-intent"),
+                ]),
+            ]
+        ))
+        #expect(exact.ok == true)
+
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("exact-intent-agent"),
+                "run_id": .string("exact-intent-run"),
+                "project": .string("exact-intent"),
+                "repo": .string("exact-intent"),
+            ]
+        ))
+        #expect(started.ok == true)
+        let startedPayload = try requireObject(started.payload)
+        let sessionID = try #require(startedPayload["session_id"]?.stringValue)
+
+        let prefix = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("AgentBroker-Client prefix from the current session."),
+                "session_id": .string(sessionID),
+                "memory_type": .string("note"),
+                "durability": .string("working"),
+            ]
+        ))
+        #expect(prefix.ok == true)
+
+        let merged = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string("AgentBroker"),
+                "scope": .string("global"),
+                "session_id": .string(sessionID),
+                "limit": .int(8),
+            ]
+        ))
+        #expect(merged.ok == true)
+        let mergedPayload = try requireObject(merged.payload)
+        #expect(mergedPayload["requested_mode"]?.stringValue == "text")
+        #expect(mergedPayload["effective_mode"]?.stringValue == "text")
+        let mergedResults = mergedPayload["results"]?.arrayValue ?? []
+        let mergedFirstText = mergedResults.first?.objectValue?["text"]?.stringValue ?? ""
+        #expect(mergedFirstText.localizedCaseInsensitiveContains("canonical AgentBroker"))
+
+        let opened = await service.handle(.init(
+            command: "session_open",
+            arguments: [
+                "project": .string("exact-intent"),
+                "repo": .string("exact-intent"),
+                "agent_id": .string("exact-intent-reopen"),
+                "run_id": .string("exact-intent-reopen"),
+                "recall_query": .string("AgentBroker"),
+            ]
+        ))
+        #expect(opened.ok == true)
+        let openPayload = try requireObject(opened.payload)
+        let recall = try requireObject(openPayload["recall"])
+        #expect(recall["requested_mode"]?.stringValue == "text")
+        #expect(recall["effective_mode"]?.stringValue == "text")
+    }
+}


### PR DESCRIPTION
## Summary
- When recall mode is omitted, identifiers and quoted phrases go to text-only search with no embedding. Explicit hybrid/vector stay as requested.
- Rank exact token-boundary matches ahead of prefixes/substrings, while keeping #166 hyphen/underscore glue.
- Rebased onto `main` after #169.
- Omitted-mode hybrid coverage tests use ordinary prose, not identifier canaries.

## Test plan
- [x] `swift test --filter ExactIntentRoutingTests`
- [x] `swift test --filter QueryClassifierTests`
- [x] `swift test --filter UniqueTokenRankingTests`
- [x] `swift test --traits MCPServer --filter defaultRecallUsesHybridWhenVectorCoverageIsPartial`
- [ ] CI gates on `2c656eabb`