### PR TITLE
refactor(broker): extract Compact assembly from compact_context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,11 +22,15 @@ _Avoid_: query planning in the text engine; calling this RetrievalMode; FTS5Sear
 
 **Recall assembly**:
 Builds RAGContext from already-ranked hits (token budget, expansion, surrogates). May reorder for an answer budget. Does not rewrite Ranking's published score.
-_Avoid_: treating Memory.search as Ranking’s test surface; broker multi-horizon merge (that is Layered recall)
+_Avoid_: treating Memory.search as Ranking’s test surface; broker multi-horizon merge (that is Layered recall); compact three-bucket packing (that is Compact assembly)
 
 **Layered recall**:
-Broker read path that owns scope/identity resolution, fetches from the virtual session store and/or long-term Memory, merges hits, and applies project/repo filters. Horizon flags (working / episodic / durable) are how it interprets a resolved scope—not a second policy language. Callers pass a structured request after coercing tool args; Layered recall owns what those fields mean. Feeds tools such as recall and layered search. Does not own Ranking's published score, Recall assembly's token packing, MCP payloads, or session rebind/hit recording.
-_Avoid_: Broker recall; Horizon recall; treating MCP tool names as the module name; splitting recall scope enums from layered horizon flags; putting AgentBrokerValue parsing inside Layered recall
+Broker read path that owns scope/identity resolution, fetches from the virtual session store and/or long-term Memory, merges hits, and applies project/repo filters. Horizon flags (working / episodic / durable) are how it interprets a resolved scope—not a second policy language. Callers pass a structured request after coercing tool args; Layered recall owns what those fields mean. Feeds recall, layered search, and Compact assembly. Does not own Ranking's published score, Recall assembly's token packing, Compact assembly's packing, MCP payloads, or session rebind/hit recording.
+_Avoid_: Broker recall; Horizon recall; treating MCP tool names as the module name; splitting recall scope enums from layered horizon flags; putting AgentBrokerValue parsing inside Layered recall; compact packing
+
+**Compact assembly**:
+Budgeted packing of already-fetched Layered recall hits into short/medium/long buckets (working / episodic / durable). Relies on Layered recall for fetch, project filter, and the working-lane empty fallback. Fetch top-K stays compact-sized; project-scope overfetch is recall-only. Does not flush, checkpoint, or render MCP payloads.
+_Avoid_: Compact context (the tool name); treating this as Recall assembly; folding packing into Layered recall; putting fetch or project filter here; inflating compact fetch top-K
 
 **Long-term Memory**:
 The store the broker keeps across virtual sessions. Distinct from a virtual session store.

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -316,15 +316,6 @@ extension AgentBrokerService {
     typealias LayeredMemoryHit = LayeredRecall.Hit
     typealias MemoryReference = LayeredRecall.MemoryReference
 
-    struct CompactContextAssembly {
-        var short: [LayeredMemoryHit]
-        var medium: [LayeredMemoryHit]
-        var long: [LayeredMemoryHit]
-        var compactedText: String
-        var summary: String
-        var usedTokens: Int
-    }
-
     struct MarkdownProjectionReport {
         var memoryMarkdownPath: String
         var dailyNotePaths: [String]
@@ -1707,12 +1698,21 @@ extension AgentBrokerService {
             try await refreshSessionManifest(sessionID)
         }
         try await longTermMemory.flush()
-        let assembled = try await assembleCompactContext(
-            query: query,
-            sessionID: sessionID,
-            mode: mode,
-            tokenBudget: tokenBudget,
-            maxItems: maxItems
+        let counter = try await TokenCounter.shared()
+        let tokenizer = CompactAssembly.Tokenizer(
+            count: { text in await counter.count(text) },
+            truncate: { text, maxTokens in await counter.truncate(text, maxTokens: maxTokens) }
+        )
+        let assembled = try await CompactAssembly.assemble(
+            request: CompactAssembly.Request(
+                query: query,
+                sessionID: sessionID,
+                mode: mode,
+                tokenBudget: tokenBudget,
+                maxItems: maxItems
+            ),
+            stores: layeredRecallStores(),
+            tokenizer: tokenizer
         )
         if let sessionID {
             try await recordCheckpoint(
@@ -1721,11 +1721,11 @@ extension AgentBrokerService {
                 compactedText: assembled.compactedText
             )
         }
-        for hit in assembled.short {
+        for hit in assembled.short + assembled.medium + assembled.long {
             if hit.horizon == .durable {
                 await longTermMemory.recordAccess(frameId: hit.frameID)
             } else if let sessionID = hit.sessionID, let session = activeSessions[sessionID] {
-                await session.memory.recordAccess(frameId: hit.frameID)
+                await session.memory.recordAccess(frameId: hit.sessionID)
             }
         }
         return .object([
@@ -2323,6 +2323,53 @@ extension AgentBrokerService {
                 }
                 return laneHits
             },
+            recallEndedSession: { manifest, query, mode, topK, frameFilter in
+                let sessionURL = URL(fileURLWithPath: manifest.storePath)
+                return try await self.openAdhocMemory(
+                    at: sessionURL,
+                    structuredMemoryEnabled: false,
+                    noEmbedder: noEmbedderFlag
+                ) { memory in
+                    let items = try await memory.recallExecution(
+                        query: query,
+                        mode: mode,
+                        frameFilter: frameFilter,
+                        timeRange: nil,
+                        topK: topK
+                    ).context.items
+                    var hits: [LayeredRecall.Hit] = []
+                    hits.reserveCapacity(items.count)
+                    for item in items {
+                        let canonicalFrameID = await self.bestEffortCanonicalDocumentFrameID(
+                            for: item.frameId,
+                            memory: memory
+                        ) ?? item.frameId
+                        hits.append(
+                            LayeredRecall.Hit(
+                                reference: LayeredRecall.makeMemoryReference(
+                                    .episodic,
+                                    sessionID: manifest.sessionID,
+                                    frameID: canonicalFrameID
+                                ),
+                                horizon: .episodic,
+                                sessionID: manifest.sessionID,
+                                agentID: manifest.agentID,
+                                runID: manifest.runID,
+                                frameID: canonicalFrameID,
+                                score: item.score,
+                                text: item.text,
+                                preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
+                                metadata: item.metadata,
+                                explanations: ["recent session episode"] + item.explanations,
+                                timestampMs: manifest.updatedAtMs,
+                                kind: "\(item.kind)",
+                                sources: item.sources.map(\.rawValue)
+                            )
+                        )
+                    }
+                    return hits
+                }
+            },
             nowMs: { Self.nowMs() }
         )
     }
@@ -2379,226 +2426,6 @@ extension AgentBrokerService {
                 body: loader
             )
         }
-    }
-
-    func assembleCompactContext(
-        query: String,
-        sessionID: UUID?,
-        mode: Memory.RetrievalMode,
-        tokenBudget: Int,
-        maxItems: Int
-    ) async throws -> CompactContextAssembly {
-        let counter = try await TokenCounter.shared()
-        var short: [LayeredMemoryHit] = []
-        var medium: [LayeredMemoryHit] = []
-        var long: [LayeredMemoryHit] = []
-
-        if let sessionID, let state = activeSessions[sessionID] {
-            let execution = try await state.memory.recallExecution(
-                query: query,
-                mode: mode,
-                frameFilter: nil,
-                timeRange: nil,
-                topK: min(4, maxItems)
-            )
-            for item in execution.context.items {
-                let canonicalFrameID = try await canonicalDocumentFrameID(for: item.frameId, memory: state.memory)
-                short.append(LayeredMemoryHit(
-                    reference: Self.makeMemoryReference(.working, sessionID: sessionID, frameID: canonicalFrameID),
-                    horizon: .working,
-                    sessionID: sessionID,
-                    agentID: state.manifest.agentID,
-                    runID: state.manifest.runID,
-                    frameID: canonicalFrameID,
-                    score: item.score,
-                    text: item.text,
-                    preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
-                    metadata: item.metadata,
-                    explanations: ["current session"] + item.explanations,
-                    timestampMs: state.manifest.updatedAtMs
-                ))
-            }
-            if short.isEmpty {
-                let documents = try await state.memory.corpusSourceDocuments()
-                    .sorted { lhs, rhs in
-                        if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
-                        return lhs.frameId > rhs.frameId
-                    }
-                for document in documents.prefix(min(4, maxItems)) {
-                    short.append(LayeredMemoryHit(
-                        reference: Self.makeMemoryReference(.working, sessionID: sessionID, frameID: document.frameId),
-                        horizon: .working,
-                        sessionID: sessionID,
-                        agentID: state.manifest.agentID,
-                        runID: state.manifest.runID,
-                        frameID: document.frameId,
-                        score: 0.2,
-                        text: document.text,
-                        preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
-                        metadata: document.metadata,
-                        explanations: ["current session", "recent session note"],
-                        timestampMs: document.timestampMs
-                    ))
-                }
-            }
-        }
-
-        let longExecution = try await longTermMemory.recallExecution(
-            query: query,
-            mode: mode,
-            frameFilter: nil,
-            timeRange: nil,
-            topK: min(4, maxItems)
-        )
-        for item in longExecution.context.items {
-            let canonicalFrameID = try await canonicalDocumentFrameID(for: item.frameId, memory: longTermMemory)
-            long.append(LayeredMemoryHit(
-                reference: Self.makeMemoryReference(.durable, sessionID: nil, frameID: canonicalFrameID),
-                horizon: .durable,
-                sessionID: nil,
-                agentID: nil,
-                runID: nil,
-                frameID: canonicalFrameID,
-                score: item.score,
-                text: item.text,
-                preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
-                metadata: item.metadata,
-                explanations: ["durable memory"] + item.explanations,
-                timestampMs: item.metadata[MemoryMetadataKeys.createdAtMs].flatMap(Int64.init) ?? 0
-            ))
-        }
-
-        let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
-        let selectedManifests = manifests
-            .filter { manifest in
-                if let sessionID, manifest.sessionID == sessionID { return false }
-                if let sessionID, let active = activeSessions[sessionID]?.manifest, manifest.agentID != active.agentID {
-                    return false
-                }
-                return manifest.status == .ended
-            }
-        for manifest in selectedManifests {
-            let episodicHits = try await openAdhocMemory(
-                at: URL(fileURLWithPath: manifest.storePath),
-                structuredMemoryEnabled: false,
-                noEmbedder: noEmbedder
-            ) { memory in
-                let items = try await memory.recallExecution(
-                    query: query,
-                    mode: mode,
-                    frameFilter: nil,
-                    timeRange: nil,
-                    topK: 2
-                ).context.items
-                var hits: [LayeredMemoryHit] = []
-                hits.reserveCapacity(items.count)
-                for item in items {
-                    let canonicalFrameID = try await self.canonicalDocumentFrameID(for: item.frameId, memory: memory)
-                    hits.append(LayeredMemoryHit(
-                        reference: Self.makeMemoryReference(.episodic, sessionID: manifest.sessionID, frameID: canonicalFrameID),
-                        horizon: .episodic,
-                        sessionID: manifest.sessionID,
-                        agentID: manifest.agentID,
-                        runID: manifest.runID,
-                        frameID: canonicalFrameID,
-                        score: item.score,
-                        text: item.text,
-                        preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
-                        metadata: item.metadata,
-                        explanations: ["recent session episode"] + item.explanations,
-                        timestampMs: manifest.updatedAtMs
-                    ))
-                }
-                return hits
-            }
-            medium.append(contentsOf: episodicHits)
-        }
-
-        short = Self.deduplicateLayeredHits(short)
-        medium = Self.deduplicateLayeredHits(medium).sorted {
-            if $0.score != $1.score { return $0.score > $1.score }
-            if $0.timestampMs != $1.timestampMs { return $0.timestampMs > $1.timestampMs }
-            return $0.reference < $1.reference
-        }
-        long = Self.deduplicateLayeredHits(long)
-
-        let ordered = Array((short.prefix(maxItems) + medium.prefix(maxItems) + long.prefix(maxItems)).prefix(maxItems * 3))
-        var selectedShort: [LayeredMemoryHit] = []
-        var selectedMedium: [LayeredMemoryHit] = []
-        var selectedLong: [LayeredMemoryHit] = []
-        var usedTokens = await counter.count(renderCompactedContext(
-            query: query,
-            short: selectedShort,
-            medium: selectedMedium,
-            long: selectedLong
-        ))
-
-        for hit in ordered {
-            var candidateShort = selectedShort
-            var candidateMedium = selectedMedium
-            var candidateLong = selectedLong
-            switch hit.horizon {
-            case .working:
-                candidateShort.append(hit)
-            case .episodic:
-                candidateMedium.append(hit)
-            case .durable:
-                candidateLong.append(hit)
-            }
-            let candidateText = renderCompactedContext(
-                query: query,
-                short: candidateShort,
-                medium: candidateMedium,
-                long: candidateLong
-            )
-            let candidateTokens = await counter.count(candidateText)
-            guard candidateTokens <= tokenBudget else { continue }
-            selectedShort = candidateShort
-            selectedMedium = candidateMedium
-            selectedLong = candidateLong
-            usedTokens = candidateTokens
-        }
-
-        var compactedText = renderCompactedContext(
-            query: query,
-            short: selectedShort,
-            medium: selectedMedium,
-            long: selectedLong
-        )
-        let renderedTokens = await counter.count(compactedText)
-        if renderedTokens > tokenBudget {
-            compactedText = await counter.truncate(compactedText, maxTokens: tokenBudget)
-            usedTokens = await counter.count(compactedText)
-        } else {
-            usedTokens = renderedTokens
-        }
-        let summary = [
-            selectedShort.first?.preview,
-            selectedMedium.first?.preview,
-            selectedLong.first?.preview,
-        ]
-        .compactMap { $0 }
-        .prefix(3)
-        .joined(separator: " | ")
-
-        return CompactContextAssembly(
-            short: selectedShort,
-            medium: selectedMedium,
-            long: selectedLong,
-            compactedText: compactedText,
-            summary: summary.isEmpty ? "No compacted context available." : summary,
-            usedTokens: usedTokens
-        )
-    }
-
-    static func deduplicateLayeredHits(_ hits: [LayeredMemoryHit]) -> [LayeredMemoryHit] {
-        var seen = Set<String>()
-        var deduped: [LayeredMemoryHit] = []
-        deduped.reserveCapacity(hits.count)
-        for hit in hits where seen.insert(hit.reference).inserted {
-            deduped.append(hit)
-        }
-        return deduped
     }
 
     func exportMarkdownProjection(
@@ -3224,30 +3051,6 @@ extension AgentBrokerService {
         }
     }
 
-    func renderCompactedContext(
-        query: String,
-        short: [LayeredMemoryHit],
-        medium: [LayeredMemoryHit],
-        long: [LayeredMemoryHit]
-    ) -> String {
-        var lines = ["Query: \(query)"]
-        func appendSection(_ title: String, _ hits: [LayeredMemoryHit]) {
-            guard !hits.isEmpty else { return }
-            lines.append("")
-            lines.append(title)
-            for hit in hits {
-                let reason = hit.explanations.prefix(2).joined(separator: ", ")
-                lines.append("- \(hit.preview)")
-                if !reason.isEmpty {
-                    lines.append("  why: \(reason)")
-                }
-            }
-        }
-        appendSection("Short-Term Context", short)
-        appendSection("Medium-Term Context", medium)
-        appendSection("Long-Term Context", long)
-        return lines.joined(separator: "\n")
-    }
 
     func renderMemoryMarkdown(documents: [MemoryOrchestrator.CorpusSourceDocument]) -> String {
         var sections: [MemoryType: [String]] = [:]

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1725,7 +1725,7 @@ extension AgentBrokerService {
             if hit.horizon == .durable {
                 await longTermMemory.recordAccess(frameId: hit.frameID)
             } else if let sessionID = hit.sessionID, let session = activeSessions[sessionID] {
-                await session.memory.recordAccess(frameId: hit.sessionID)
+                await session.memory.recordAccess(frameId: hit.frameID)
             }
         }
         return .object([

--- a/Sources/Wax/Broker/CompactAssembly.swift
+++ b/Sources/Wax/Broker/CompactAssembly.swift
@@ -1,0 +1,269 @@
+import Foundation
+import WaxCore
+
+/// Compact assembly: budgeted packing of Layered recall hits into short/medium/long buckets.
+/// Fetch, project filter, and the working-lane empty fallback stay in Layered recall.
+package enum CompactAssembly {
+    package struct Request: Sendable {
+        package var query: String
+        package var sessionID: UUID?
+        package var mode: Memory.RetrievalMode
+        package var tokenBudget: Int
+        package var maxItems: Int
+        package var scope: LayeredRecall.Scope
+        package var explicitProject: String?
+        package var explicitRepo: String?
+        package var clientCWD: String?
+        package var frameFilter: FrameFilter?
+        package var timeRange: SearchTimeRange?
+
+        package init(
+            query: String,
+            sessionID: UUID?,
+            mode: Memory.RetrievalMode,
+            tokenBudget: Int,
+            maxItems: Int,
+            scope: LayeredRecall.Scope = .project,
+            explicitProject: String? = nil,
+            explicitRepo: String? = nil,
+            clientCWD: String? = nil,
+            frameFilter: FrameFilter? = nil,
+            timeRange: SearchTimeRange? = nil
+        ) {
+            self.query = query
+            self.sessionID = sessionID
+            self.mode = mode
+            self.tokenBudget = tokenBudget
+            self.maxItems = maxItems
+            self.scope = scope
+            self.explicitProject = explicitProject
+            self.explicitRepo = explicitRepo
+            self.clientCWD = clientCWD
+            self.frameFilter = frameFilter
+            self.timeRange = timeRange
+        }
+    }
+
+    package struct Result: Sendable {
+        package var short: [LayeredRecall.Hit]
+        package var medium: [LayeredRecall.Hit]
+        package var long: [LayeredRecall.Hit]
+        package var compactedText: String
+        package var summary: String
+        package var usedTokens: Int
+    }
+
+    package struct Tokenizer: Sendable {
+        package var count: @Sendable (String) async -> Int
+        package var truncate: @Sendable (String, Int) async -> String
+
+        package init(
+            count: @escaping @Sendable (String) async -> Int,
+            truncate: @escaping @Sendable (String, Int) async -> String
+        ) {
+            self.count = count
+            self.truncate = truncate
+        }
+
+        /// Test adapter: one token per Character.
+        package static let character = Tokenizer(
+            count: { $0.count },
+            truncate: { text, maxTokens in
+                String(text.prefix(max(0, maxTokens)))
+            }
+        )
+    }
+
+    package static func fetchSearchTopK(maxItems: Int) -> Int {
+        max(1, min(4, maxItems))
+    }
+
+    package static func assemble(
+        request: Request,
+        stores: LayeredRecall.Stores,
+        tokenizer: Tokenizer
+    ) async throws -> Result {
+        let recallRequest = LayeredRecall.RecallRequest(
+            query: request.query,
+            scope: request.scope,
+            limit: request.maxItems,
+            searchTopK: fetchSearchTopK(maxItems: request.maxItems),
+            mode: request.mode,
+            sessionID: request.sessionID,
+            explicitProject: request.explicitProject,
+            explicitRepo: request.explicitRepo,
+            clientCWD: request.clientCWD,
+            frameFilter: request.frameFilter,
+            timeRange: request.timeRange
+        )
+        let lanes = try await LayeredRecall.fetchLanes(
+            request: recallRequest,
+            stores: stores,
+            horizons: .all,
+            canonicalizeFrameIDs: true,
+            episodicTopK: 2
+        )
+
+        let identity = lanes.identity
+
+        let working = scoped(lanes.working, scope: request.scope, identity: identity).map(annotate)
+        let episodic = scoped(lanes.episodic, scope: request.scope, identity: identity).map(annotate)
+        let durable = scoped(lanes.durable, scope: request.scope, identity: identity).map(annotate)
+
+        return await pack(
+            query: request.query,
+            working: working,
+            episodic: episodic,
+            durable: durable,
+            tokenBudget: request.tokenBudget,
+            maxItems: request.maxItems,
+            tokenizer: tokenizer
+        )
+    }
+
+    package static func pack(
+        query: String,
+        working: [LayeredRecall.Hit],
+        episodic: [LayeredRecall.Hit],
+        durable: [LayeredRecall.Hit],
+        tokenBudget: Int,
+        maxItems: Int,
+        tokenizer: Tokenizer
+    ) async -> Result {
+        let short = deduplicate(working)
+        let medium = deduplicate(episodic).sorted {
+            if $0.score != $1.score { return $0.score > $1.score }
+            if $0.timestampMs != $1.timestampMs { return $0.timestampMs > $1.timestampMs }
+            return $0.reference < $1.reference
+        }
+        let long = deduplicate(durable)
+
+        let ordered = Array(
+            (short.prefix(maxItems) + medium.prefix(maxItems) + long.prefix(maxItems))
+                .prefix(maxItems * 3)
+        )
+        var selectedShort: [LayeredRecall.Hit] = []
+        var selectedMedium: [LayeredRecall.Hit] = []
+        var selectedLong: [LayeredRecall.Hit] = []
+        var usedTokens = await tokenizer.count(
+            render(query: query, short: selectedShort, medium: selectedMedium, long: selectedLong)
+        )
+
+        for hit in ordered {
+            var candidateShort = selectedShort
+            var candidateMedium = selectedMedium
+            var candidateLong = selectedLong
+            switch hit.horizon {
+            case .working:
+                candidateShort.append(hit)
+            case .episodic:
+                candidateMedium.append(hit)
+            case .durable:
+                candidateLong.append(hit)
+            }
+            let candidateText = render(
+                query: query,
+                short: candidateShort,
+                medium: candidateMedium,
+                long: candidateLong
+            )
+            let candidateTokens = await tokenizer.count(candidateText)
+            guard candidateTokens <= tokenBudget else { continue }
+            selectedShort = candidateShort
+            selectedMedium = candidateMedium
+            selectedLong = candidateLong
+            usedTokens = candidateTokens
+        }
+
+        var compactedText = render(
+            query: query,
+            short: selectedShort,
+            medium: selectedMedium,
+            long: selectedLong
+        )
+        let renderedTokens = await tokenizer.count(compactedText)
+        if renderedTokens > tokenBudget {
+            compactedText = await tokenizer.truncate(compactedText, tokenBudget)
+            usedTokens = await tokenizer.count(compactedText)
+        } else {
+            usedTokens = renderedTokens
+        }
+
+        let summary = [
+            selectedShort.first?.preview,
+            selectedMedium.first?.preview,
+            selectedLong.first?.preview,
+        ]
+        .compactMap { $0 }
+        .prefix(3)
+        .joined(separator: " | ")
+
+        return Result(
+            short: selectedShort,
+            medium: selectedMedium,
+            long: selectedLong,
+            compactedText: compactedText,
+            summary: summary.isEmpty ? "No compacted context available." : summary,
+            usedTokens: usedTokens
+        )
+    }
+
+    package static func render(
+        query: String,
+        short: [LayeredRecall.Hit],
+        medium: [LayeredRecall.Hit],
+        long: [LayeredRecall.Hit]
+    ) -> String {
+        var lines = ["Query: \(query)"]
+        func appendSection(_ title: String, _ hits: [LayeredRecall.Hit]) {
+            guard !hits.isEmpty else { return }
+            lines.append("")
+            lines.append(title)
+            for hit in hits {
+                let reason = hit.explanations.prefix(2).joined(separator: ", ")
+                lines.append("- \(hit.preview)")
+                if !reason.isEmpty {
+                    lines.append("  why: \(reason)")
+                }
+            }
+        }
+        appendSection("Short-Term Context", short)
+        appendSection("Medium-Term Context", medium)
+        appendSection("Long-Term Context", long)
+        return lines.joined(separator: "\n")
+    }
+
+    package static func deduplicate(_ hits: [LayeredRecall.Hit]) -> [LayeredRecall.Hit] {
+        var seen = Set<String>()
+        var deduped: [LayeredRecall.Hit] = []
+        deduped.reserveCapacity(hits.count)
+        for hit in hits where seen.insert(hit.reference).inserted {
+            deduped.append(hit)
+        }
+        return deduped
+    }
+
+    private static func scoped(
+        _ hits: [LayeredRecall.Hit],
+        scope: LayeredRecall.Scope,
+        identity: LayeredRecall.Identity
+    ) -> [LayeredRecall.Hit] {
+        LayeredRecall.selectHits(merged: hits, scope: scope, identity: identity).hits
+    }
+
+    private static func annotate(_ hit: LayeredRecall.Hit) -> LayeredRecall.Hit {
+        let prefix: String
+        switch hit.horizon {
+        case .working:
+            prefix = "current session"
+        case .episodic:
+            prefix = "recent session episode"
+        case .durable:
+            prefix = "durable memory"
+        }
+        guard !hit.explanations.contains(prefix) else { return hit }
+        var copy = hit
+        copy.explanations = [prefix] + hit.explanations
+        return copy
+    }
+}

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -2,7 +2,9 @@ import Foundation
 import WaxCore
 
 /// Broker Layered recall: scope/identity, multi-horizon fetch/merge, project filter.
-/// Does not own Ranking scores, Recall assembly packing, MCP payloads, or session rebind.
+/// Feeds recall, layered search, and Compact assembly.
+/// Does not own Ranking scores, Recall assembly packing, Compact assembly packing,
+/// MCP payloads, or session rebind.
 package enum LayeredRecall {
     package enum Horizon: String, Sendable {
         case working
@@ -237,6 +239,13 @@ package enum LayeredRecall {
             _ mode: Memory.RetrievalMode,
             _ topK: Int
         ) async throws -> [EpisodicLaneHit]
+        package var recallEndedSession: @Sendable (
+            _ manifest: BrokerSessionManifest,
+            _ query: String,
+            _ mode: Memory.RetrievalMode,
+            _ topK: Int,
+            _ frameFilter: FrameFilter?
+        ) async throws -> [Hit]
         package var nowMs: @Sendable () -> Int64
 
         package init(
@@ -252,6 +261,13 @@ package enum LayeredRecall {
                 Memory.RetrievalMode,
                 Int
             ) async throws -> [EpisodicLaneHit],
+            recallEndedSession: @escaping @Sendable (
+                BrokerSessionManifest,
+                String,
+                Memory.RetrievalMode,
+                Int,
+                FrameFilter?
+            ) async throws -> [Hit],
             nowMs: @escaping @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
         ) {
             self.longTermMemory = longTermMemory
@@ -261,8 +277,18 @@ package enum LayeredRecall {
             self.canonicalFrameID = canonicalFrameID
             self.endedManifests = endedManifests
             self.searchEndedSession = searchEndedSession
+            self.recallEndedSession = recallEndedSession
             self.nowMs = nowMs
         }
+    }
+
+    package struct HorizonLanes: Sendable {
+        package var working: [Hit]
+        package var episodic: [Hit]
+        package var durable: [Hit]
+        package var identity: Identity
+        package var workingExecution: MemoryOrchestrator.RecallExecution?
+        package var durableExecution: MemoryOrchestrator.RecallExecution?
     }
 
     package static func makeMemoryReference(
@@ -321,6 +347,25 @@ package enum LayeredRecall {
                 return hit.metadata[MemoryMetadataKeys.repo] == repo
             }
             return false
+        }
+    }
+
+    /// Ended virtual session stores eligible for the episodic lane.
+    /// Agent filtering applies only when a current session is in scope.
+    /// Reclaimed tombstones are excluded; callers still skip missing store files.
+    package static func episodicManifests(
+        from manifests: [BrokerSessionManifest],
+        currentSessionID: UUID?,
+        currentAgentID: String?
+    ) -> [BrokerSessionManifest] {
+        manifests.filter { manifest in
+            guard manifest.status == .ended else { return false }
+            guard manifest.reclaimedAtMs == nil else { return false }
+            if let currentSessionID, manifest.sessionID == currentSessionID { return false }
+            if currentSessionID != nil, let currentAgentID, manifest.agentID != currentAgentID {
+                return false
+            }
+            return true
         }
     }
 
@@ -543,10 +588,13 @@ package enum LayeredRecall {
         return items.filter { allowed.contains($0.frameId) }
     }
 
-    package static func recall(
+    package static func fetchLanes(
         request: RecallRequest,
-        stores: Stores
-    ) async throws -> RecallResult {
+        stores: Stores,
+        horizons: HorizonSet = [.working, .durable],
+        canonicalizeFrameIDs: Bool = false,
+        episodicTopK: Int = 2
+    ) async throws -> HorizonLanes {
         let working: WorkingLane? = request.sessionID.flatMap { stores.workingLane($0) }
         let inferred = stores.inferWriteScope(request.sessionID, request.clientCWD)
         let identity = resolveIdentity(
@@ -557,7 +605,7 @@ package enum LayeredRecall {
             inferred: inferred
         )
 
-        let retrievalTopK = Self.retrievalTopK(requested: request.searchTopK, scope: request.scope)
+        let topK = max(1, request.searchTopK)
         let scopedFrameFilter = Self.frameFilterForScopedRetrieval(
             base: request.frameFilter,
             scope: request.scope,
@@ -566,13 +614,13 @@ package enum LayeredRecall {
 
         var sessionHits: [Hit] = []
         var sessionExecution: MemoryOrchestrator.RecallExecution?
-        if let working {
+        if horizons.contains(.working), let working {
             let execution = try await working.memory.recallExecution(
                 query: request.query,
                 mode: request.mode,
                 frameFilter: scopedFrameFilter,
                 timeRange: request.timeRange,
-                topK: retrievalTopK
+                topK: topK
             )
             sessionExecution = execution
             sessionHits = execution.context.items.map {
@@ -584,7 +632,7 @@ package enum LayeredRecall {
                         if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
                         return lhs.frameId > rhs.frameId
                     }
-                sessionHits = documents.prefix(retrievalTopK).map { document in
+                sessionHits = documents.prefix(topK).map { document in
                     Hit(
                         reference: makeMemoryReference(
                             .working,
@@ -615,17 +663,20 @@ package enum LayeredRecall {
                     return copy
                 }
             }
+            if canonicalizeFrameIDs {
+                sessionHits = await canonicalizeHits(sessionHits, memory: working.memory, stores: stores)
+            }
         }
 
         var durableHits: [Hit] = []
         var durableExecution: MemoryOrchestrator.RecallExecution?
-        if request.scope != .session {
+        if request.scope != .session, horizons.contains(.durable) {
             let execution = try await stores.longTermMemory.recallExecution(
                 query: request.query,
                 mode: request.mode,
                 frameFilter: scopedFrameFilter,
                 timeRange: request.timeRange,
-                topK: retrievalTopK
+                topK: topK
             )
             durableExecution = execution
             durableHits = execution.context.items.map {
@@ -640,20 +691,67 @@ package enum LayeredRecall {
                     mode: request.mode
                 )
             }
+            if canonicalizeFrameIDs {
+                durableHits = await canonicalizeHits(
+                    durableHits,
+                    memory: stores.longTermMemory,
+                    stores: stores
+                )
+            }
         }
+
+        var episodicHits: [Hit] = []
+        if horizons.contains(.episodic) {
+            let selected = onDiskEpisodicManifests(
+                episodicManifests(
+                    from: try stores.endedManifests(),
+                    currentSessionID: request.sessionID,
+                    currentAgentID: working?.agentID
+                )
+            )
+            for manifest in selected {
+                let hits = try await stores.recallEndedSession(
+                    manifest,
+                    request.query,
+                    request.mode ?? .hybrid(),
+                    max(1, episodicTopK),
+                    scopedFrameFilter
+                )
+                episodicHits.append(contentsOf: hits)
+            }
+        }
+
+        return HorizonLanes(
+            working: sessionHits,
+            episodic: episodicHits,
+            durable: durableHits,
+            identity: identity,
+            workingExecution: sessionExecution,
+            durableExecution: durableExecution
+        )
+    }
+
+    package static func recall(
+        request: RecallRequest,
+        stores: Stores
+    ) async throws -> RecallResult {
+        var fetchRequest = request
+        fetchRequest.searchTopK = retrievalTopK(requested: request.searchTopK, scope: request.scope)
+        let lanes = try await fetchLanes(request: fetchRequest, stores: stores)
+        let identity = lanes.identity
 
         let merged: [Hit]
         if request.scope == .session {
-            merged = Array(sessionHits.prefix(request.limit))
+            merged = Array(lanes.working.prefix(request.limit))
         } else if request.scope == .project {
             // Filter before merge so foreign ranks cannot consume the result budget.
             let scopedSession = Self.filterHitsByProject(
-                sessionHits,
+                lanes.working,
                 project: identity.project,
                 repo: identity.repo
             )
             let scopedDurable = Self.filterHitsByProject(
-                durableHits,
+                lanes.durable,
                 project: identity.project,
                 repo: identity.repo
             )
@@ -664,14 +762,14 @@ package enum LayeredRecall {
             )
         } else {
             merged = mergeHits(
-                sessionHits: sessionHits,
-                durableHits: durableHits,
+                sessionHits: lanes.working,
+                durableHits: lanes.durable,
                 limit: request.limit
             )
         }
 
         let selected = selectHits(merged: merged, scope: request.scope, identity: identity)
-        let primary = sessionExecution ?? durableExecution
+        let primary = lanes.workingExecution ?? lanes.durableExecution
 
         return RecallResult(
             hits: selected.hits,
@@ -770,19 +868,15 @@ package enum LayeredRecall {
         }
 
         if request.horizons.contains(.episodic) {
-            let manifests = try stores.endedManifests()
-            let scopedManifests = manifests
-                .filter { manifest in
-                    guard manifest.status == .ended else { return false }
-                    guard manifest.reclaimedAtMs == nil else { return false }
-                    guard FileManager.default.fileExists(atPath: manifest.storePath) else { return false }
-                    if let sessionID = request.sessionID, manifest.sessionID == sessionID { return false }
-                    if let current = request.sessionID, let active = stores.workingLane(current) {
-                        if let agentID = active.agentID, manifest.agentID != agentID { return false }
-                    }
-                    return true
-                }
-                .prefix(6)
+            let currentAgentID = request.sessionID.flatMap { stores.workingLane($0)?.agentID }
+            let scopedManifests = onDiskEpisodicManifests(
+                episodicManifests(
+                    from: try stores.endedManifests(),
+                    currentSessionID: request.sessionID,
+                    currentAgentID: currentAgentID
+                )
+            )
+            .prefix(6)
 
             for manifest in scopedManifests {
                 let laneHits = try await stores.searchEndedSession(
@@ -836,5 +930,33 @@ package enum LayeredRecall {
                 return lhs.reference < rhs.reference
             }.prefix(request.topK)
         )
+    }
+
+    private static func onDiskEpisodicManifests(
+        _ manifests: [BrokerSessionManifest]
+    ) -> [BrokerSessionManifest] {
+        manifests.filter { FileManager.default.fileExists(atPath: $0.storePath) }
+    }
+
+    private static func canonicalizeHits(
+        _ hits: [Hit],
+        memory: MemoryOrchestrator,
+        stores: Stores
+    ) async -> [Hit] {
+        var canonicalized: [Hit] = []
+        canonicalized.reserveCapacity(hits.count)
+        for hit in hits {
+            var copy = hit
+            if let canonical = await stores.canonicalFrameID(hit.frameID, memory) {
+                copy.frameID = canonical
+                copy.reference = makeMemoryReference(
+                    hit.horizon,
+                    sessionID: hit.sessionID,
+                    frameID: canonical
+                )
+            }
+            canonicalized.append(copy)
+        }
+        return canonicalized
     }
 }

--- a/Tests/WaxTests/CompactAssemblyTests.swift
+++ b/Tests/WaxTests/CompactAssemblyTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func compactAssemblyPackKeepsHorizonBuckets() async {
+    let working = compactHit(frameID: 1, text: "live note", horizon: .working)
+    let episodic = compactHit(frameID: 2, text: "ended note", horizon: .episodic)
+    let durable = compactHit(frameID: 3, text: "durable note", horizon: .durable)
+
+    let packed = await CompactAssembly.pack(
+        query: "q",
+        working: [working],
+        episodic: [episodic],
+        durable: [durable],
+        tokenBudget: 10_000,
+        maxItems: 4,
+        tokenizer: .character
+    )
+
+    #expect(packed.short.map(\.frameID) == [1])
+    #expect(packed.medium.map(\.frameID) == [2])
+    #expect(packed.long.map(\.frameID) == [3])
+    #expect(packed.compactedText.contains("Short-Term Context"))
+    #expect(packed.compactedText.contains("Medium-Term Context"))
+    #expect(packed.compactedText.contains("Long-Term Context"))
+    #expect(packed.summary.contains("live note"))
+    #expect(packed.summary.contains("ended note"))
+    #expect(packed.summary.contains("durable note"))
+}
+
+@Test
+func compactAssemblyPackSkipsHitsThatExceedBudgetThenContinues() async {
+    let oversized = compactHit(frameID: 1, text: String(repeating: "x", count: 80), horizon: .working)
+    let small = compactHit(frameID: 2, text: "ok", horizon: .working)
+    let packed = await CompactAssembly.pack(
+        query: "q",
+        working: [oversized, small],
+        episodic: [],
+        durable: [],
+        tokenBudget: 50,
+        maxItems: 4,
+        tokenizer: .character
+    )
+
+    #expect(packed.short.map(\.frameID) == [2])
+    #expect(packed.usedTokens <= 50)
+    #expect(packed.compactedText.contains("ok"))
+    #expect(!packed.compactedText.contains(String(repeating: "x", count: 80)))
+}
+
+@Test
+func compactAssemblyPackEmptyLanesYieldDefaultSummary() async {
+    let packed = await CompactAssembly.pack(
+        query: "q",
+        working: [],
+        episodic: [],
+        durable: [],
+        tokenBudget: 128,
+        maxItems: 4,
+        tokenizer: .character
+    )
+
+    #expect(packed.short.isEmpty)
+    #expect(packed.medium.isEmpty)
+    #expect(packed.long.isEmpty)
+    #expect(packed.summary == "No compacted context available.")
+    #expect(packed.compactedText.hasPrefix("Query: q"))
+}
+
+@Test
+func compactAssemblyPackDedupesByReference() async {
+    let first = compactHit(frameID: 1, text: "one", horizon: .durable, score: 0.9)
+    var duplicate = compactHit(frameID: 1, text: "one-dup", horizon: .durable, score: 0.2)
+    duplicate.reference = first.reference
+
+    let packed = await CompactAssembly.pack(
+        query: "q",
+        working: [],
+        episodic: [],
+        durable: [first, duplicate],
+        tokenBudget: 10_000,
+        maxItems: 4,
+        tokenizer: .character
+    )
+
+    #expect(packed.long.map(\.text) == ["one"])
+}
+
+@Test
+func compactAssemblyPackCapsEachLaneAtMaxItems() async {
+    let working = (1...6).map { compactHit(frameID: UInt64($0), text: "w\($0)", horizon: .working) }
+    let packed = await CompactAssembly.pack(
+        query: "q",
+        working: working,
+        episodic: [],
+        durable: [],
+        tokenBudget: 10_000,
+        maxItems: 2,
+        tokenizer: .character
+    )
+
+    #expect(packed.short.map(\.frameID) == [1, 2])
+}
+
+@Test
+func layeredRecallEpisodicManifestsKeepEndedPeersAndDropCurrent() {
+    let current = UUID()
+    let endedPeer = UUID()
+    let otherAgent = UUID()
+    let manifests = [
+        compactManifest(sessionID: current, agentID: "a", status: .active),
+        compactManifest(sessionID: endedPeer, agentID: "a", status: .ended),
+        compactManifest(sessionID: otherAgent, agentID: "b", status: .ended),
+    ]
+
+    let withSession = LayeredRecall.episodicManifests(
+        from: manifests,
+        currentSessionID: current,
+        currentAgentID: "a"
+    )
+    #expect(withSession.map(\.sessionID) == [endedPeer])
+
+    let unscoped = LayeredRecall.episodicManifests(
+        from: manifests,
+        currentSessionID: nil,
+        currentAgentID: nil
+    )
+    #expect(Set(unscoped.map(\.sessionID)) == [endedPeer, otherAgent])
+}
+
+@Test
+func layeredRecallEpisodicManifestsDropReclaimedTombstones() {
+    let liveEnded = UUID()
+    let reclaimed = UUID()
+    let manifests = [
+        compactManifest(sessionID: liveEnded, agentID: "a", status: .ended),
+        compactManifest(sessionID: reclaimed, agentID: "a", status: .ended, reclaimedAtMs: 99),
+    ]
+
+    let selected = LayeredRecall.episodicManifests(
+        from: manifests,
+        currentSessionID: nil,
+        currentAgentID: nil
+    )
+    #expect(selected.map(\.sessionID) == [liveEnded])
+}
+
+@Test
+func compactAssemblyFetchSearchTopKStaysUninflated() {
+    #expect(CompactAssembly.fetchSearchTopK(maxItems: 8) == 4)
+    #expect(CompactAssembly.fetchSearchTopK(maxItems: 1) == 1)
+    #expect(CompactAssembly.fetchSearchTopK(maxItems: 4) == 4)
+    #expect(LayeredRecall.retrievalTopK(requested: 4, scope: .project) == 12)
+}
+
+private func compactHit(
+    frameID: UInt64,
+    text: String,
+    horizon: LayeredRecall.Horizon,
+    score: Float = 1
+) -> LayeredRecall.Hit {
+    LayeredRecall.Hit(
+        reference: LayeredRecall.makeMemoryReference(horizon, sessionID: nil, frameID: frameID),
+        horizon: horizon,
+        frameID: frameID,
+        score: score,
+        text: text,
+        preview: text,
+        metadata: [:],
+        explanations: ["why"],
+        timestampMs: 0
+    )
+}
+
+private func compactManifest(
+    sessionID: UUID,
+    agentID: String,
+    status: BrokerSessionManifest.Status,
+    reclaimedAtMs: Int64? = nil
+) -> BrokerSessionManifest {
+    BrokerSessionManifest(
+        sessionID: sessionID,
+        agentID: agentID,
+        runID: "run",
+        project: nil,
+        repo: nil,
+        storePath: "/tmp/\(sessionID.uuidString).wax",
+        eventLogPath: "/tmp/\(sessionID.uuidString).log",
+        status: status,
+        brokerLeaseOwnerID: nil,
+        leaseExpiresAtMs: nil,
+        createdAtMs: 0,
+        updatedAtMs: 0,
+        lastCheckpointAtMs: nil,
+        checkpointCount: 0,
+        lastHandoffAtMs: nil,
+        lastCompactionAtMs: nil,
+        latestSummary: nil,
+        latestHandoff: nil,
+        reclaimedAtMs: reclaimedAtMs
+    )
+}


### PR DESCRIPTION
## Summary
- Stop `compact_context` from fetching working / episodic / durable beside Layered recall. Fetch, project filter, and the empty working-lane fallback now go through `LayeredRecall.fetchLanes`.
- Packing lives in Compact assembly (`short` / `medium` / `long` under the token budget). The broker adapter only flushes, checkpoints, and renders the MCP payload.
- Record Compact assembly in `CONTEXT.md` so packing stays out of Layered recall.

## Test plan
- [x] `swift test --filter CompactAssemblyTests`
- [x] `swift test --filter LayeredRecall`
- [x] `swift test --traits MCPServer --filter compactContext`
- [x] `swift test --traits MCPServer --filter brokerCompactContext --filter brokerBackedF152Compact --filter brokerBackedCompactContext`
- [ ] Confirm `compact_context` still returns live-session notes on an unrelated query
- [ ] Confirm ended-session hits still land in `medium_context` (older relevant session before recency cutoff)


Made with [Cursor](https://cursor.com)