### PR TITLE
fix(maintenance): harden copy-first store repair and vector health

### DIFF
--- a/Resources/website/docs/core/file-format.md
+++ b/Resources/website/docs/core/file-format.md
@@ -15,7 +15,7 @@ Offset          Region              Size
 ──────          ──────              ────
 0 KiB           Header Page A       4 KiB
 4 KiB           Header Page B       4 KiB
-8 KiB           WAL Ring Buffer     Configurable (default 8 MiB)
+8 KiB           WAL Ring Buffer     Configurable (new-store default 8 MiB)
 WAL + 8 KiB     Frame Payloads      Variable
 After Payloads  TOC                 Variable
 After TOC       Footer              64 bytes
@@ -121,7 +121,9 @@ Frame payloads support four encoding strategies via `CanonicalEncoding`:
 | Header region (A+B) | 8 KiB |
 | Footer size | 64 bytes |
 | WAL record header | 48 bytes |
-| Default WAL size | 8 MiB |
+| Default WAL size for new stores | 8 MiB |
+| Broker session WAL size | 4 MiB |
+| Legacy long-term WAL size | 256 MiB (retained until copy-first compaction) |
 | Max string bytes | 16 MiB |
 | Max blob bytes | 256 MiB |
 | Max array count | 10,000,000 |

--- a/Resources/website/docs/core/wal-crash-recovery.md
+++ b/Resources/website/docs/core/wal-crash-recovery.md
@@ -16,7 +16,7 @@ The WAL (Write-Ahead Log) is a fixed-size circular ring buffer that records all 
 
 ## Ring Buffer Architecture
 
-The WAL occupies a contiguous region starting at file offset 8 KiB. Its default size is 8 MiB, configurable at creation time. The ring buffer uses two pointers:
+The WAL occupies a contiguous region starting at file offset 8 KiB. New long-term stores use an 8 MiB WAL by default, configurable at creation time. Broker session stores use a 4 MiB WAL. Existing stores retain their recorded size when opened; a copy-first compaction can reclaim a legacy 256 MiB ring. The ring buffer uses two pointers:
 
 - **Write position** — where the next record will be written
 - **Checkpoint position** — the boundary of committed records

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1357,6 +1357,13 @@ package actor MemoryOrchestrator {
         )
     }
 
+    /// Select a real live searchable frame for operator health canaries. The
+    /// caller can then constrain the vector query to this ID instead of
+    /// validating a synthetic temporary store.
+    package func healthCanaryFrame() async -> SurrogateSourceFrame? {
+        await wax.activeSurrogateSourceFrames().first
+    }
+
     /// True when query embedding can run now (``.active`` / ``.degraded``).
     package func isQueryEmbedderReady() async -> Bool {
         embeddingStatus.isQueryEmbedderConfigured

--- a/Sources/WaxCLI/VectorHealthCommand.swift
+++ b/Sources/WaxCLI/VectorHealthCommand.swift
@@ -42,6 +42,7 @@ struct VectorHealthCommand: AsyncParsableCommand {
                     "passed": primary.canary.passed,
                     "vectorSourceSeen": primary.canary.vectorSourceSeen,
                     "expectedDocMatched": primary.canary.expectedDocMatched,
+                    "canaryFrameId": primary.canary.frameId ?? NSNull(),
                     "topPreview": primary.canary.topPreview,
                     "topSources": primary.canary.topSources,
                     "queryEmbeddingState": primary.canary.queryEmbeddingState.rawValue,
@@ -94,6 +95,7 @@ private extension VectorHealthCommand {
         let topSources: [String]
         let queryEmbeddingState: RAGContext.QueryEmbeddingState
         let effectiveMode: SearchMode
+        let frameId: UInt64?
     }
 
     func checkPrimaryStore() async throws -> PrimaryStoreCheck {
@@ -107,19 +109,25 @@ private extension VectorHealthCommand {
             requireVector: true
         ) { memory in
             let stats = await memory.runtimeStats()
+            let canaryFrame = await memory.healthCanaryFrame()
+            let canaryQuery = canaryFrame?.searchText ?? "wax vector health canary"
+            let canaryFilter = canaryFrame.map { FrameFilter(frameIds: Set([$0.id])) }
             let execution = try await memory.searchExecution(
-                query: "wax vector health canary",
+                query: canaryQuery,
                 mode: .vectorOnly,
-                topK: 5,
-                frameFilter: nil,
+                topK: 1,
+                frameFilter: canaryFilter,
                 timeRange: nil
             )
             let vectorSourceSeen = execution.hits.contains { $0.sources.contains(.vector) }
+            let expectedDocMatched = canaryFrame == nil || execution.hits.contains {
+                $0.frameId == canaryFrame?.id
+            }
             let canaryPassed = execution.effectiveMode == .vectorOnly
                 && execution.queryEmbeddingState == .available
-                // An empty store has no frame to return, but the actual target
-                // query still proves the provider and vector engine are live.
-                && (stats.frameCount == 0 || vectorSourceSeen)
+                // A store without a live searchable frame has no frame to
+                // match, but the target query still proves the engine/provider.
+                && (canaryFrame == nil || (vectorSourceSeen && expectedDocMatched))
             return PrimaryStoreCheck(
                 path: stats.storeURL.path,
                 vectorSearchEnabled: stats.vectorSearchEnabled,
@@ -129,11 +137,12 @@ private extension VectorHealthCommand {
                 canary: SemanticProbeResult(
                     passed: canaryPassed,
                     vectorSourceSeen: vectorSourceSeen,
-                    expectedDocMatched: !execution.hits.isEmpty,
+                    expectedDocMatched: expectedDocMatched,
                     topPreview: execution.hits.first?.previewText ?? "",
                     topSources: (execution.hits.first?.sources ?? []).map(\.rawValue),
                     queryEmbeddingState: execution.queryEmbeddingState,
-                    effectiveMode: execution.effectiveMode
+                    effectiveMode: execution.effectiveMode,
+                    frameId: canaryFrame?.id,
                 )
             )
         }

--- a/Sources/WaxCLI/VectorHealthCommand.swift
+++ b/Sources/WaxCLI/VectorHealthCommand.swift
@@ -41,7 +41,7 @@ struct VectorHealthCommand: AsyncParsableCommand {
                 "semanticProbe": [
                     "passed": primary.canary.passed,
                     "vectorSourceSeen": primary.canary.vectorSourceSeen,
-                    "expectedDocMatched": primary.canary.expectedDocMatched,
+                    "expectedDocMatched": primary.canary.expectedDocMatched ?? NSNull(),
                     "canaryFrameId": primary.canary.frameId ?? NSNull(),
                     "topPreview": primary.canary.topPreview,
                     "topSources": primary.canary.topSources,
@@ -90,7 +90,7 @@ private extension VectorHealthCommand {
     struct SemanticProbeResult {
         let passed: Bool
         let vectorSourceSeen: Bool
-        let expectedDocMatched: Bool
+        let expectedDocMatched: Bool?
         let topPreview: String
         let topSources: [String]
         let queryEmbeddingState: RAGContext.QueryEmbeddingState
@@ -120,14 +120,14 @@ private extension VectorHealthCommand {
                 timeRange: nil
             )
             let vectorSourceSeen = execution.hits.contains { $0.sources.contains(.vector) }
-            let expectedDocMatched = canaryFrame == nil || execution.hits.contains {
-                $0.frameId == canaryFrame?.id
+            let expectedDocMatched = canaryFrame.map { frame in
+                execution.hits.contains { $0.frameId == frame.id }
             }
             let canaryPassed = execution.effectiveMode == .vectorOnly
                 && execution.queryEmbeddingState == .available
                 // A store without a live searchable frame has no frame to
                 // match, but the target query still proves the engine/provider.
-                && (canaryFrame == nil || (vectorSourceSeen && expectedDocMatched))
+                && (canaryFrame == nil || (vectorSourceSeen && expectedDocMatched == true))
             return PrimaryStoreCheck(
                 path: stats.storeURL.path,
                 vectorSearchEnabled: stats.vectorSearchEnabled,

--- a/Sources/WaxCLI/VectorHealthCommand.swift
+++ b/Sources/WaxCLI/VectorHealthCommand.swift
@@ -5,15 +5,17 @@ import Wax
 struct VectorHealthCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vector-health",
-        abstract: "Verify MiniLM vector search health with a semantic probe"
+        abstract: "Verify vector search health against the target store"
     )
 
     @OptionGroup var store: VectorStoreOptions
 
     func runAsync() async throws {
         let primary = try await checkPrimaryStore()
-        let probe = try await runSemanticProbe()
-        let healthy = primary.vectorSearchEnabled && primary.embedderIdentity != nil && probe.passed
+        let healthy = primary.vectorSearchEnabled
+            && primary.embedderIdentity != nil
+            && primary.framesWithoutVectors == 0
+            && primary.canary.passed
 
         switch store.format {
         case .json:
@@ -32,20 +34,26 @@ struct VectorHealthCommand: AsyncParsableCommand {
                 "primaryStore": [
                     "path": primary.path,
                     "vectorSearchEnabled": primary.vectorSearchEnabled,
+                    "frameCount": primary.frameCount,
+                    "framesWithoutVectors": primary.framesWithoutVectors,
                     "embedder": embedder,
                 ],
                 "semanticProbe": [
-                    "passed": probe.passed,
-                    "vectorSourceSeen": probe.vectorSourceSeen,
-                    "expectedDocMatched": probe.expectedDocMatched,
-                    "topPreview": probe.topPreview,
-                    "topSources": probe.topSources,
+                    "passed": primary.canary.passed,
+                    "vectorSourceSeen": primary.canary.vectorSourceSeen,
+                    "expectedDocMatched": primary.canary.expectedDocMatched,
+                    "topPreview": primary.canary.topPreview,
+                    "topSources": primary.canary.topSources,
+                    "queryEmbeddingState": primary.canary.queryEmbeddingState.rawValue,
+                    "effectiveMode": primary.canary.effectiveMode.diagnosticsSummary,
+                    "targetStore": true,
                 ],
             ])
         case .text:
             print("Vector health: \(healthy ? "PASS" : "FAIL")")
             print("Store: \(primary.path)")
             print("Vector search: \(primary.vectorSearchEnabled ? "enabled" : "disabled")")
+            print("Frames without vectors: \(primary.framesWithoutVectors)")
             if let identity = primary.embedderIdentity {
                 let provider = identity.provider ?? "unknown"
                 let model = identity.model ?? "unknown"
@@ -54,11 +62,11 @@ struct VectorHealthCommand: AsyncParsableCommand {
             } else {
                 print("Embedder: none")
             }
-            print("Semantic probe: \(probe.passed ? "PASS" : "FAIL")")
-            print("Probe vector source seen: \(probe.vectorSourceSeen ? "yes" : "no")")
-            print("Probe expected doc matched: \(probe.expectedDocMatched ? "yes" : "no")")
-            if !probe.topPreview.isEmpty {
-                print("Probe top preview: \(probe.topPreview)")
+            print("Primary-store canary: \(primary.canary.passed ? "PASS" : "FAIL")")
+            print("Canary vector source seen: \(primary.canary.vectorSourceSeen ? "yes" : "no")")
+            print("Canary query embedding: \(primary.canary.queryEmbeddingState.rawValue)")
+            if !primary.canary.topPreview.isEmpty {
+                print("Canary top preview: \(primary.canary.topPreview)")
             }
         }
 
@@ -73,6 +81,9 @@ private extension VectorHealthCommand {
         let path: String
         let vectorSearchEnabled: Bool
         let embedderIdentity: EmbeddingIdentity?
+        let frameCount: UInt64
+        let framesWithoutVectors: UInt64
+        let canary: SemanticProbeResult
     }
 
     struct SemanticProbeResult {
@@ -81,6 +92,8 @@ private extension VectorHealthCommand {
         let expectedDocMatched: Bool
         let topPreview: String
         let topSources: [String]
+        let queryEmbeddingState: RAGContext.QueryEmbeddingState
+        let effectiveMode: SearchMode
     }
 
     func checkPrimaryStore() async throws -> PrimaryStoreCheck {
@@ -94,56 +107,34 @@ private extension VectorHealthCommand {
             requireVector: true
         ) { memory in
             let stats = await memory.runtimeStats()
+            let execution = try await memory.searchExecution(
+                query: "wax vector health canary",
+                mode: .vectorOnly,
+                topK: 5,
+                frameFilter: nil,
+                timeRange: nil
+            )
+            let vectorSourceSeen = execution.hits.contains { $0.sources.contains(.vector) }
+            let canaryPassed = execution.effectiveMode == .vectorOnly
+                && execution.queryEmbeddingState == .available
+                // An empty store has no frame to return, but the actual target
+                // query still proves the provider and vector engine are live.
+                && (stats.frameCount == 0 || vectorSourceSeen)
             return PrimaryStoreCheck(
                 path: stats.storeURL.path,
                 vectorSearchEnabled: stats.vectorSearchEnabled,
-                embedderIdentity: stats.embedderIdentity
-            )
-        }
-    }
-
-    func runSemanticProbe() async throws -> SemanticProbeResult {
-        let probeURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("wax-vector-health-\(UUID().uuidString).wax")
-        defer {
-            try? FileManager.default.removeItem(at: probeURL)
-        }
-        return try await StoreSession.withOpen(
-            at: probeURL,
-            noEmbedder: store.noEmbedder,
-            embedderChoice: store.embedder,
-            embedderTuning: store.embedderTuning,
-            requireVector: true
-        ) { memory in
-            let expectedDocument = "An automobile needs periodic maintenance and tire rotation."
-            try await memory.remember(expectedDocument, metadata: ["probe": "vector-health"])
-            try await memory.remember(
-                "Bananas are a tropical fruit often eaten in smoothies.",
-                metadata: ["probe": "vector-health"]
-            )
-            try await memory.flush()
-
-            let hits = try await memory.search(
-                query: "car service",
-                mode: .hybrid(alpha: 0.5),
-                topK: 3,
-                frameFilter: nil
-            )
-
-            let topHit = hits.first
-            let vectorSourceSeen = hits.contains(where: { $0.sources.contains(.vector) })
-            let expectedDocMatched = hits.contains {
-                ($0.previewText ?? "").localizedCaseInsensitiveContains("automobile")
-            }
-            let topPreview = topHit?.previewText ?? ""
-            let topSources = (topHit?.sources ?? []).map(\.rawValue)
-
-            return SemanticProbeResult(
-                passed: vectorSourceSeen && expectedDocMatched,
-                vectorSourceSeen: vectorSourceSeen,
-                expectedDocMatched: expectedDocMatched,
-                topPreview: topPreview,
-                topSources: topSources
+                embedderIdentity: stats.embedderIdentity,
+                frameCount: stats.frameCount,
+                framesWithoutVectors: stats.framesWithoutVectors,
+                canary: SemanticProbeResult(
+                    passed: canaryPassed,
+                    vectorSourceSeen: vectorSourceSeen,
+                    expectedDocMatched: !execution.hits.isEmpty,
+                    topPreview: execution.hits.first?.previewText ?? "",
+                    topSources: (execution.hits.first?.sources ?? []).map(\.rawValue),
+                    queryEmbeddingState: execution.queryEmbeddingState,
+                    effectiveMode: execution.effectiveMode
+                )
             )
         }
     }

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -26,6 +26,8 @@ struct WaxCLI: ParsableCommand {
             CompactStoreCommand.self,
             EmbedBackfillCommand.self,
             VectorHealthCommand.self,
+            CompactStoreCommand.self,
+            EmbedBackfillCommand.self,
             FlushCommand.self,
             SessionStartCommand.self,
             SessionResumeCommand.self,

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -26,8 +26,6 @@ struct WaxCLI: ParsableCommand {
             CompactStoreCommand.self,
             EmbedBackfillCommand.self,
             VectorHealthCommand.self,
-            CompactStoreCommand.self,
-            EmbedBackfillCommand.self,
             FlushCommand.self,
             SessionStartCommand.self,
             SessionResumeCommand.self,

--- a/Sources/WaxCore/WaxCore.docc/Articles/FileFormat.md
+++ b/Sources/WaxCore/WaxCore.docc/Articles/FileFormat.md
@@ -11,7 +11,7 @@ Offset          Region              Size
 ──────          ──────              ────
 0 KiB           Header Page A       4 KiB
 4 KiB           Header Page B       4 KiB
-8 KiB           WAL Ring Buffer     Configurable (default 8 MiB)
+8 KiB           WAL Ring Buffer     Configurable (new-store default 8 MiB)
 WAL + 8 KiB     Frame Payloads      Variable
 After Payloads  TOC                 Variable
 After TOC       Footer              64 bytes
@@ -117,7 +117,9 @@ Frame payloads support four encoding strategies via ``CanonicalEncoding``:
 | Header region (A+B) | 8 KiB |
 | Footer size | 64 bytes |
 | WAL record header | 48 bytes |
-| Default WAL size | 8 MiB |
+| Default WAL size for new stores | 8 MiB |
+| Broker session WAL size | 4 MiB |
+| Legacy long-term WAL size | 256 MiB (retained until copy-first compaction) |
 | Max string bytes | 16 MiB |
 | Max blob bytes | 256 MiB |
 | Max array count | 10,000,000 |

--- a/Sources/WaxCore/WaxCore.docc/Articles/WALAndCrashRecovery.md
+++ b/Sources/WaxCore/WaxCore.docc/Articles/WALAndCrashRecovery.md
@@ -12,7 +12,7 @@ The WAL (Write-Ahead Log) is a fixed-size circular ring buffer that records all 
 
 ## Ring Buffer Architecture
 
-The WAL occupies a contiguous region starting at file offset 8 KiB. Its default size is 8 MiB, configurable at creation time. The ring buffer uses two pointers:
+The WAL occupies a contiguous region starting at file offset 8 KiB. New long-term stores use an 8 MiB WAL by default, configurable at creation time. Broker session stores use a 4 MiB WAL. Existing stores retain their recorded size when opened; a copy-first compaction can reclaim a legacy 256 MiB ring. The ring buffer uses two pointers:
 
 - **Write position** — where the next record will be written
 - **Checkpoint position** — the boundary of committed records

--- a/Tests/WaxCLITests/CompactStoreCommandTests.swift
+++ b/Tests/WaxCLITests/CompactStoreCommandTests.swift
@@ -89,8 +89,8 @@ struct CompactStoreCommandTests {
 
         let dest = try await Wax.open(at: destURL)
         let destWal = await dest.walStats()
-        // Shipped rewriteLiveSet automatic dest for a 256 MiB source with small
-        // payload is sessionWalSize. Constants.longTermWalSize is not on this line.
+        // Shipped rewriteLiveSet keeps a small-payload destination at
+        // sessionWalSize; Constants.longTermWalSize is not on this line.
         #expect(destWal.walSize == Constants.sessionWalSize)
         try await dest.verify(deep: true)
         try await dest.close()

--- a/Tests/WaxCLITests/StoreRepairCommandTests.swift
+++ b/Tests/WaxCLITests/StoreRepairCommandTests.swift
@@ -75,6 +75,70 @@ struct StoreRepairCommandTests {
     }
 
     @Test
+    func maintenanceCommandsRejectDirectoryOutputsAndLockedDestinations() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-destination-guards-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("source.wax")
+        let directory = root.appendingPathComponent("output-directory", isDirectory: true)
+        let destination = root.appendingPathComponent("output.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let sourceStore = try await Wax.create(at: source)
+        try await sourceStore.close()
+
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--no-embedder",
+                "--store-path", source.path,
+                "--output", directory.path,
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", source.path,
+                "--output", directory.path,
+            ])
+        }
+
+        FileManager.default.createFile(atPath: destination.path, contents: Data("old output".utf8))
+        let held = try FileLock.acquire(at: destination, mode: .exclusive, timeout: .seconds(1))
+        defer { try? held.release() }
+
+        let compact = try CompactStoreCommand.parse([
+            "--direct-store",
+            "--no-embedder",
+            "--overwrite",
+            "--store-path", source.path,
+            "--output", destination.path,
+        ])
+        do {
+            try await compact.runAsync()
+            Issue.record("compact-store must fail before replacing a locked output")
+        } catch let error as CLIError {
+            #expect(error.message.contains("locked"))
+        }
+
+        try held.release()
+        let embedBackfill = try EmbedBackfillCommand.parse([
+            "--direct-store",
+            "--overwrite",
+            "--store-path", source.path,
+            "--output", destination.path,
+        ])
+        let heldAgain = try FileLock.acquire(at: destination, mode: .exclusive, timeout: .seconds(1))
+        defer { try? heldAgain.release() }
+        do {
+            try await embedBackfill.runAsync()
+            Issue.record("embed-backfill must fail before replacing a locked output")
+        } catch let error as CLIError {
+            #expect(error.message.contains("locked"))
+        }
+    }
+
+    @Test
     func compactStorePreservesSourceAndDeepVerifiesReopenedDestination() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("wax-repair-compact-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/WaxCLITests/StoreRepairCommandTests.swift
+++ b/Tests/WaxCLITests/StoreRepairCommandTests.swift
@@ -210,5 +210,24 @@ struct StoreRepairCommandTests {
         ])
         try await command.runAsync()
     }
+
+    @Test
+    func vectorHealthEmptyStoreDoesNotClaimDocumentMatch() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-health-empty-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("target.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let store = try await Wax.create(at: source)
+        try await store.close()
+
+        let command = try VectorHealthCommand.parse([
+            "--direct-store",
+            "--store-path", source.path,
+            "--format", "json",
+        ])
+        try await command.runAsync()
+    }
 #endif
 }

--- a/Tests/WaxCLITests/StoreRepairCommandTests.swift
+++ b/Tests/WaxCLITests/StoreRepairCommandTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+import Wax
+import WaxCore
+@testable import wax_cli
+
+@Suite("Store repair commands", .serialized)
+struct StoreRepairCommandTests {
+    @Test
+    func maintenanceCommandsRequireDirectStoreAndOutput() throws {
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--store-path", "/tmp/wax-repair-source.wax",
+                "--output", "/tmp/wax-repair-destination.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", "/tmp/wax-repair-source.wax",
+            ])
+        }
+    }
+
+    @Test
+    func maintenanceCommandsRefuseLiveFamilyAndAliases() throws {
+        #expect(throws: (any Error).self) {
+            _ = try CompactStoreCommand.parse([
+                "--direct-store",
+                "--store-path", "~/.wax/memory.wax",
+                "--output", "/tmp/wax-repair-destination.wax",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try EmbedBackfillCommand.parse([
+                "--direct-store",
+                "--store-path", "/tmp/wax-repair-source.wax",
+                "--output", "~/.wax/memory.wax",
+            ])
+        }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-alias-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("source.wax")
+        let symlink = root.appendingPathComponent("source-link.wax")
+        let hardlink = root.appendingPathComponent("source-hardlink.wax")
+        let target = root.appendingPathComponent("target.wax")
+        let targetLink = root.appendingPathComponent("target-link.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: source.path, contents: Data("source".utf8))
+        FileManager.default.createFile(atPath: target.path, contents: Data("target".utf8))
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: source)
+        try FileManager.default.createSymbolicLink(at: targetLink, withDestinationURL: target)
+        try FileManager.default.linkItem(at: source, to: hardlink)
+
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.validate(source: symlink, destination: root.appendingPathComponent("out.wax"), command: "compact-store")
+        }
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.validate(source: source, destination: symlink, command: "compact-store")
+        }
+        #expect(throws: (any Error).self) {
+            try StoreRepairSupport.validate(source: source, destination: hardlink, command: "compact-store")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try StoreRepairSupport.copySource(from: source, to: targetLink, overwrite: true)
+        }
+        #expect(try Data(contentsOf: target) == Data("target".utf8))
+
+        let nestedOutput = root.appendingPathComponent("nested/output.wax")
+        let resolvedOutput = try StoreRepairSupport.destinationURL(from: nestedOutput.path)
+        #expect(resolvedOutput == nestedOutput.standardizedFileURL)
+        #expect(FileManager.default.fileExists(atPath: nestedOutput.deletingLastPathComponent().path))
+    }
+
+    @Test
+    func compactStorePreservesSourceAndDeepVerifiesReopenedDestination() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-compact-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("source.wax")
+        let destination = root.appendingPathComponent("destination.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let original = try await Wax.create(at: source)
+        for index in 0..<4 {
+            _ = try await original.put(
+                Data("repair payload \(index)".utf8),
+                options: FrameMetaSubset(searchText: "repair payload \(index)")
+            )
+        }
+        try await original.commit()
+        try await original.close()
+
+        let sourceBefore = try StoreRepairSupport.fingerprint(of: source)
+        let command = try CompactStoreCommand.parse([
+            "--direct-store",
+            "--no-embedder",
+            "--store-path", source.path,
+            "--output", destination.path,
+            "--format", "json",
+        ])
+        try await command.runAsync()
+
+        #expect(try StoreRepairSupport.fingerprint(of: source) == sourceBefore)
+        let destinationWal = try await StoreRepairSupport.verifyDeep(at: destination)
+        #expect(destinationWal.walSize >= Constants.sessionWalSize)
+        let reopened = try await Wax.open(at: destination)
+        let frames = await reopened.frameMetas()
+        #expect(frames.filter { $0.status == .active && $0.supersededBy == nil }.count == 4)
+        try await reopened.close()
+
+        let overwriteCommand = try CompactStoreCommand.parse([
+            "--direct-store",
+            "--no-embedder",
+            "--overwrite",
+            "--store-path", source.path,
+            "--output", destination.path,
+            "--format", "json",
+        ])
+        try await overwriteCommand.runAsync()
+        let reopenedAfterOverwrite = try await Wax.open(at: destination)
+        try await reopenedAfterOverwrite.verify(deep: true)
+        try await reopenedAfterOverwrite.close()
+    }
+
+#if canImport(CoreML)
+    @Test
+    func vectorHealthUsesARealPrimaryStoreCanary() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-repair-health-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("target.wax")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let memory = try await StoreSession.open(at: source, requireVector: true)
+        try await memory.remember("target store canary for actual vector health")
+        try await memory.flush()
+        try await memory.close()
+
+        let command = try VectorHealthCommand.parse([
+            "--direct-store",
+            "--store-path", source.path,
+            "--format", "json",
+        ])
+        try await command.runAsync()
+    }
+#endif
+}

--- a/Tests/WaxTests/WaxCLISurfaceParityTests.swift
+++ b/Tests/WaxTests/WaxCLISurfaceParityTests.swift
@@ -27,6 +27,16 @@ import Testing
     for command in requiredCommands {
         #expect(source.contains(command), "Missing CLI broker parity command \(command)")
     }
+
+    for command in ["CompactStoreCommand.self", "EmbedBackfillCommand.self"] {
+        let registrations = source
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { $0.trimmingCharacters(in: .whitespaces) == "\(command)," }
+        #expect(
+            registrations.count == 1,
+            "CLI must register \(command) exactly once, found \(registrations.count)"
+        )
+    }
 }
 
 @Test func waxCLIExposesLinuxDemoCommand() throws {

--- a/Tests/WaxTests/WaxCLISurfaceParityTests.swift
+++ b/Tests/WaxTests/WaxCLISurfaceParityTests.swift
@@ -20,6 +20,8 @@ import Testing
         "CorpusSearchCommand.self",
         "MarkdownExportCommand.self",
         "MarkdownSyncCommand.self",
+        "CompactStoreCommand.self",
+        "EmbedBackfillCommand.self",
     ]
 
     for command in requiredCommands {


### PR DESCRIPTION
## Summary
- Repair commands stay copy-first: reject directories/aliases, verify identity, and pin rollback backups before replacing a destination.
- `vector-health` now canaries a real live frame instead of a disposable probe store.
- Batch oversized rewrites so metadata-heavy stores do not blow the destination WAL.
- Rebased onto `main` after #169. Duplicate `CompactStore` / `EmbedBackfill` CLI registrations from the stack are removed.
- This is the code path for live-store repair; it does not mutate the operator store.

## Test plan
- [x] `swift test --filter StoreRepairCommandTests`
- [x] `swift test --filter rewriteLiveSet`
- [x] `swift test --filter backfillUnembedded`
- [x] Confirm `--overwrite` refuses an existing directory and an active destination lock
- [ ] CI gates on `f8ba4dc1d`