### PR TITLE
Harvest session memory on close and reclaim leftover stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Workflow rules:
 - Use `recall` for assembled context and `search` for raw ranked hits.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
-- Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
+- Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
 - `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
@@ -391,7 +391,7 @@ Share across agents: the parent writes before spawning. Children often have no W
 
 Close: `session_close` (`session_id`, `content`, `project`, `pending_tasks`) or `handoff` then `session_end`.
 
-Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
+Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Do not call `memory-maintain` from the agent loop. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
 ```
 
 </details>
@@ -417,7 +417,7 @@ Write as you go:
 
 Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.
 
-Close with `session_close` (or `handoff` then `session_end`). Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
+Close with `session_close` (or `handoff` then `session_end`). Harvest is automatic; do not call `memory_promote` or `memory-maintain` in the agent loop. Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
 ```
 
 </details>

--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -32,7 +32,8 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
-   - Call `session_end` (pass `session_id` when multiple sessions may be active).
+   - Prefer `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or call `session_end` (pass `session_id` when multiple sessions may be active).
+   - Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or `memory-maintain` in the agent loop; `wax-cli memory-maintain` is operator-only.
    - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
 ## Read Path
@@ -72,8 +73,8 @@ Write quality rules:
 
 ## Anti-Patterns (do not do these)
 
-- Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows.
-  The broker owns long-term memory and virtual session stores.
+- Do not manage `SESSION_STORE`, `--store-path`, `flush`, or `memory-maintain` in normal agent flows.
+  The broker owns long-term memory and virtual session stores. `wax-cli memory-maintain` is operator-only.
 - Do not skip `handoff_latest` at session start and re-ask the user for prior context.
 - Do not invent a `session_id`; only use values returned by `session_start` / `session_resume`.
 - Do not put `session_id` inside `metadata`.
@@ -85,7 +86,7 @@ Write quality rules:
 - Read handoffs and recall results before asking the user to restate known context.
 - When a cross-session hit matters, cite provenance so the user knows which session store it came from.
 - Use `session_resume` only when continuing a known persisted `session_id` after a restart.
-- Use `compact_context` / `session_synthesize` / promotion tools only when the task needs long-horizon compaction or durable promotion, not as default chatter.
+- Use `compact_context` / `session_synthesize` / promotion tools only when the task needs long-horizon compaction or durable promotion, not as default chatter. Close already harvests promotable facts.
 - Prefer `mode: "text"` for recent facts, exact names, and identity. Hybrid can rank old test frames first.
 - `memory_get` IDs are `durable:<frame>` or `episodic:<session_id>:<frame>`. Never a bare frame number.
 

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -21,7 +21,7 @@ Workflow rules:
 - Use `recall` for assembled context and `search` for raw ranked hits.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
-- Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
+- Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
 - `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
@@ -44,7 +44,7 @@ Share across agents: the parent writes before spawning. Children often have no W
 
 Close: `session_close` (`session_id`, `content`, `project`, `pending_tasks`) or `handoff` then `session_end`.
 
-Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
+Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Do not call `memory-maintain` from the agent loop. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
 ```
 
 ## Hermes / OpenClaw SOUL.md
@@ -65,5 +65,5 @@ Write as you go:
 
 Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.
 
-Close with `session_close` (or `handoff` then `session_end`). Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
+Close with `session_close` (or `handoff` then `session_end`). Harvest is automatic; do not call `memory_promote` or `memory-maintain` in the agent loop. Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
 ```

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -32,7 +32,8 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 3. **End**
    - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
-   - Call `session_end` (pass `session_id` when multiple sessions may be active).
+   - Prefer `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or call `session_end` (pass `session_id` when multiple sessions may be active).
+   - Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or `memory-maintain` in the agent loop; `wax-cli memory-maintain` is operator-only.
    - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
 ## Read Path
@@ -72,8 +73,8 @@ Write quality rules:
 
 ## Anti-Patterns (do not do these)
 
-- Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows.
-  The broker owns long-term memory and virtual session stores.
+- Do not manage `SESSION_STORE`, `--store-path`, `flush`, or `memory-maintain` in normal agent flows.
+  The broker owns long-term memory and virtual session stores. `wax-cli memory-maintain` is operator-only.
 - Do not skip `handoff_latest` at session start and re-ask the user for prior context.
 - Do not invent a `session_id`; only use values returned by `session_start` / `session_resume`.
 - Do not put `session_id` inside `metadata`.
@@ -85,7 +86,7 @@ Write quality rules:
 - Read handoffs and recall results before asking the user to restate known context.
 - When a cross-session hit matters, cite provenance so the user knows which session store it came from.
 - Use `session_resume` only when continuing a known persisted `session_id` after a restart.
-- Use `compact_context` / `session_synthesize` / promotion tools only when the task needs long-horizon compaction or durable promotion, not as default chatter.
+- Use `compact_context` / `session_synthesize` / promotion tools only when the task needs long-horizon compaction or durable promotion, not as default chatter. Close already harvests promotable facts.
 - Prefer `mode: "text"` for recent facts, exact names, and identity. Hybrid can rank old test frames first.
 - `memory_get` IDs are `durable:<frame>` or `episodic:<session_id>:<frame>`. Never a bare frame number.
 

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -21,7 +21,7 @@ Workflow rules:
 - Use `recall` for assembled context and `search` for raw ranked hits.
 - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
-- Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
+- Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
 - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
 - `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
@@ -44,7 +44,7 @@ Share across agents: the parent writes before spawning. Children often have no W
 
 Close: `session_close` (`session_id`, `content`, `project`, `pending_tasks`) or `handoff` then `session_end`.
 
-Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
+Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Do not call `memory-maintain` from the agent loop. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
 ```
 
 ## Hermes / OpenClaw SOUL.md
@@ -65,5 +65,5 @@ Write as you go:
 
 Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.
 
-Close with `session_close` (or `handoff` then `session_end`). Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
+Close with `session_close` (or `handoff` then `session_end`). Harvest is automatic; do not call `memory_promote` or `memory-maintain` in the agent loop. Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
 ```

--- a/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
+++ b/Sources/Wax/Broker/AgentBrokerCommandSurface.swift
@@ -99,6 +99,11 @@ package enum AgentBrokerCommandSurface {
         Entry(canonicalName: "facts_query", acceptedArgumentKeys: ["subject", "predicate", "as_of", "system_as_of", "valid_as_of", "limit"], requiresStructuredMemory: true),
         Entry(canonicalName: "entity_resolve", acceptedArgumentKeys: ["alias", "limit"], requiresStructuredMemory: true),
         Entry(canonicalName: "flush", acceptedArgumentKeys: [], exposure: .control),
+        Entry(
+            canonicalName: "memory_maintain",
+            acceptedArgumentKeys: ["apply", "dry_run", "force_reclaim"],
+            exposure: .control
+        ),
         Entry(canonicalName: "shutdown", aliases: ["exit", "quit"], acceptedArgumentKeys: [], exposure: .control),
     ]
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1240,9 +1240,7 @@ extension AgentBrokerService {
             payload["frame_id"] = .from(handoffFrameID)
             payload["committed"] = .bool(true)
         }
-        if let error = harvest.error {
-            payload["harvest_error"] = .string(error)
-        }
+        payload.merge(harvestErrorPayload(harvest)) { _, new in new }
         return .object(payload)
     }
 
@@ -1444,7 +1442,12 @@ extension AgentBrokerService {
             "reclaim_after_ms": .from(harvest.reclaimAfterMs),
             "reclaimed": .bool(reclaimed),
             "display_text": .string(display),
-        ])
+        ].merging(harvestErrorPayload(harvest)) { _, new in new })
+    }
+
+    private func harvestErrorPayload(_ harvest: SessionHarvest.Report) -> [String: AgentBrokerValue] {
+        guard let error = harvest.error, !error.isEmpty else { return [:] }
+        return ["harvest_error": .string(error)]
     }
 
     private func makeHarvestCallback() -> @Sendable (VirtualSessionStore.SessionState) async -> SessionHarvest.Report {
@@ -1475,7 +1478,7 @@ extension AgentBrokerService {
         }
         let immediate = manifest.reclaimAfterMs == manifest.harvestedAtMs
         return SessionHarvest.Report(
-            harvested: manifest.harvestedAtMs != nil && manifest.harvestError == nil,
+            harvested: manifest.harvestedAtMs != nil,
             promotedCount: manifest.promotedCount,
             leftoverDocumentCount: immediate ? 0 : 1,
             leftoverLockedCount: 0,

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1155,8 +1155,7 @@ extension AgentBrokerService {
             return sessionEndPayload(.idle)
         }
         let result = try await virtualSessions.end(sessionID: target, afterFlush: makeHarvestCallback())
-        let reclaimed = await reclaimSessionIfDue(sessionID: target)
-        return sessionEndPayload(result, sessionID: target, reclaimed: reclaimed)
+        return sessionEndPayload(result, sessionID: target)
     }
 
     /// Atomic handoff then end for one `session_id` (C6). Idempotent when already ended.
@@ -1170,15 +1169,13 @@ extension AgentBrokerService {
             if let status = try virtualSessions.persistedStatus(for: sessionID) {
                 if status == .ended {
                     let harvest = await harvestPersistedSession(sessionID: sessionID)
-                    let reclaimed = await reclaimSessionIfDue(sessionID: sessionID)
                     return sessionClosePayload(
                         sessionID: sessionID,
                         ended: true,
                         alreadyEnded: true,
                         handoffFrameID: nil,
                         remainingActive: activeSessions.count,
-                        harvest: harvest,
-                        reclaimed: reclaimed
+                        harvest: harvest
                     )
                 }
             } else {
@@ -1199,15 +1196,13 @@ extension AgentBrokerService {
         try await recordHandoff(sessionID: sessionID, content: content)
         try await longTermMemory.flush()
         let result = try await virtualSessions.end(sessionID: sessionID, afterFlush: makeHarvestCallback())
-        let reclaimed = await reclaimSessionIfDue(sessionID: sessionID)
         return sessionClosePayload(
             sessionID: sessionID,
             ended: result.ended,
             alreadyEnded: false,
             handoffFrameID: frameId,
             remainingActive: result.activeCount,
-            harvest: loadHarvestReport(sessionID: sessionID),
-            reclaimed: reclaimed
+            harvest: loadHarvestReport(sessionID: sessionID)
         )
     }
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -282,6 +282,9 @@ package actor AgentBrokerService {
             case .corpusSearch(let command):
                 payload = try await corpusSearch(command)
                 shouldExit = false
+            case .memoryMaintain(let command):
+                payload = try await memoryMaintain(command)
+                shouldExit = false
             }
 
             return AgentBrokerResponse.success(
@@ -511,7 +514,13 @@ extension AgentBrokerService {
                 },
                 memory: sessionMemory
             )
+            await sessionMemory.recordImpressions(
+                frameIds: result.hits.filter { $0.horizon == .working }.map(\.frameID)
+            )
         }
+        await longTermMemory.recordImpressions(
+            frameIds: result.hits.filter { $0.horizon == .durable }.map(\.frameID)
+        )
 
         var payload: [String: AgentBrokerValue] = [
             "query": .string(query),
@@ -862,12 +871,20 @@ extension AgentBrokerService {
             accessStats: accessStats,
             facts: facts
         )
+        let sessionDisk = SessionReclaim.diskStats(
+            rootURL: sessionRootURL,
+            manifests: (try? BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)) ?? [],
+            liveIDs: Set(activeSessions.keys),
+            nowMs: Self.nowMs()
+        )
         return .object([
             "total_documents": .from(report.totalDocuments),
             "typed_counts": .object(report.typedCounts.mapValues { .from($0) }),
             "expired_frame_ids": .array(report.expiredFrameIds.map(AgentBrokerValue.from)),
             "stale_frame_ids": .array(report.staleFrameIds.map(AgentBrokerValue.from)),
             "low_hit_frame_ids": .array(report.lowHitFrameIds.map(AgentBrokerValue.from)),
+            "quarantine_candidate_ids": .array(report.quarantineCandidateIds.map(AgentBrokerValue.from)),
+            "reclaimable_session_ids": .array(sessionDisk.reclaimableSessionIDs.map { .string($0.uuidString) }),
             "duplicate_pairs": .array(report.duplicatePairs.map { pair in
                 .object([
                     "left_frame_id": .from(pair.leftFrameId),
@@ -1013,6 +1030,12 @@ extension AgentBrokerService {
                 "normalized": .from(identity.normalized),
             ])
         }()
+        let sessionDisk = SessionReclaim.diskStats(
+            rootURL: sessionRootURL,
+            manifests: (try? BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)) ?? [],
+            liveIDs: Set(activeSessions.keys),
+            nowMs: Self.nowMs()
+        )
 
         return .object([
             "frameCount": .from(stats.frameCount),
@@ -1053,6 +1076,7 @@ extension AgentBrokerService {
                 "pendingFramesStoreWide": .from(sessionStats.pendingFramesStoreWide),
                 "countsIncludePending": .from(sessionStats.countsIncludePending),
             ]),
+            "sessions": sessionDisk.asBrokerValue(),
         ])
     }
 
@@ -1130,8 +1154,9 @@ extension AgentBrokerService {
         guard let target = try virtualSessions.peekEndTarget(sessionID: requested) else {
             return sessionEndPayload(.idle)
         }
-        let result = try await virtualSessions.end(sessionID: target)
-        return sessionEndPayload(result)
+        let result = try await virtualSessions.end(sessionID: target, afterFlush: makeHarvestCallback())
+        let reclaimed = await reclaimSessionIfDue(sessionID: target)
+        return sessionEndPayload(result, sessionID: target, reclaimed: reclaimed)
     }
 
     /// Atomic handoff then end for one `session_id` (C6). Idempotent when already ended.
@@ -1144,12 +1169,16 @@ extension AgentBrokerService {
         if activeSessions[sessionID] == nil {
             if let status = try virtualSessions.persistedStatus(for: sessionID) {
                 if status == .ended {
+                    let harvest = await harvestPersistedSession(sessionID: sessionID)
+                    let reclaimed = await reclaimSessionIfDue(sessionID: sessionID)
                     return sessionClosePayload(
                         sessionID: sessionID,
                         ended: true,
                         alreadyEnded: true,
                         handoffFrameID: nil,
-                        remainingActive: activeSessions.count
+                        remainingActive: activeSessions.count,
+                        harvest: harvest,
+                        reclaimed: reclaimed
                     )
                 }
             } else {
@@ -1169,13 +1198,16 @@ extension AgentBrokerService {
         )
         try await recordHandoff(sessionID: sessionID, content: content)
         try await longTermMemory.flush()
-        let result = try await virtualSessions.end(sessionID: sessionID)
+        let result = try await virtualSessions.end(sessionID: sessionID, afterFlush: makeHarvestCallback())
+        let reclaimed = await reclaimSessionIfDue(sessionID: sessionID)
         return sessionClosePayload(
             sessionID: sessionID,
             ended: result.ended,
             alreadyEnded: false,
             handoffFrameID: frameId,
-            remainingActive: result.activeCount
+            remainingActive: result.activeCount,
+            harvest: loadHarvestReport(sessionID: sessionID),
+            reclaimed: reclaimed
         )
     }
 
@@ -1184,7 +1216,9 @@ extension AgentBrokerService {
         ended: Bool,
         alreadyEnded: Bool,
         handoffFrameID: UInt64?,
-        remainingActive: Int
+        remainingActive: Int,
+        harvest: SessionHarvest.Report = .skipped,
+        reclaimed: Bool = false
     ) -> AgentBrokerValue {
         let display =
             "Session \(sessionID.uuidString) \(alreadyEnded ? "already ended" : "closed"). This session active=false. Other live sessions remaining_active=\(remainingActive > 0) count=\(remainingActive)."
@@ -1196,11 +1230,18 @@ extension AgentBrokerService {
             "already_ended": .bool(alreadyEnded),
             "remaining_active": .from(remainingActive > 0),
             "active_session_count": .from(remainingActive),
+            "harvested": .bool(harvest.harvested),
+            "promoted_count": .from(harvest.promotedCount),
+            "reclaim_after_ms": .from(harvest.reclaimAfterMs),
+            "reclaimed": .bool(reclaimed),
             "display_text": .string(display),
         ]
         if let handoffFrameID {
             payload["frame_id"] = .from(handoffFrameID)
             payload["committed"] = .bool(true)
+        }
+        if let error = harvest.error {
+            payload["harvest_error"] = .string(error)
         }
         return .object(payload)
     }
@@ -1377,14 +1418,19 @@ extension AgentBrokerService {
         return candidateCount <= maxTokens ? candidate : ""
     }
 
-    private func sessionEndPayload(_ result: VirtualSessionStore.EndResult) -> AgentBrokerValue {
+    private func sessionEndPayload(
+        _ result: VirtualSessionStore.EndResult,
+        sessionID: UUID? = nil,
+        reclaimed: Bool = false
+    ) -> AgentBrokerValue {
         let remaining = result.activeCount
+        let harvest = sessionID.map { loadHarvestReport(sessionID: $0) } ?? .skipped
         let display: String
         switch result {
         case .idle:
             display = "No live session to end. This session active=false. Other live sessions remaining_active=false count=0."
-        case .ended(let sessionID, _):
-            display = "Session \(sessionID.uuidString) ended. This session active=false. Other live sessions remaining_active=\(remaining > 0) count=\(remaining)."
+        case .ended(let endedID, _):
+            display = "Session \(endedID.uuidString) ended. This session active=false. Other live sessions remaining_active=\(remaining > 0) count=\(remaining)."
         }
         return .object([
             "status": .string("ok"),
@@ -1393,6 +1439,213 @@ extension AgentBrokerService {
             "active": .bool(false),
             "remaining_active": .from(result.remainingActive),
             "active_session_count": .from(result.activeCount),
+            "harvested": .bool(harvest.harvested),
+            "promoted_count": .from(harvest.promotedCount),
+            "reclaim_after_ms": .from(harvest.reclaimAfterMs),
+            "reclaimed": .bool(reclaimed),
+            "display_text": .string(display),
+        ])
+    }
+
+    private func makeHarvestCallback() -> @Sendable (VirtualSessionStore.SessionState) async -> SessionHarvest.Report {
+        let longTerm = longTermMemory
+        let settings = promotionSettings
+        let scope = scopeContext
+        return { state in
+            let events = (try? BrokerSessionPersistence.loadEvents(from: state.eventLogURL)) ?? []
+            return await SessionHarvest.run(
+                sessionMemory: state.memory,
+                longTermMemory: longTerm,
+                sessionID: state.id,
+                manifest: state.manifest,
+                events: events,
+                scope: scope,
+                settings: settings,
+                nowMs: AgentBrokerService.nowMs()
+            )
+        }
+    }
+
+    private func loadHarvestReport(sessionID: UUID) -> SessionHarvest.Report {
+        guard let manifest = try? BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRootURL,
+            sessionID: sessionID
+        ) else {
+            return .skipped
+        }
+        let immediate = manifest.reclaimAfterMs == manifest.harvestedAtMs
+        return SessionHarvest.Report(
+            harvested: manifest.harvestedAtMs != nil && manifest.harvestError == nil,
+            promotedCount: manifest.promotedCount,
+            leftoverDocumentCount: immediate ? 0 : 1,
+            leftoverLockedCount: 0,
+            reclaimAfterMs: manifest.reclaimAfterMs,
+            error: manifest.harvestError,
+            alreadyHarvested: manifest.harvestedAtMs != nil
+        )
+    }
+
+    private func harvestPersistedSession(sessionID: UUID) async -> SessionHarvest.Report {
+        guard let manifest = try? BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRootURL,
+            sessionID: sessionID
+        ) else {
+            return .skipped
+        }
+        if manifest.harvestedAtMs != nil, manifest.harvestError == nil {
+            return loadHarvestReport(sessionID: sessionID)
+        }
+        let events = (try? BrokerSessionPersistence.loadEvents(
+            from: URL(fileURLWithPath: manifest.eventLogPath)
+        )) ?? []
+        let storeURL = URL(fileURLWithPath: manifest.storePath)
+        let report: SessionHarvest.Report
+        if FileManager.default.fileExists(atPath: storeURL.path) {
+            do {
+                report = try await openAdhocMemory(
+                    at: storeURL,
+                    structuredMemoryEnabled: false,
+                    noEmbedder: noEmbedder
+                ) { memory in
+                    await SessionHarvest.run(
+                        sessionMemory: memory,
+                        longTermMemory: self.longTermMemory,
+                        sessionID: sessionID,
+                        manifest: manifest,
+                        events: events,
+                        scope: self.scopeContext,
+                        settings: self.promotionSettings,
+                        nowMs: Self.nowMs()
+                    )
+                }
+            } catch {
+                report = SessionHarvest.Report(
+                    harvested: false,
+                    promotedCount: 0,
+                    leftoverDocumentCount: 0,
+                    leftoverLockedCount: 0,
+                    reclaimAfterMs: nil,
+                    error: error.localizedDescription,
+                    alreadyHarvested: false
+                )
+            }
+        } else {
+            report = SessionHarvest.Report(
+                harvested: true,
+                promotedCount: 0,
+                leftoverDocumentCount: 0,
+                leftoverLockedCount: 0,
+                reclaimAfterMs: Self.nowMs(),
+                error: nil,
+                alreadyHarvested: false
+            )
+        }
+        _ = try? virtualSessions.persistHarvestToDisk(
+            sessionID: sessionID,
+            report: report,
+            markEnded: true
+        )
+        return report
+    }
+
+    @discardableResult
+    private func reclaimSessionIfDue(sessionID: UUID, force: Bool = false) async -> Bool {
+        guard let manifest = try? BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRootURL,
+            sessionID: sessionID
+        ) else {
+            return false
+        }
+        let now = Self.nowMs()
+        guard SessionReclaim.isReclaimable(manifest: manifest, nowMs: now, force: force) else {
+            return false
+        }
+        do {
+            _ = try SessionReclaim.unlink(
+                manifest: manifest,
+                sessionRootURL: sessionRootURL,
+                nowMs: now
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func memoryMaintain(_ command: BrokerCommand.MemoryMaintain) async throws -> AgentBrokerValue {
+        let apply = command.apply
+        let force = command.forceReclaim
+        let now = Self.nowMs()
+        let manifests = (try? BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)) ?? []
+        let liveIDs = Set(activeSessions.keys)
+        var zombiesToEnd = 0
+        var harvests = 0
+        var unlinks = 0
+        var quarantineSoftDeletes = 0
+
+        var zombieIDs = Set<UUID>()
+        for manifest in manifests where SessionReclaim.isZombie(manifest: manifest, liveIDs: liveIDs, nowMs: now) {
+            zombiesToEnd += 1
+            zombieIDs.insert(manifest.sessionID)
+            harvests += 1
+            if apply {
+                _ = await harvestPersistedSession(sessionID: manifest.sessionID)
+            }
+        }
+
+        let afterZombies = (try? BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)) ?? []
+        for manifest in afterZombies {
+            if !zombieIDs.contains(manifest.sessionID),
+               manifest.status == .ended,
+               manifest.harvestedAtMs == nil || manifest.harvestError != nil {
+                harvests += 1
+                if apply {
+                    _ = await harvestPersistedSession(sessionID: manifest.sessionID)
+                }
+            }
+            let current = (try? BrokerSessionPersistence.loadManifest(
+                rootURL: sessionRootURL,
+                sessionID: manifest.sessionID
+            )) ?? manifest
+            if SessionReclaim.isReclaimable(manifest: current, nowMs: now, force: force) {
+                unlinks += 1
+                if apply {
+                    if await reclaimSessionIfDue(sessionID: current.sessionID, force: force) {
+                        // counted
+                    }
+                }
+            }
+        }
+
+        let documents = try await longTermMemory.corpusSourceDocuments()
+        let accessStats = await longTermMemory.accessStatsSnapshot()
+        let quarantineIDs = documents.compactMap { document -> UInt64? in
+            MemoryRetention.isQuarantineCandidate(
+                metadata: document.metadata,
+                stats: accessStats[document.frameId],
+                nowMs: now
+            ) ? document.frameId : nil
+        }
+        quarantineSoftDeletes = quarantineIDs.count
+        if apply {
+            for frameId in quarantineIDs {
+                try await longTermMemory.delete(frameId: frameId)
+            }
+            if !quarantineIDs.isEmpty {
+                try await longTermMemory.flush()
+            }
+        }
+
+        let display = apply
+            ? "Maintain apply: zombies=\(zombiesToEnd) harvests=\(harvests) unlinks=\(unlinks) quarantine=\(quarantineSoftDeletes)"
+            : "Maintain dry-run: zombies=\(zombiesToEnd) harvests=\(harvests) unlinks=\(unlinks) quarantine=\(quarantineSoftDeletes)"
+        return .object([
+            "status": .string("ok"),
+            "dry_run": .bool(!apply),
+            "zombies_to_end": .from(zombiesToEnd),
+            "harvests": .from(harvests),
+            "unlinks": .from(unlinks),
+            "quarantine_soft_deletes": .from(quarantineSoftDeletes),
             "display_text": .string(display),
         ])
     }
@@ -1469,6 +1722,13 @@ extension AgentBrokerService {
                 summary: assembled.summary,
                 compactedText: assembled.compactedText
             )
+        }
+        for hit in assembled.short {
+            if hit.horizon == .durable {
+                await longTermMemory.recordAccess(frameId: hit.frameID)
+            } else if let sessionID = hit.sessionID, let session = activeSessions[sessionID] {
+                await session.memory.recordAccess(frameId: hit.frameID)
+            }
         }
         return .object([
             "query": .string(query),
@@ -2021,6 +2281,7 @@ extension AgentBrokerService {
             },
             searchEndedSession: { manifest, query, mode, topK in
                 let sessionURL = URL(fileURLWithPath: manifest.storePath)
+                guard FileManager.default.fileExists(atPath: sessionURL.path) else { return [] }
                 let eventLogURL = URL(fileURLWithPath: manifest.eventLogPath)
                 let execution = try await self.openAdhocMemory(
                     at: sessionURL,

--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -36,6 +36,7 @@ package enum BrokerCommand: Sendable, Equatable {
     case promote(MemoryPromote)
     case factAssert(FactAssert)
     case corpusSearch(CorpusSearch)
+    case memoryMaintain(MemoryMaintain)
 
     package enum RememberWriteScope: String, Sendable, Equatable {
         case session
@@ -121,6 +122,11 @@ package enum BrokerCommand: Sendable, Equatable {
 
     package struct Stats: Sendable, Equatable {
         package var sessionID: UUID?
+    }
+
+    package struct MemoryMaintain: Sendable, Equatable {
+        package var apply: Bool
+        package var forceReclaim: Bool
     }
 
     package struct MarkdownSync: Sendable, Equatable {
@@ -317,6 +323,8 @@ package enum BrokerCommand: Sendable, Equatable {
             return .factAssert(try FactAssert.decode(args))
         case "corpus_search":
             return .corpusSearch(try CorpusSearch.decode(args))
+        case "memory_maintain":
+            return .memoryMaintain(try MemoryMaintain.decode(args))
         default:
             throw BrokerValidationError.invalid("Unknown broker command '\(command)'.")
         }
@@ -511,6 +519,17 @@ extension BrokerCommand.MemoryGet {
 extension BrokerCommand.Stats {
     package static func decode(_ args: BrokerArguments) throws -> Self {
         Self(sessionID: try BrokerCommand.parseOptionalSessionID(args))
+    }
+}
+
+extension BrokerCommand.MemoryMaintain {
+    package static func decode(_ args: BrokerArguments) throws -> Self {
+        let apply = try args.optionalBool("apply") ?? false
+        let dryRun = try args.optionalBool("dry_run")
+        return Self(
+            apply: dryRun == true ? false : apply,
+            forceReclaim: try args.optionalBool("force_reclaim") ?? false
+        )
     }
 }
 

--- a/Sources/Wax/Broker/BrokerMemoryInsights.swift
+++ b/Sources/Wax/Broker/BrokerMemoryInsights.swift
@@ -82,6 +82,8 @@ package struct BrokerMemoryHealth: Sendable, Equatable {
     package var lowHitFrameIds: [UInt64]
     package var duplicatePairs: [BrokerHealthDuplicatePair]
     package var contradictionSummaries: [String]
+    package var quarantineCandidateIds: [UInt64]
+    package var reclaimableSessionIds: [UUID]
 }
 
 package enum BrokerMemoryInsights {
@@ -298,6 +300,7 @@ package enum BrokerMemoryInsights {
         var expired: [UInt64] = []
         var stale: [UInt64] = []
         var lowHit: [UInt64] = []
+        var quarantine: [UInt64] = []
 
         for document in documents {
             let info = MemorySemantics.parse(metadata: document.metadata, nowMs: nowMs)
@@ -310,9 +313,16 @@ package enum BrokerMemoryInsights {
                 if ageDays > 30, info.durability == .working || info.durability == .ephemeral {
                     stale.append(document.frameId)
                 }
-                if let stat = accessStats[document.frameId], ageDays > 14, stat.accessCount <= 1 {
+                if let stat = accessStats[document.frameId], ageDays > 14, stat.engagementCount <= 1 {
                     lowHit.append(document.frameId)
                 }
+            }
+            if MemoryRetention.isQuarantineCandidate(
+                metadata: document.metadata,
+                stats: accessStats[document.frameId],
+                nowMs: nowMs
+            ) {
+                quarantine.append(document.frameId)
             }
         }
 
@@ -326,7 +336,9 @@ package enum BrokerMemoryInsights {
             staleFrameIds: stale.sorted(),
             lowHitFrameIds: lowHit.sorted(),
             duplicatePairs: duplicatePairs,
-            contradictionSummaries: contradictionSummaries
+            contradictionSummaries: contradictionSummaries,
+            quarantineCandidateIds: quarantine.sorted(),
+            reclaimableSessionIds: []
         )
     }
 

--- a/Sources/Wax/Broker/BrokerSessionPersistence.swift
+++ b/Sources/Wax/Broker/BrokerSessionPersistence.swift
@@ -24,6 +24,39 @@ package struct BrokerSessionManifest: Codable, Sendable, Equatable {
     package var lastCompactionAtMs: Int64?
     package var latestSummary: String?
     package var latestHandoff: String?
+    package var endedAtMs: Int64?
+    package var harvestedAtMs: Int64?
+    package var promotedCount: Int
+    package var reclaimAfterMs: Int64?
+    package var reclaimedAtMs: Int64?
+    package var harvestError: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionID
+        case agentID
+        case runID
+        case project
+        case repo
+        case storePath
+        case eventLogPath
+        case status
+        case brokerLeaseOwnerID
+        case leaseExpiresAtMs
+        case createdAtMs
+        case updatedAtMs
+        case lastCheckpointAtMs
+        case checkpointCount
+        case lastHandoffAtMs
+        case lastCompactionAtMs
+        case latestSummary
+        case latestHandoff
+        case endedAtMs
+        case harvestedAtMs
+        case promotedCount
+        case reclaimAfterMs
+        case reclaimedAtMs
+        case harvestError
+    }
 
     package init(
         sessionID: UUID,
@@ -43,7 +76,13 @@ package struct BrokerSessionManifest: Codable, Sendable, Equatable {
         lastHandoffAtMs: Int64? = nil,
         lastCompactionAtMs: Int64? = nil,
         latestSummary: String? = nil,
-        latestHandoff: String? = nil
+        latestHandoff: String? = nil,
+        endedAtMs: Int64? = nil,
+        harvestedAtMs: Int64? = nil,
+        promotedCount: Int = 0,
+        reclaimAfterMs: Int64? = nil,
+        reclaimedAtMs: Int64? = nil,
+        harvestError: String? = nil
     ) {
         self.sessionID = sessionID
         self.agentID = agentID
@@ -63,6 +102,40 @@ package struct BrokerSessionManifest: Codable, Sendable, Equatable {
         self.lastCompactionAtMs = lastCompactionAtMs
         self.latestSummary = latestSummary
         self.latestHandoff = latestHandoff
+        self.endedAtMs = endedAtMs
+        self.harvestedAtMs = harvestedAtMs
+        self.promotedCount = promotedCount
+        self.reclaimAfterMs = reclaimAfterMs
+        self.reclaimedAtMs = reclaimedAtMs
+        self.harvestError = harvestError
+    }
+
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionID = try container.decode(UUID.self, forKey: .sessionID)
+        agentID = try container.decode(String.self, forKey: .agentID)
+        runID = try container.decode(String.self, forKey: .runID)
+        project = try container.decodeIfPresent(String.self, forKey: .project)
+        repo = try container.decodeIfPresent(String.self, forKey: .repo)
+        storePath = try container.decode(String.self, forKey: .storePath)
+        eventLogPath = try container.decode(String.self, forKey: .eventLogPath)
+        status = try container.decode(Status.self, forKey: .status)
+        brokerLeaseOwnerID = try container.decodeIfPresent(String.self, forKey: .brokerLeaseOwnerID)
+        leaseExpiresAtMs = try container.decodeIfPresent(Int64.self, forKey: .leaseExpiresAtMs)
+        createdAtMs = try container.decode(Int64.self, forKey: .createdAtMs)
+        updatedAtMs = try container.decode(Int64.self, forKey: .updatedAtMs)
+        lastCheckpointAtMs = try container.decodeIfPresent(Int64.self, forKey: .lastCheckpointAtMs)
+        checkpointCount = try container.decodeIfPresent(Int.self, forKey: .checkpointCount) ?? 0
+        lastHandoffAtMs = try container.decodeIfPresent(Int64.self, forKey: .lastHandoffAtMs)
+        lastCompactionAtMs = try container.decodeIfPresent(Int64.self, forKey: .lastCompactionAtMs)
+        latestSummary = try container.decodeIfPresent(String.self, forKey: .latestSummary)
+        latestHandoff = try container.decodeIfPresent(String.self, forKey: .latestHandoff)
+        endedAtMs = try container.decodeIfPresent(Int64.self, forKey: .endedAtMs)
+        harvestedAtMs = try container.decodeIfPresent(Int64.self, forKey: .harvestedAtMs)
+        promotedCount = try container.decodeIfPresent(Int.self, forKey: .promotedCount) ?? 0
+        reclaimAfterMs = try container.decodeIfPresent(Int64.self, forKey: .reclaimAfterMs)
+        reclaimedAtMs = try container.decodeIfPresent(Int64.self, forKey: .reclaimedAtMs)
+        harvestError = try container.decodeIfPresent(String.self, forKey: .harvestError)
     }
 }
 

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -662,10 +662,22 @@ package enum LayeredRecall {
         }
 
         let selected = selectHits(merged: merged, scope: request.scope, identity: identity)
+        let accessStats = await stores.longTermMemory.accessStatsSnapshot()
+        let nowMs = stores.nowMs()
+        let visibleHits = selected.hits.filter { hit in
+            guard hit.horizon == .durable else { return true }
+            return MemoryRetention.isVisibleInDefaultRecall(
+                metadata: hit.metadata,
+                stats: accessStats[hit.frameID],
+                nowMs: nowMs,
+                query: request.query,
+                mode: request.mode
+            )
+        }
         let primary = sessionExecution ?? durableExecution
 
         return RecallResult(
-            hits: selected.hits,
+            hits: visibleHits,
             scope: request.scope,
             identity: identity,
             projectMiss: selected.projectMiss,
@@ -728,7 +740,16 @@ package enum LayeredRecall {
                 frameFilter: nil,
                 timeRange: nil
             )
+            let accessStats = await stores.longTermMemory.accessStatsSnapshot()
+            let nowMs = stores.nowMs()
             for result in execution.hits {
+                guard MemoryRetention.isVisibleInDefaultRecall(
+                    metadata: result.metadata,
+                    stats: accessStats[result.frameId],
+                    nowMs: nowMs,
+                    query: request.query,
+                    mode: request.mode
+                ) else { continue }
                 guard let canonicalFrameID = await stores.canonicalFrameID(
                     result.frameId,
                     stores.longTermMemory
@@ -758,6 +779,8 @@ package enum LayeredRecall {
             let scopedManifests = manifests
                 .filter { manifest in
                     guard manifest.status == .ended else { return false }
+                    guard manifest.reclaimedAtMs == nil else { return false }
+                    guard FileManager.default.fileExists(atPath: manifest.storePath) else { return false }
                     if let sessionID = request.sessionID, manifest.sessionID == sessionID { return false }
                     if let current = request.sessionID, let active = stores.workingLane(current) {
                         if let agentID = active.agentID, manifest.agentID != agentID { return false }

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -631,6 +631,15 @@ package enum LayeredRecall {
             durableHits = execution.context.items.map {
                 hit(from: $0, horizon: .durable, sessionID: nil)
             }
+            let nowMs = stores.nowMs()
+            durableHits = durableHits.filter { hit in
+                MemoryRetention.isVisibleInDefaultRecall(
+                    metadata: hit.metadata,
+                    nowMs: nowMs,
+                    query: request.query,
+                    mode: request.mode
+                )
+            }
         }
 
         let merged: [Hit]
@@ -662,22 +671,10 @@ package enum LayeredRecall {
         }
 
         let selected = selectHits(merged: merged, scope: request.scope, identity: identity)
-        let accessStats = await stores.longTermMemory.accessStatsSnapshot()
-        let nowMs = stores.nowMs()
-        let visibleHits = selected.hits.filter { hit in
-            guard hit.horizon == .durable else { return true }
-            return MemoryRetention.isVisibleInDefaultRecall(
-                metadata: hit.metadata,
-                stats: accessStats[hit.frameID],
-                nowMs: nowMs,
-                query: request.query,
-                mode: request.mode
-            )
-        }
         let primary = sessionExecution ?? durableExecution
 
         return RecallResult(
-            hits: visibleHits,
+            hits: selected.hits,
             scope: request.scope,
             identity: identity,
             projectMiss: selected.projectMiss,
@@ -740,12 +737,10 @@ package enum LayeredRecall {
                 frameFilter: nil,
                 timeRange: nil
             )
-            let accessStats = await stores.longTermMemory.accessStatsSnapshot()
             let nowMs = stores.nowMs()
             for result in execution.hits {
                 guard MemoryRetention.isVisibleInDefaultRecall(
                     metadata: result.metadata,
-                    stats: accessStats[result.frameId],
                     nowMs: nowMs,
                     query: request.query,
                     mode: request.mode

--- a/Sources/Wax/Broker/MemoryRetention.swift
+++ b/Sources/Wax/Broker/MemoryRetention.swift
@@ -102,6 +102,7 @@ package enum MemoryRetention {
         return .hot
     }
 
+    /// Keep-score archival candidate (REQ-011). Default recall uses explicit `wax.tier` only.
     package static func isCold(
         metadata: [String: String],
         stats: FrameAccessStats?,
@@ -136,18 +137,21 @@ package enum MemoryRetention {
         return RuleBasedQueryClassifier.isExactIntentQuery(query)
     }
 
+    /// Default hybrid omits only explicit `wax.tier=cold`. Unset tier is hot (REQ-010).
     package static func isVisibleInDefaultRecall(
         metadata: [String: String],
-        stats: FrameAccessStats?,
         nowMs: Int64,
         query: String,
-        mode: Memory.RetrievalMode?,
-        settings: MemoryRetentionSettings = .default
+        mode: Memory.RetrievalMode?
     ) -> Bool {
         if includeColdInRetrieval(query: query, mode: mode) {
             return true
         }
-        return !isCold(metadata: metadata, stats: stats, nowMs: nowMs, settings: settings)
+        let info = MemorySemantics.parse(metadata: metadata, nowMs: nowMs)
+        if info.durability == .locked {
+            return true
+        }
+        return parsedTier(metadata) != .cold
     }
 
     package static func isQuarantineCandidate(

--- a/Sources/Wax/Broker/MemoryRetention.swift
+++ b/Sources/Wax/Broker/MemoryRetention.swift
@@ -1,0 +1,192 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+package struct MemoryRetentionSettings: Sendable, Equatable {
+    package var recentlyClosedMs: Int64
+    package var workingQuarantineMs: Int64
+    package var keepColdThreshold: Float
+    package var coldMinAgeMs: Int64
+    package var lowEngagementAgeMs: Int64
+    package var lowEngagementMaxCount: UInt32
+
+    package static let `default` = MemoryRetentionSettings(
+        recentlyClosedMs: 604_800_000,
+        workingQuarantineMs: 2_592_000_000,
+        keepColdThreshold: 0.55,
+        coldMinAgeMs: 1_209_600_000,
+        lowEngagementAgeMs: 1_209_600_000,
+        lowEngagementMaxCount: 1
+    )
+
+    package static func fromEnvironment(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> MemoryRetentionSettings {
+        func seconds(_ key: String, defaultMs: Int64) -> Int64 {
+            guard let raw = environment[key], let seconds = Int64(raw) else {
+                return defaultMs
+            }
+            return max(0, seconds) * 1000
+        }
+        let threshold = environment["WAX_KEEP_COLD_THRESHOLD"].flatMap(Float.init)
+        return MemoryRetentionSettings(
+            recentlyClosedMs: seconds("WAX_SESSION_RECENTLY_CLOSED_SECS", defaultMs: Self.default.recentlyClosedMs),
+            workingQuarantineMs: seconds("WAX_WORKING_QUARANTINE_SECS", defaultMs: Self.default.workingQuarantineMs),
+            keepColdThreshold: threshold.map { min(max($0, 0), 1) } ?? Self.default.keepColdThreshold,
+            coldMinAgeMs: seconds("WAX_COLD_MIN_AGE_SECS", defaultMs: Self.default.coldMinAgeMs),
+            lowEngagementAgeMs: Self.default.lowEngagementAgeMs,
+            lowEngagementMaxCount: Self.default.lowEngagementMaxCount
+        )
+    }
+}
+
+package enum MemoryTier: String, Sendable {
+    case hot
+    case cold
+}
+
+package enum MemoryRetention {
+    private static let frequencyHalfLifeHours: Float = 30 * 24
+    private static let recencyHalfLifeHours: Float = 24
+    private static let countSaturation: Float = 32
+
+    package static func typePrior(for type: MemoryType) -> Float {
+        switch type {
+        case .decision, .constraint:
+            return 1.0
+        case .userPreference, .lesson, .fact:
+            return 0.85
+        case .handoff:
+            return 0.55
+        case .note:
+            return 0.40
+        case .taskState:
+            return 0.25
+        }
+    }
+
+    package static func keepScore(
+        type: MemoryType,
+        durability: MemoryDurability,
+        reviewed: Bool,
+        engagementCount: UInt32,
+        lastEngagementMs: Int64,
+        nowMs: Int64
+    ) -> Float {
+        let hours: Float
+        if lastEngagementMs > 0 {
+            hours = Float(max(0, nowMs - lastEngagementMs)) / (1000 * 60 * 60)
+        } else {
+            hours = Float.greatestFiniteMagnitude / 4
+        }
+        let frequency = log(Float(min(engagementCount, UInt32(countSaturation))) + 1) / log(countSaturation + 1)
+        let frequencyDecay = hours.isFinite ? exp(-hours / frequencyHalfLifeHours) : 0
+        let recency = hours.isFinite ? exp(-hours / recencyHalfLifeHours) : 0
+        let agedEngagement = frequency * frequencyDecay
+        let pin: Float = (durability == .locked || reviewed) ? 1.0 : 0.0
+        let keep =
+            0.35 * typePrior(for: type)
+            + 0.25 * agedEngagement
+            + 0.15 * recency
+            + 0.25 * pin
+        return min(1, max(0, keep))
+    }
+
+    package static func parsedTier(_ metadata: [String: String]) -> MemoryTier {
+        if metadata[MemoryMetadataKeys.tier] == MemoryTier.cold.rawValue {
+            return .cold
+        }
+        return .hot
+    }
+
+    package static func isCold(
+        metadata: [String: String],
+        stats: FrameAccessStats?,
+        nowMs: Int64,
+        settings: MemoryRetentionSettings = .default
+    ) -> Bool {
+        let info = MemorySemantics.parse(metadata: metadata, nowMs: nowMs)
+        if info.durability == .locked {
+            return false
+        }
+        if parsedTier(metadata) == .cold {
+            return true
+        }
+        guard let createdAtMs = info.createdAtMs else { return false }
+        let ageMs = max(0, nowMs - createdAtMs)
+        guard ageMs > settings.coldMinAgeMs else { return false }
+        let keep = keepScore(
+            type: info.type,
+            durability: info.durability,
+            reviewed: info.isReviewed,
+            engagementCount: stats?.engagementCount ?? 0,
+            lastEngagementMs: stats?.lastEngagementMs ?? 0,
+            nowMs: nowMs
+        )
+        return keep < settings.keepColdThreshold
+    }
+
+    package static func includeColdInRetrieval(query: String, mode: Memory.RetrievalMode?) -> Bool {
+        if mode == .textOnly {
+            return true
+        }
+        return RuleBasedQueryClassifier.isExactIntentQuery(query)
+    }
+
+    package static func isVisibleInDefaultRecall(
+        metadata: [String: String],
+        stats: FrameAccessStats?,
+        nowMs: Int64,
+        query: String,
+        mode: Memory.RetrievalMode?,
+        settings: MemoryRetentionSettings = .default
+    ) -> Bool {
+        if includeColdInRetrieval(query: query, mode: mode) {
+            return true
+        }
+        return !isCold(metadata: metadata, stats: stats, nowMs: nowMs, settings: settings)
+    }
+
+    package static func isQuarantineCandidate(
+        metadata: [String: String],
+        stats: FrameAccessStats?,
+        nowMs: Int64,
+        settings: MemoryRetentionSettings = .default
+    ) -> Bool {
+        let info = MemorySemantics.parse(metadata: metadata, nowMs: nowMs)
+        if info.durability == .durable || info.durability == .locked {
+            return false
+        }
+        if info.isExpired {
+            return true
+        }
+        guard let createdAtMs = info.createdAtMs else { return false }
+        let ageMs = max(0, nowMs - createdAtMs)
+        if ageMs > settings.workingQuarantineMs,
+           info.durability == .working || info.durability == .ephemeral {
+            return true
+        }
+        let engagement = stats?.engagementCount ?? 0
+        if ageMs > settings.lowEngagementAgeMs, engagement <= settings.lowEngagementMaxCount,
+           info.durability == .working || info.durability == .ephemeral {
+            return true
+        }
+        return false
+    }
+
+    package static func fileApparentBytes(at path: String) -> UInt64 {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attrs[.size] as? NSNumber
+        else { return 0 }
+        return size.uint64Value
+    }
+
+    package static func fileActualBytes(at path: String) -> UInt64? {
+        var st = stat()
+        guard stat(path, &st) == 0 else { return nil }
+        return UInt64(st.st_blocks) * 512
+    }
+}

--- a/Sources/Wax/Broker/SessionHarvest.swift
+++ b/Sources/Wax/Broker/SessionHarvest.swift
@@ -60,6 +60,7 @@ package enum SessionHarvest {
             var promotedCount = 0
             var leftoverDocumentCount = 0
             var leftoverLockedCount = 0
+            var harvestError: String?
 
             for document in documents {
                 let info = MemorySemantics.parse(metadata: document.metadata, nowMs: nowMs)
@@ -97,25 +98,45 @@ package enum SessionHarvest {
                     leftoverDocumentCount += 1
                     continue
                 }
-                let written = try await longTermMemory.remember(document.text, metadata: metadata)
-                if let sourceStats = sessionStats[document.frameId] {
-                    await longTermMemory.seedAccessStats(frameId: written.frameId, from: sourceStats)
-                }
-                longTermDocuments.append(
-                    MemoryOrchestrator.CorpusSourceDocument(
-                        frameId: written.frameId,
-                        timestampMs: nowMs,
-                        kind: document.kind,
-                        role: document.role,
-                        text: document.text,
-                        metadata: metadata
+                do {
+                    let written = try await longTermMemory.remember(document.text, metadata: metadata)
+                    if let sourceStats = sessionStats[document.frameId] {
+                        await longTermMemory.seedAccessStats(frameId: written.frameId, from: sourceStats)
+                    }
+                    longTermDocuments.append(
+                        MemoryOrchestrator.CorpusSourceDocument(
+                            frameId: written.frameId,
+                            timestampMs: nowMs,
+                            kind: document.kind,
+                            role: document.role,
+                            text: document.text,
+                            metadata: metadata
+                        )
                     )
-                )
-                promotedCount += 1
+                    promotedCount += 1
+                } catch {
+                    leftoverDocumentCount += 1
+                    if harvestError == nil {
+                        harvestError = error.localizedDescription
+                    }
+                }
             }
-            try await longTermMemory.flush()
+            do {
+                try await longTermMemory.flush()
+            } catch {
+                harvestError = error.localizedDescription
+                return Report(
+                    harvested: false,
+                    promotedCount: promotedCount,
+                    leftoverDocumentCount: leftoverDocumentCount,
+                    leftoverLockedCount: leftoverLockedCount,
+                    reclaimAfterMs: nil,
+                    error: harvestError,
+                    alreadyHarvested: false
+                )
+            }
 
-            let immediate = leftoverDocumentCount == 0 && leftoverLockedCount == 0
+            let immediate = leftoverDocumentCount == 0 && leftoverLockedCount == 0 && harvestError == nil
             let reclaimAfterMs = immediate ? nowMs : nowMs + retention.recentlyClosedMs
             return Report(
                 harvested: true,
@@ -123,7 +144,7 @@ package enum SessionHarvest {
                 leftoverDocumentCount: leftoverDocumentCount,
                 leftoverLockedCount: leftoverLockedCount,
                 reclaimAfterMs: reclaimAfterMs,
-                error: nil,
+                error: harvestError,
                 alreadyHarvested: false
             )
         } catch {

--- a/Sources/Wax/Broker/SessionHarvest.swift
+++ b/Sources/Wax/Broker/SessionHarvest.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+package enum SessionHarvest {
+    package struct Report: Sendable, Equatable {
+        package var harvested: Bool
+        package var promotedCount: Int
+        package var leftoverDocumentCount: Int
+        package var leftoverLockedCount: Int
+        package var reclaimAfterMs: Int64?
+        package var error: String?
+        package var alreadyHarvested: Bool
+
+        package static let skipped = Report(
+            harvested: false,
+            promotedCount: 0,
+            leftoverDocumentCount: 0,
+            leftoverLockedCount: 0,
+            reclaimAfterMs: nil,
+            error: nil,
+            alreadyHarvested: false
+        )
+
+        package var immediateReclaimEligible: Bool {
+            harvested
+                && error == nil
+                && leftoverDocumentCount == 0
+                && leftoverLockedCount == 0
+        }
+    }
+
+    package static func run(
+        sessionMemory: MemoryOrchestrator,
+        longTermMemory: MemoryOrchestrator,
+        sessionID: UUID,
+        manifest: BrokerSessionManifest,
+        events: [BrokerSessionEvent],
+        scope: MemoryScopeContext?,
+        settings: BrokerPromotionSettings = .default,
+        retention: MemoryRetentionSettings = .fromEnvironment(),
+        nowMs: Int64
+    ) async -> Report {
+        if let harvestedAtMs = manifest.harvestedAtMs, manifest.harvestError == nil {
+            let immediate = manifest.reclaimAfterMs == harvestedAtMs
+            return Report(
+                harvested: true,
+                promotedCount: manifest.promotedCount,
+                leftoverDocumentCount: immediate ? 0 : 1,
+                leftoverLockedCount: 0,
+                reclaimAfterMs: manifest.reclaimAfterMs,
+                error: nil,
+                alreadyHarvested: true
+            )
+        }
+
+        do {
+            let documents = try await sessionMemory.corpusSourceDocuments()
+            var longTermDocuments = try await longTermMemory.corpusSourceDocuments()
+            let recallSignals = BrokerSessionPersistence.recallSignals(from: events)
+            let sessionStats = await sessionMemory.accessStatsSnapshot()
+            var promotedCount = 0
+            var leftoverDocumentCount = 0
+            var leftoverLockedCount = 0
+
+            for document in documents {
+                let info = MemorySemantics.parse(metadata: document.metadata, nowMs: nowMs)
+                if info.durability == .locked {
+                    leftoverLockedCount += 1
+                    leftoverDocumentCount += 1
+                    continue
+                }
+                let proposal = BrokerMemoryInsights.proposePromotion(
+                    content: document.text,
+                    metadata: document.metadata,
+                    sessionID: sessionID,
+                    sourceFrameID: document.frameId,
+                    scope: scope,
+                    longTermDocuments: longTermDocuments,
+                    recallSignals: recallSignals[document.frameId],
+                    settings: settings
+                )
+                guard proposal.shouldWrite else {
+                    leftoverDocumentCount += 1
+                    continue
+                }
+                var metadata = MemorySemantics.approvedPromotionMetadata(
+                    metadata: document.metadata,
+                    semantics: MemoryWriteSemantics(),
+                    suggestedType: proposal.suggestedType,
+                    suggestedDurability: proposal.suggestedDurability,
+                    suggestedConfidence: proposal.confidence
+                )
+                metadata[MemoryMetadataKeys.promotedFromSession] = sessionID.uuidString
+                metadata[MemoryMetadataKeys.promotedFromFrame] = String(document.frameId)
+                metadata[MemoryMetadataKeys.tier] = MemoryTier.hot.rawValue
+                metadata.removeValue(forKey: "session_id")
+                if SecretHeuristics.detectSecretLikeContent(document.text, metadata: metadata) != nil {
+                    leftoverDocumentCount += 1
+                    continue
+                }
+                let written = try await longTermMemory.remember(document.text, metadata: metadata)
+                if let sourceStats = sessionStats[document.frameId] {
+                    await longTermMemory.seedAccessStats(frameId: written.frameId, from: sourceStats)
+                }
+                longTermDocuments.append(
+                    MemoryOrchestrator.CorpusSourceDocument(
+                        frameId: written.frameId,
+                        timestampMs: nowMs,
+                        kind: document.kind,
+                        role: document.role,
+                        text: document.text,
+                        metadata: metadata
+                    )
+                )
+                promotedCount += 1
+            }
+            try await longTermMemory.flush()
+
+            let immediate = leftoverDocumentCount == 0 && leftoverLockedCount == 0
+            let reclaimAfterMs = immediate ? nowMs : nowMs + retention.recentlyClosedMs
+            return Report(
+                harvested: true,
+                promotedCount: promotedCount,
+                leftoverDocumentCount: leftoverDocumentCount,
+                leftoverLockedCount: leftoverLockedCount,
+                reclaimAfterMs: reclaimAfterMs,
+                error: nil,
+                alreadyHarvested: false
+            )
+        } catch {
+            return Report(
+                harvested: false,
+                promotedCount: 0,
+                leftoverDocumentCount: 0,
+                leftoverLockedCount: 0,
+                reclaimAfterMs: nil,
+                error: error.localizedDescription,
+                alreadyHarvested: false
+            )
+        }
+    }
+}

--- a/Sources/Wax/Broker/SessionHarvest.swift
+++ b/Sources/Wax/Broker/SessionHarvest.swift
@@ -28,6 +28,20 @@ package enum SessionHarvest {
         }
     }
 
+    /// Close harvest trusts explicit types. Implicit notes/task_state still need recall
+    /// even when text cues would make operator `promote` always-write.
+    private static func harvestShouldWrite(
+        proposal: BrokerPromotionProposal,
+        storedType: MemoryType,
+        settings: BrokerPromotionSettings
+    ) -> Bool {
+        guard proposal.shouldWrite else { return false }
+        if storedType == .note || storedType == .taskState {
+            return proposal.recallCount >= settings.minimumRecallCount
+        }
+        return true
+    }
+
     package static func run(
         sessionMemory: MemoryOrchestrator,
         longTermMemory: MemoryOrchestrator,
@@ -69,6 +83,7 @@ package enum SessionHarvest {
                     leftoverDocumentCount += 1
                     continue
                 }
+                let storedType = info.type
                 let proposal = BrokerMemoryInsights.proposePromotion(
                     content: document.text,
                     metadata: document.metadata,
@@ -79,7 +94,7 @@ package enum SessionHarvest {
                     recallSignals: recallSignals[document.frameId],
                     settings: settings
                 )
-                guard proposal.shouldWrite else {
+                guard harvestShouldWrite(proposal: proposal, storedType: storedType, settings: settings) else {
                     leftoverDocumentCount += 1
                     continue
                 }

--- a/Sources/Wax/Broker/SessionReclaim.swift
+++ b/Sources/Wax/Broker/SessionReclaim.swift
@@ -1,0 +1,190 @@
+import Foundation
+import WaxCore
+
+package struct SessionDiskStats: Sendable, Equatable {
+    package var rootPath: String
+    package var active: Int
+    package var ended: Int
+    package var zombies: Int
+    package var recentlyClosed: Int
+    package var reclaimable: Int
+    package var apparentBytes: UInt64
+    package var actualBytes: UInt64
+    package var reclaimableBytes: UInt64
+    package var reclaimableSessionIDs: [UUID]
+
+    package func asBrokerValue() -> AgentBrokerValue {
+        .object([
+            "root_path": .string(rootPath),
+            "active": .from(active),
+            "ended": .from(ended),
+            "zombies": .from(zombies),
+            "recently_closed": .from(recentlyClosed),
+            "reclaimable": .from(reclaimable),
+            "apparent_bytes": .from(apparentBytes),
+            "actual_bytes": .from(actualBytes),
+            "reclaimable_bytes": .from(reclaimableBytes),
+        ])
+    }
+}
+
+package enum SessionReclaim {
+    package static func isZombie(
+        manifest: BrokerSessionManifest,
+        liveIDs: Set<UUID>,
+        nowMs: Int64
+    ) -> Bool {
+        guard manifest.status == .active else { return false }
+        guard !liveIDs.contains(manifest.sessionID) else { return false }
+        guard let lease = manifest.leaseExpiresAtMs else { return false }
+        return lease < nowMs
+    }
+
+    package static func isRecentlyClosed(
+        manifest: BrokerSessionManifest,
+        nowMs: Int64
+    ) -> Bool {
+        guard manifest.status == .ended, manifest.reclaimedAtMs == nil else { return false }
+        guard let reclaimAfterMs = manifest.reclaimAfterMs else { return false }
+        return nowMs < reclaimAfterMs && FileManager.default.fileExists(atPath: manifest.storePath)
+    }
+
+    package static func isReclaimable(
+        manifest: BrokerSessionManifest,
+        nowMs: Int64,
+        force: Bool = false
+    ) -> Bool {
+        guard manifest.status == .ended else { return false }
+        guard manifest.reclaimedAtMs == nil else { return false }
+        guard FileManager.default.fileExists(atPath: manifest.storePath) else { return false }
+        if force {
+            return true
+        }
+        if manifest.harvestError != nil {
+            return false
+        }
+        guard let reclaimAfterMs = manifest.reclaimAfterMs else { return false }
+        return nowMs >= reclaimAfterMs
+    }
+
+    package static func diskStats(
+        rootURL: URL,
+        manifests: [BrokerSessionManifest],
+        liveIDs: Set<UUID>,
+        nowMs: Int64
+    ) -> SessionDiskStats {
+        var active = 0
+        var ended = 0
+        var zombies = 0
+        var recentlyClosed = 0
+        var reclaimableIDs: [UUID] = []
+        var reclaimableBytes: UInt64 = 0
+
+        for manifest in manifests {
+            if isZombie(manifest: manifest, liveIDs: liveIDs, nowMs: nowMs) {
+                zombies += 1
+                reclaimableBytes += MemoryRetention.fileApparentBytes(at: manifest.storePath)
+            } else if manifest.status == .active {
+                active += 1
+            } else {
+                ended += 1
+                if isRecentlyClosed(manifest: manifest, nowMs: nowMs) {
+                    recentlyClosed += 1
+                }
+                if isReclaimable(manifest: manifest, nowMs: nowMs) {
+                    reclaimableIDs.append(manifest.sessionID)
+                    reclaimableBytes += MemoryRetention.fileApparentBytes(at: manifest.storePath)
+                }
+            }
+        }
+
+        var apparent: UInt64 = 0
+        var actual: UInt64 = 0
+        if let items = try? FileManager.default.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) {
+            for url in items {
+                apparent += MemoryRetention.fileApparentBytes(at: url.path)
+                actual += MemoryRetention.fileActualBytes(at: url.path) ?? MemoryRetention.fileApparentBytes(at: url.path)
+            }
+        }
+
+        return SessionDiskStats(
+            rootPath: rootURL.path,
+            active: active,
+            ended: ended,
+            zombies: zombies,
+            recentlyClosed: recentlyClosed,
+            reclaimable: reclaimableIDs.count,
+            apparentBytes: apparent,
+            actualBytes: actual,
+            reclaimableBytes: reclaimableBytes,
+            reclaimableSessionIDs: reclaimableIDs.sorted { $0.uuidString < $1.uuidString }
+        )
+    }
+
+    package static func unlink(
+        manifest: BrokerSessionManifest,
+        sessionRootURL: URL,
+        nowMs: Int64
+    ) throws -> BrokerSessionManifest {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: manifest.storePath) {
+            try fileManager.removeItem(atPath: manifest.storePath)
+        }
+        if fileManager.fileExists(atPath: manifest.eventLogPath) {
+            try fileManager.removeItem(atPath: manifest.eventLogPath)
+        }
+        var tombstone = manifest
+        tombstone.status = .ended
+        tombstone.storePath = ""
+        tombstone.reclaimedAtMs = nowMs
+        tombstone.updatedAtMs = nowMs
+        tombstone.brokerLeaseOwnerID = nil
+        tombstone.leaseExpiresAtMs = nil
+        try BrokerSessionPersistence.saveManifest(
+            tombstone,
+            to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
+        )
+        return tombstone
+    }
+
+    package static func compactThenUnlink(
+        manifest: BrokerSessionManifest,
+        sessionRootURL: URL,
+        nowMs: Int64,
+        openMemory: (@Sendable (URL) async throws -> MemoryOrchestrator)? = nil
+    ) async throws -> BrokerSessionManifest {
+        let storeURL = URL(fileURLWithPath: manifest.storePath)
+        if let openMemory, FileManager.default.fileExists(atPath: storeURL.path) {
+            let size = MemoryRetention.fileApparentBytes(at: storeURL.path)
+            if size >= Constants.sessionWalSize {
+                let compactURL = storeURL.deletingLastPathComponent()
+                    .appendingPathComponent(".\(manifest.sessionID.uuidString)-reclaim-compact.wax")
+                do {
+                    let memory = try await openMemory(storeURL)
+                    do {
+                        _ = try await memory.rewriteLiveSet(
+                            to: compactURL,
+                            options: LiveSetRewriteOptions(
+                                overwriteDestination: true,
+                                dropNonLivePayloads: true,
+                                verifyDeep: false
+                            )
+                        )
+                    } catch {
+                        try await memory.close()
+                        throw error
+                    }
+                    try await memory.close()
+                    try? FileManager.default.removeItem(at: compactURL)
+                } catch {
+                    try? FileManager.default.removeItem(at: compactURL)
+                }
+            }
+        }
+        return try unlink(manifest: manifest, sessionRootURL: sessionRootURL, nowMs: nowMs)
+    }
+}

--- a/Sources/Wax/Broker/SessionReclaim.swift
+++ b/Sources/Wax/Broker/SessionReclaim.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WaxCore
 
 package struct SessionDiskStats: Sendable, Equatable {
     package var rootPath: String
@@ -149,42 +148,5 @@ package enum SessionReclaim {
             to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
         )
         return tombstone
-    }
-
-    package static func compactThenUnlink(
-        manifest: BrokerSessionManifest,
-        sessionRootURL: URL,
-        nowMs: Int64,
-        openMemory: (@Sendable (URL) async throws -> MemoryOrchestrator)? = nil
-    ) async throws -> BrokerSessionManifest {
-        let storeURL = URL(fileURLWithPath: manifest.storePath)
-        if let openMemory, FileManager.default.fileExists(atPath: storeURL.path) {
-            let size = MemoryRetention.fileApparentBytes(at: storeURL.path)
-            if size >= Constants.sessionWalSize {
-                let compactURL = storeURL.deletingLastPathComponent()
-                    .appendingPathComponent(".\(manifest.sessionID.uuidString)-reclaim-compact.wax")
-                do {
-                    let memory = try await openMemory(storeURL)
-                    do {
-                        _ = try await memory.rewriteLiveSet(
-                            to: compactURL,
-                            options: LiveSetRewriteOptions(
-                                overwriteDestination: true,
-                                dropNonLivePayloads: true,
-                                verifyDeep: false
-                            )
-                        )
-                    } catch {
-                        try await memory.close()
-                        throw error
-                    }
-                    try await memory.close()
-                    try? FileManager.default.removeItem(at: compactURL)
-                } catch {
-                    try? FileManager.default.removeItem(at: compactURL)
-                }
-            }
-        }
-        return try unlink(manifest: manifest, sessionRootURL: sessionRootURL, nowMs: nowMs)
     }
 }

--- a/Sources/Wax/Broker/VirtualSessionStore.swift
+++ b/Sources/Wax/Broker/VirtualSessionStore.swift
@@ -828,7 +828,9 @@ package final class VirtualSessionStore: @unchecked Sendable {
                 manifest.harvestedAtMs = nowMs
             }
             manifest.promotedCount = report.promotedCount
-            if let reclaimAfterMs = report.reclaimAfterMs {
+            if report.immediateReclaimEligible {
+                manifest.reclaimAfterMs = manifest.harvestedAtMs
+            } else if let reclaimAfterMs = report.reclaimAfterMs {
                 manifest.reclaimAfterMs = reclaimAfterMs
             }
             return

--- a/Sources/Wax/Broker/VirtualSessionStore.swift
+++ b/Sources/Wax/Broker/VirtualSessionStore.swift
@@ -323,13 +323,19 @@ package final class VirtualSessionStore: @unchecked Sendable {
         }
     }
 
-    package func end(sessionID: UUID?) async throws -> EndResult {
+    package func end(
+        sessionID: UUID?,
+        afterFlush: (@Sendable (SessionState) async -> SessionHarvest.Report)? = nil
+    ) async throws -> EndResult {
         try await endMutex.withLock { [self] in
-            try await endSerialized(sessionID: sessionID)
+            try await endSerialized(sessionID: sessionID, afterFlush: afterFlush)
         }
     }
 
-    private func endSerialized(sessionID: UUID?) async throws -> EndResult {
+    private func endSerialized(
+        sessionID: UUID?,
+        afterFlush: (@Sendable (SessionState) async -> SessionHarvest.Report)?
+    ) async throws -> EndResult {
         let target: (id: UUID, state: SessionState)? = try locked {
             switch endTarget(sessionID) {
             case .idle:
@@ -361,16 +367,21 @@ package final class VirtualSessionStore: @unchecked Sendable {
 
         // `_live` retains the state for retry, while `endingSessions` removes it
         // from every routable view before the first suspension point.
-        if target.state.manifest.status != .ended {
-            do {
-                try await target.state.memory.flush()
-                _ = try locked {
-                    guard var state = _live[target.id] else {
-                        throw Self.notActiveError(for: target.id)
-                    }
-                    let timestamp = nowMs()
+        do {
+            try await target.state.memory.flush()
+            var harvest = SessionHarvest.Report.skipped
+            if let afterFlush {
+                harvest = await afterFlush(target.state)
+            }
+            _ = try locked {
+                guard var state = _live[target.id] else {
+                    throw Self.notActiveError(for: target.id)
+                }
+                let timestamp = nowMs()
+                let wasEnded = state.manifest.status == .ended
+                if !wasEnded {
                     state.manifest.status = .ended
-                    state.manifest.updatedAtMs = timestamp
+                    state.manifest.endedAtMs = timestamp
                     state.manifest.brokerLeaseOwnerID = nil
                     state.manifest.leaseExpiresAtMs = nil
                     if endEventFailuresForTesting > 0 {
@@ -387,14 +398,16 @@ package final class VirtualSessionStore: @unchecked Sendable {
                         ),
                         to: state.eventLogURL
                     )
-                    try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
-                    _live[target.id] = state
-                    return state
                 }
-            } catch {
-                _ = locked { endingSessions.remove(target.id) }
-                throw error
+                state.manifest.updatedAtMs = timestamp
+                Self.applyHarvest(harvest, to: &state.manifest, nowMs: timestamp)
+                try BrokerSessionPersistence.saveManifest(state.manifest, to: state.manifestURL)
+                _live[target.id] = state
+                return state
             }
+        } catch {
+            _ = locked { endingSessions.remove(target.id) }
+            throw error
         }
 
         // A close failure deliberately leaves the session reserved (not routable)
@@ -778,6 +791,49 @@ package final class VirtualSessionStore: @unchecked Sendable {
             endingSessions.contains(entry.key)
                 && entry.value.manifest.agentID == agentID
                 && entry.value.manifest.runID == runID
+        }
+    }
+
+    package func persistHarvestToDisk(
+        sessionID: UUID,
+        report: SessionHarvest.Report,
+        markEnded: Bool,
+        nowMs: Int64? = nil
+    ) throws -> BrokerSessionManifest {
+        let timestamp = nowMs ?? self.nowMs()
+        var manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)
+        if markEnded, manifest.status != .ended {
+            manifest.status = .ended
+            manifest.endedAtMs = timestamp
+            manifest.brokerLeaseOwnerID = nil
+            manifest.leaseExpiresAtMs = nil
+        }
+        manifest.updatedAtMs = timestamp
+        Self.applyHarvest(report, to: &manifest, nowMs: timestamp)
+        try BrokerSessionPersistence.saveManifest(
+            manifest,
+            to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
+        )
+        return manifest
+    }
+
+    package static func applyHarvest(
+        _ report: SessionHarvest.Report,
+        to manifest: inout BrokerSessionManifest,
+        nowMs: Int64
+    ) {
+        if let error = report.error, !error.isEmpty {
+            manifest.harvestError = error
+            return
+        }
+        guard report.harvested else { return }
+        manifest.harvestError = nil
+        if manifest.harvestedAtMs == nil {
+            manifest.harvestedAtMs = nowMs
+        }
+        manifest.promotedCount = report.promotedCount
+        if let reclaimAfterMs = report.reclaimAfterMs {
+            manifest.reclaimAfterMs = reclaimAfterMs
         }
     }
 

--- a/Sources/Wax/Broker/VirtualSessionStore.swift
+++ b/Sources/Wax/Broker/VirtualSessionStore.swift
@@ -822,18 +822,19 @@ package final class VirtualSessionStore: @unchecked Sendable {
         to manifest: inout BrokerSessionManifest,
         nowMs: Int64
     ) {
-        if let error = report.error, !error.isEmpty {
-            manifest.harvestError = error
+        if report.harvested {
+            manifest.harvestError = (report.error?.isEmpty == false) ? report.error : nil
+            if manifest.harvestedAtMs == nil {
+                manifest.harvestedAtMs = nowMs
+            }
+            manifest.promotedCount = report.promotedCount
+            if let reclaimAfterMs = report.reclaimAfterMs {
+                manifest.reclaimAfterMs = reclaimAfterMs
+            }
             return
         }
-        guard report.harvested else { return }
-        manifest.harvestError = nil
-        if manifest.harvestedAtMs == nil {
-            manifest.harvestedAtMs = nowMs
-        }
-        manifest.promotedCount = report.promotedCount
-        if let reclaimAfterMs = report.reclaimAfterMs {
-            manifest.reclaimAfterMs = reclaimAfterMs
+        if let error = report.error, !error.isEmpty {
+            manifest.harvestError = error
         }
     }
 

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -89,6 +89,7 @@ package enum MemoryMetadataKeys {
     package static let expiresAtMs = "wax.expires_at_ms"
     package static let confidence = "wax.confidence"
     package static let reviewed = "wax.reviewed"
+    package static let tier = "wax.tier"
     package static let promotedFromSession = "wax.promoted_from_session"
     package static let promotedFromFrame = "wax.promoted_from_frame"
     package static let duplicateOfFrame = "wax.duplicate_of_frame"
@@ -442,11 +443,13 @@ package enum MemorySemantics {
         }
 
         var reasons: [String] = []
-        let cappedCount = min(stats.accessCount, 32)
+        let rankingCount = stats.engagementCount
+        let rankingLast = stats.lastEngagementMs > 0 ? stats.lastEngagementMs : stats.firstAccessMs
+        let cappedCount = min(rankingCount, 32)
         if cappedCount >= 3 {
             reasons.append("repeated use")
         }
-        let hoursSinceAccess = max(0, nowMs - stats.lastAccessMs) / (1000 * 60 * 60)
+        let hoursSinceAccess = max(0, nowMs - rankingLast) / (1000 * 60 * 60)
         if hoursSinceAccess <= 24 {
             reasons.append("recently used")
         }

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1479,10 +1479,24 @@ package actor MemoryOrchestrator {
     }
 
     /// Records an explicit use of a frame (get/promote). Search and recall rank
-    /// against the stored snapshot but do not mutate it.
+    /// against the stored snapshot but do not mutate engagement.
     package func recordAccess(frameId: UInt64) async {
         let nowMs = config.rag.deterministicNowMs ?? nowProvider()
-        await recordAccessesIfEnabled(frameIds: [frameId], nowMs: nowMs)
+        await recordEngagementsIfEnabled(frameIds: [frameId], nowMs: nowMs)
+    }
+
+    package func recordImpression(frameId: UInt64) async {
+        await recordImpressions(frameIds: [frameId])
+    }
+
+    package func recordImpressions(frameIds: [UInt64]) async {
+        let nowMs = config.rag.deterministicNowMs ?? nowProvider()
+        await recordImpressionsIfEnabled(frameIds: frameIds, nowMs: nowMs)
+    }
+
+    package func seedAccessStats(frameId: UInt64, from stats: FrameAccessStats) async {
+        guard config.enableAccessStatsScoring else { return }
+        await accessStatsManager.seedStats(stats, for: frameId)
     }
 
     private func dedupedExplanations(_ reasons: [String]) -> [String] {
@@ -2596,8 +2610,17 @@ package actor MemoryOrchestrator {
     }
 
     private func recordAccessesIfEnabled(frameIds: [UInt64], nowMs: Int64) async {
+        await recordEngagementsIfEnabled(frameIds: frameIds, nowMs: nowMs)
+    }
+
+    private func recordEngagementsIfEnabled(frameIds: [UInt64], nowMs: Int64) async {
         guard config.enableAccessStatsScoring, !frameIds.isEmpty else { return }
         await accessStatsManager.recordAccesses(frameIds: frameIds, nowMs: nowMs)
+    }
+
+    private func recordImpressionsIfEnabled(frameIds: [UInt64], nowMs: Int64) async {
+        guard config.enableAccessStatsScoring, !frameIds.isEmpty else { return }
+        await accessStatsManager.recordImpressions(frameIds: frameIds, nowMs: nowMs)
     }
 
     private func loadPersistedAccessStatsIfNeeded() async throws {

--- a/Sources/Wax/RAG/AccessFrequencyRanker.swift
+++ b/Sources/Wax/RAG/AccessFrequencyRanker.swift
@@ -123,10 +123,12 @@ package enum AccessFrequencyRanker {
 
     package static func rawAdjustment(stats: FrameAccessStats?, nowMs: Int64) -> Float {
         guard let stats else { return 0 }
-        let hoursSinceAccess = Float(max(0, nowMs - stats.lastAccessMs)) / (1000 * 60 * 60)
+        let rankingCount = stats.engagementCount
+        let rankingLast = stats.lastEngagementMs > 0 ? stats.lastEngagementMs : stats.firstAccessMs
+        let hoursSinceAccess = Float(max(0, nowMs - rankingLast)) / (1000 * 60 * 60)
         let frequency = min(
             1,
-            log(Float(min(stats.accessCount, countSaturation)) + 1)
+            log(Float(min(rankingCount, countSaturation)) + 1)
                 / log(Float(countSaturation) + 1)
         )
         let frequencyDecay = exp(-hoursSinceAccess / frequencyHalfLifeHours)

--- a/Sources/Wax/Stats/AccessStats.swift
+++ b/Sources/Wax/Stats/AccessStats.swift
@@ -4,28 +4,116 @@ import Foundation
 package struct FrameAccessStats: Sendable, Equatable, Codable {
     /// Frame ID
     package var frameId: UInt64
-    
-    /// Total access count
-    package var accessCount: UInt32
-    
-    /// Last access timestamp (milliseconds since epoch)
-    package var lastAccessMs: Int64
-    
+
+    /// Times the frame appeared in a retrieval result list.
+    package var impressionCount: UInt32
+
+    /// Times the frame was explicitly used (get/promote/compact short).
+    package var engagementCount: UInt32
+
+    /// Last impression timestamp (milliseconds since epoch)
+    package var lastImpressionMs: Int64
+
+    /// Last engagement timestamp (milliseconds since epoch)
+    package var lastEngagementMs: Int64
+
     /// First access timestamp (milliseconds since epoch)
     package var firstAccessMs: Int64
-    
+
+    package var accessCount: UInt32 {
+        get { impressionCount }
+        set { impressionCount = newValue }
+    }
+
+    package var lastAccessMs: Int64 {
+        get { lastImpressionMs }
+        set { lastImpressionMs = newValue }
+    }
+
     package init(frameId: UInt64, nowMs: Int64) {
         self.frameId = frameId
-        self.accessCount = 1
-        self.lastAccessMs = nowMs
+        self.impressionCount = 1
+        self.engagementCount = 0
+        self.lastImpressionMs = nowMs
+        self.lastEngagementMs = 0
         self.firstAccessMs = nowMs
     }
 
+    package init(
+        frameId: UInt64,
+        impressionCount: UInt32,
+        engagementCount: UInt32,
+        lastImpressionMs: Int64,
+        lastEngagementMs: Int64,
+        firstAccessMs: Int64
+    ) {
+        self.frameId = frameId
+        self.impressionCount = impressionCount
+        self.engagementCount = engagementCount
+        self.lastImpressionMs = lastImpressionMs
+        self.lastEngagementMs = lastEngagementMs
+        self.firstAccessMs = firstAccessMs
+    }
+
+    package mutating func recordImpression(nowMs: Int64) {
+        let (nextCount, overflowed) = impressionCount.addingReportingOverflow(1)
+        impressionCount = overflowed ? UInt32.max : nextCount
+        lastImpressionMs = nowMs
+    }
+
+    package mutating func recordEngagement(nowMs: Int64) {
+        let (nextCount, overflowed) = engagementCount.addingReportingOverflow(1)
+        engagementCount = overflowed ? UInt32.max : nextCount
+        lastEngagementMs = nowMs
+        lastImpressionMs = nowMs
+        let (nextImpression, impressionOverflowed) = impressionCount.addingReportingOverflow(1)
+        impressionCount = impressionOverflowed ? UInt32.max : nextImpression
+    }
+
     package mutating func recordAccess(nowMs: Int64) {
-        // Use saturating addition to prevent overflow
-        let (nextCount, overflowed) = accessCount.addingReportingOverflow(1)
-        accessCount = overflowed ? UInt32.max : nextCount
-        lastAccessMs = nowMs
+        recordEngagement(nowMs: nowMs)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case frameId
+        case impressionCount
+        case engagementCount
+        case lastImpressionMs
+        case lastEngagementMs
+        case firstAccessMs
+        case accessCount
+        case lastAccessMs
+    }
+
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        frameId = try container.decode(UInt64.self, forKey: .frameId)
+        firstAccessMs = try container.decode(Int64.self, forKey: .firstAccessMs)
+        if let impression = try container.decodeIfPresent(UInt32.self, forKey: .impressionCount) {
+            impressionCount = impression
+            engagementCount = try container.decodeIfPresent(UInt32.self, forKey: .engagementCount) ?? 0
+            lastImpressionMs = try container.decodeIfPresent(Int64.self, forKey: .lastImpressionMs)
+                ?? container.decodeIfPresent(Int64.self, forKey: .lastAccessMs)
+                ?? firstAccessMs
+            lastEngagementMs = try container.decodeIfPresent(Int64.self, forKey: .lastEngagementMs) ?? 0
+        } else {
+            let access = try container.decode(UInt32.self, forKey: .accessCount)
+            let lastAccess = try container.decode(Int64.self, forKey: .lastAccessMs)
+            impressionCount = access
+            engagementCount = access
+            lastImpressionMs = lastAccess
+            lastEngagementMs = lastAccess
+        }
+    }
+
+    package func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(frameId, forKey: .frameId)
+        try container.encode(impressionCount, forKey: .impressionCount)
+        try container.encode(engagementCount, forKey: .engagementCount)
+        try container.encode(lastImpressionMs, forKey: .lastImpressionMs)
+        try container.encode(lastEngagementMs, forKey: .lastEngagementMs)
+        try container.encode(firstAccessMs, forKey: .firstAccessMs)
     }
 }
 
@@ -37,10 +125,14 @@ package actor AccessStatsManager {
 
     package init() {}
 
-    /// Record a single frame access.
+    /// Record a single frame access (engagement).
     package func recordAccess(frameId: UInt64, nowMs: Int64) {
+        recordEngagement(frameId: frameId, nowMs: nowMs)
+    }
+
+    package func recordImpression(frameId: UInt64, nowMs: Int64) {
         if var existing = stats[frameId] {
-            existing.recordAccess(nowMs: nowMs)
+            existing.recordImpression(nowMs: nowMs)
             stats[frameId] = existing
         } else {
             stats[frameId] = FrameAccessStats(frameId: frameId, nowMs: nowMs)
@@ -49,12 +141,11 @@ package actor AccessStatsManager {
         revision = revision == UInt64.max ? 0 : revision + 1
     }
 
-    /// Record accesses for multiple frames at once.
-    package func recordAccesses(frameIds: [UInt64], nowMs: Int64) {
+    package func recordImpressions(frameIds: [UInt64], nowMs: Int64) {
         guard !frameIds.isEmpty else { return }
         for frameId in frameIds {
             if var existing = stats[frameId] {
-                existing.recordAccess(nowMs: nowMs)
+                existing.recordImpression(nowMs: nowMs)
                 stats[frameId] = existing
             } else {
                 stats[frameId] = FrameAccessStats(frameId: frameId, nowMs: nowMs)
@@ -63,12 +154,42 @@ package actor AccessStatsManager {
         dirty = true
         revision = revision == UInt64.max ? 0 : revision + 1
     }
-    
+
+    package func recordEngagement(frameId: UInt64, nowMs: Int64) {
+        if var existing = stats[frameId] {
+            existing.recordEngagement(nowMs: nowMs)
+            stats[frameId] = existing
+        } else {
+            var created = FrameAccessStats(frameId: frameId, nowMs: nowMs)
+            created.engagementCount = 1
+            created.lastEngagementMs = nowMs
+            stats[frameId] = created
+        }
+        dirty = true
+        revision = revision == UInt64.max ? 0 : revision + 1
+    }
+
+    /// Record accesses for multiple frames at once (engagement).
+    package func recordAccesses(frameIds: [UInt64], nowMs: Int64) {
+        guard !frameIds.isEmpty else { return }
+        for frameId in frameIds {
+            recordEngagement(frameId: frameId, nowMs: nowMs)
+        }
+    }
+
+    package func seedStats(_ imported: FrameAccessStats, for frameId: UInt64) {
+        var copy = imported
+        copy.frameId = frameId
+        stats[frameId] = copy
+        dirty = true
+        revision = revision == UInt64.max ? 0 : revision + 1
+    }
+
     /// Get stats for a single frame.
     package func getStats(frameId: UInt64) -> FrameAccessStats? {
         stats[frameId]
     }
-    
+
     /// Get stats for multiple frames.
     package func getStats(frameIds: [UInt64]) -> [UInt64: FrameAccessStats] {
         var result: [UInt64: FrameAccessStats] = [:]
@@ -84,7 +205,7 @@ package actor AccessStatsManager {
     package func snapshot() -> [UInt64: FrameAccessStats] {
         stats
     }
-    
+
     /// Remove stats for frames that no longer exist.
     package func pruneStats(keepingOnly activeFrameIds: Set<UInt64>) {
         let before = stats.count
@@ -94,7 +215,7 @@ package actor AccessStatsManager {
             revision = revision == UInt64.max ? 0 : revision + 1
         }
     }
-    
+
     /// Export all stats for persistence.
     package func exportStats() -> [FrameAccessStats] {
         Array(stats.values).sorted { $0.frameId < $1.frameId }
@@ -127,14 +248,14 @@ package actor AccessStatsManager {
         dirty = false
         return true
     }
-    
+
     /// Import stats from persistence.
     package func importStats(_ imported: [FrameAccessStats]) {
         stats = Dictionary(uniqueKeysWithValues: imported.map { ($0.frameId, $0) })
         dirty = false
         revision = revision == UInt64.max ? 0 : revision + 1
     }
-    
+
     /// Total number of tracked frames.
     package var count: Int {
         stats.count

--- a/Sources/WaxCLI/MemoryMaintainCommand.swift
+++ b/Sources/WaxCLI/MemoryMaintainCommand.swift
@@ -1,0 +1,55 @@
+import ArgumentParser
+import Foundation
+import Wax
+
+struct MemoryMaintainCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "memory-maintain",
+        abstract: "Dry-run or apply session harvest, reclaim, and working-set quarantine"
+    )
+
+    @OptionGroup var store: VectorStoreOptions
+
+    @Flag(
+        name: .customLong("apply"),
+        help: "Apply harvest, reclaim, and quarantine. Default is dry-run."
+    )
+    var apply = false
+
+    @Flag(
+        name: .customLong("dry-run"),
+        help: "Report planned actions without mutating (default)."
+    )
+    var dryRun = false
+
+    @Flag(
+        name: .customLong("force-reclaim"),
+        help: "Unlink ended session stores even if harvest failed."
+    )
+    var forceReclaim = false
+
+    func runAsync() async throws {
+        guard !store.directStore else {
+            throw CLIError("--direct-store is not supported for broker parity commands")
+        }
+        let response = try await AgentBrokerCLI.perform(
+            command: "memory_maintain",
+            arguments: [
+                "apply": .bool(apply && !dryRun),
+                "force_reclaim": .bool(forceReclaim),
+            ],
+            storePath: store.storePath,
+            embedderChoice: store.embedder.rawValue,
+            noEmbedder: store.noEmbedder,
+            requireVector: store.requireVector,
+            embedderTuning: store.embedderTuning
+        )
+        let payload = try brokerPayloadObject(response)
+        switch store.format {
+        case .json:
+            printJSON(payload.toJSONObject())
+        case .text:
+            print(brokerString(payload, "display_text") ?? "Maintain complete.")
+        }
+    }
+}

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -24,6 +24,7 @@ struct WaxCLI: ParsableCommand {
             DaemonCommand.self,
             StatsCommand.self,
             CompactStoreCommand.self,
+            MemoryMaintainCommand.self,
             EmbedBackfillCommand.self,
             VectorHealthCommand.self,
             FlushCommand.self,
@@ -765,7 +766,7 @@ enum WaxMCPAgentPlaybook {
         - Use `recall` for assembled context and `search` for raw ranked hits.
         - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
         - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
-        - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat.
+        - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
         - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
         - Use structured memory tools (`entity_upsert`, `fact_assert`, `fact_retract`, `facts_query`, `entity_resolve`) for stable entities and facts, not transient debugging notes.
         - `task_state` is session-local working state: it requires an active top-level `session_id` and rejects `scope: durable`, `durability: durable`, and `locked`. To repair legacy durable task-state frames, run `task_state_migrate` with a distinct `destination_path`; it copies the complete store before changing only task-state trees. Use `dry_run: true` first and choose `orphan_policy: quarantine` (default) or `drop`.
@@ -788,7 +789,7 @@ enum WaxMCPAgentPlaybook {
 
         Close: `session_close` (`session_id`, `content`, `project`, `pending_tasks`) or `handoff` then `session_end`.
 
-        Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
+        Do not put `session_id` in `metadata`. Do not store secrets, transcripts, or huge logs. Do not manage `SESSION_STORE`, `--store-path`, or `flush`. Do not call `memory-maintain` from the agent loop. Prefer `mode: "text"` for exact names and recent facts. Structured `entity_*` / `fact_*` tools are for stable graph facts, not debug notes.
         """
 
     /// Pasteable Hermes / OpenClaw SOUL.md stanza. Append; do not replace the soul.
@@ -806,7 +807,7 @@ enum WaxMCPAgentPlaybook {
 
         Read: `recall` defaults to project scope (no foreign/unlabeled frames). Need cross-project → `scope: global`. `recall` with `session_id` merges this session with durable memory. Need a budgeted mix → `compact_context`.
 
-        Close with `session_close` (or `handoff` then `session_end`). Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
+        Close with `session_close` (or `handoff` then `session_end`). Harvest is automatic; do not call `memory_promote` or `memory-maintain` in the agent loop. Do not invent a `session_id` or put it in `metadata`. Do not store secrets.
         """
 
     static let githubSkillURL =

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -12,7 +12,7 @@ enum MCPAgentInstructions {
         1) Prefer session_open(project?, agent_id?, run_id?, recall_query?) for a one-shot open, or call handoff_latest first (optional project) then session_start once and keep the returned session_id. The same agent_id+run_id resumes the active session.
         2) Before answering from memory, call recall (default) or search (raw ranked hits). Default recall scope is project: hard-filters to resolved project (explicit project, session project, or cwd/git root). Empty project lane returns an explicit miss — never auto-widens to global. Pass scope=global only when cross-project retrieval is intentional. Passing session_id merges that session with durable long-term memory under project scope.
         3) When you learn durable facts, call remember with concise factual content. Prefer scope=session|durable; session requires top-level session_id; durable forbids session_id. Never put session_id inside metadata.
-        4) Near session end, prefer session_close(session_id, content, optional project/pending_tasks) for atomic handoff+end. Keep content to a concise state summary; put unfinished work only in pending_tasks and never store transcripts. Or call handoff then session_end. session_end/session_close `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
+        4) Near session end, prefer session_close(session_id, content, optional project/pending_tasks) for atomic handoff+end. Close harvests promotable session facts into durable memory automatically — do not call memory_promote or memory-maintain in the agent loop. Keep content to a concise state summary; put unfinished work only in pending_tasks and never store transcripts. Or call handoff then session_end. session_end/session_close `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
         5) A persisted session_id survives broker hops: remember/recall/handoff rebind that UUID when the manifest is still active. Ended/unknown UUIDs return structured inactive errors (resumable=false).
         6) task_state is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with task_state_migrate into a distinct destination after a dry run; choose quarantine (default) or drop for orphaned records.
 
@@ -25,7 +25,7 @@ enum MCPAgentInstructions {
         - entity_*/fact_*: stable structured knowledge, not transient debug notes
         - stats: health / embedder / store check
 
-        Do not manage SESSION_STORE, --store-path, or flush in normal agent flows. The broker owns long-term memory and virtual session stores.
+        Do not manage SESSION_STORE, --store-path, flush, or memory-maintain in normal agent flows. The broker owns long-term memory and virtual session stores; wax-cli memory-maintain is operator-only.
 
         Responses default to one compact JSON content block. Pass verbosity=verbose only when narrative text plus structuredContent is useful.
 

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -909,6 +909,7 @@ struct WaxCLIMemoryTests {
         #expect(WaxMCPAgentPlaybook.projectRules.contains("session_id"))
         #expect(WaxMCPAgentPlaybook.projectRules.contains("task_state"))
         #expect(WaxMCPAgentPlaybook.projectRules.contains("compact_context"))
+        #expect(WaxMCPAgentPlaybook.projectRules.contains("memory-maintain"))
         #expect(WaxMCPAgentPlaybook.soulRules.contains("## Memory (Wax)"))
         #expect(WaxMCPAgentPlaybook.githubSkillURL.contains("wax-mcp"))
     }

--- a/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
+++ b/Tests/WaxIntegrationTests/AccessFrequencyRankingTests.swift
@@ -17,6 +17,8 @@ func accessFrequencyDisabledModeLeavesCandidatesUntouched() {
     ]
     var stats = FrameAccessStats(frameId: 2, nowMs: 1_700_000_000_000)
     stats.accessCount = 32
+    stats.engagementCount = 32
+    stats.lastEngagementMs = stats.lastImpressionMs
 
     let ranked = AccessFrequencyRanker.rerank(
         results: results,
@@ -49,8 +51,12 @@ func accessFrequencyDemotesStaleLowUseAndExplainsPublishedAdjustment() {
     ]
     var stale = FrameAccessStats(frameId: 1, nowMs: nowMs - 30 * dayMs)
     stale.accessCount = 1
+    stale.engagementCount = 1
+    stale.lastEngagementMs = stale.lastImpressionMs
     var recent = FrameAccessStats(frameId: 2, nowMs: nowMs - 6 * hourMs)
     recent.accessCount = 8
+    recent.engagementCount = 8
+    recent.lastEngagementMs = recent.lastImpressionMs
 
     let ranked = AccessFrequencyRanker.rerank(
         results: results,
@@ -96,6 +102,8 @@ func accessFrequencyProtectsExactIdentifierAndDurablePolicy() {
     let staleExact = FrameAccessStats(frameId: 1, nowMs: nowMs - 90 * dayMs)
     var recentNeighbor = FrameAccessStats(frameId: 2, nowMs: nowMs)
     recentNeighbor.accessCount = 32
+    recentNeighbor.engagementCount = 32
+    recentNeighbor.lastEngagementMs = recentNeighbor.lastImpressionMs
 
     let ranked = AccessFrequencyRanker.rerank(
         results: [exact, neighbor],
@@ -127,6 +135,8 @@ func accessFrequencyAdjustmentIsBoundedAgainstRichGetRicherAmplification() {
     let nowMs: Int64 = 1_700_000_000_000
     var saturated = FrameAccessStats(frameId: 1, nowMs: nowMs)
     saturated.accessCount = UInt32.max
+    saturated.engagementCount = UInt32.max
+    saturated.lastEngagementMs = saturated.lastImpressionMs
     let positive = AccessFrequencyRanker.adjustment(stats: saturated, nowMs: nowMs)
     #expect(positive == AccessFrequencyRanker.maximumAdjustment)
 
@@ -140,6 +150,8 @@ func accessFrequencyPreservesPublishedScoreScale() {
     let nowMs: Int64 = 1_700_000_000_000
     var stats = FrameAccessStats(frameId: 1, nowMs: nowMs)
     stats.accessCount = UInt32.max
+    stats.engagementCount = UInt32.max
+    stats.lastEngagementMs = stats.lastImpressionMs
     let result = makeAccessRankingResult(frameId: 1, score: 4.0, preview: "boundary")
 
     let ranked = AccessFrequencyRanker.rerank(

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -434,6 +434,7 @@ func toolsListContainsExpectedTools() {
     #expect(names.contains("knowledge_capture"))
     #expect(names.contains("corpus_search"))
     #expect(!names.contains("flush"))
+    #expect(!names.contains("memory_maintain"))
     #expect(names.contains("stats"))
     #expect(names.contains("session_start"))
     #expect(names.contains("session_resume"))

--- a/Tests/WaxTests/BrokerCommandDecodeTests.swift
+++ b/Tests/WaxTests/BrokerCommandDecodeTests.swift
@@ -32,6 +32,7 @@ struct BrokerCommandDecodeTests {
         #expect(AgentBrokerCommandSurface.canonicalCommand(for: "wax_recall") == nil)
         #expect(AgentBrokerCommandSurface.isPublicCommand("memory_append"))
         #expect(!AgentBrokerCommandSurface.isPublicCommand("flush"))
+        #expect(!AgentBrokerCommandSurface.isPublicCommand("memory_maintain"))
         #expect(AgentBrokerCommandSurface.requiresStructuredMemory("facts_query"))
         #expect(!AgentBrokerCommandSurface.requiresStructuredMemory("recall"))
 
@@ -551,6 +552,32 @@ struct BrokerCommandDecodeTests {
                 Issue.record("\(command) threw unexpected error \(error)")
             }
         }
+    }
+
+    @Test
+    func memoryMaintainDefaultsToDryRunAndHonorsDryRunOverride() throws {
+        let dry = try BrokerCommand.decode(command: "memory_maintain", arguments: [:])
+        guard case .memoryMaintain(let payload) = dry else {
+            Issue.record("expected memory_maintain")
+            return
+        }
+        #expect(payload.apply == false)
+        #expect(payload.forceReclaim == false)
+
+        let forcedDry = try BrokerCommand.decode(
+            command: "memory_maintain",
+            arguments: [
+                "apply": .bool(true),
+                "dry_run": .bool(true),
+                "force_reclaim": .bool(true),
+            ]
+        )
+        guard case .memoryMaintain(let overridden) = forcedDry else {
+            Issue.record("expected memory_maintain override")
+            return
+        }
+        #expect(overridden.apply == false)
+        #expect(overridden.forceReclaim == true)
     }
 
     @Test

--- a/Tests/WaxTests/MemoryRetentionPolicyTests.swift
+++ b/Tests/WaxTests/MemoryRetentionPolicyTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func keepScorePinsLockedAndReviewedFrames() {
+    let nowMs: Int64 = 1_700_000_000_000
+    let locked = MemoryRetention.keepScore(
+        type: .note,
+        durability: .locked,
+        reviewed: false,
+        engagementCount: 0,
+        lastEngagementMs: 0,
+        nowMs: nowMs
+    )
+    let working = MemoryRetention.keepScore(
+        type: .note,
+        durability: .working,
+        reviewed: false,
+        engagementCount: 0,
+        lastEngagementMs: 0,
+        nowMs: nowMs
+    )
+    #expect(locked > working)
+    #expect(locked >= 0.25)
+}
+
+@Test
+func lockedFramesAreNeverColdOrQuarantined() {
+    let nowMs: Int64 = 1_700_000_000_000
+    let created = nowMs - 400 * 24 * 60 * 60 * 1000
+    let metadata = [
+        MemoryMetadataKeys.type: MemoryType.decision.rawValue,
+        MemoryMetadataKeys.durability: MemoryDurability.locked.rawValue,
+        MemoryMetadataKeys.createdAtMs: String(created),
+    ]
+    #expect(
+        MemoryRetention.isCold(metadata: metadata, stats: nil, nowMs: nowMs) == false
+    )
+    #expect(
+        MemoryRetention.isQuarantineCandidate(metadata: metadata, stats: nil, nowMs: nowMs) == false
+    )
+}
+
+@Test
+func agedWorkingNotesAreQuarantineCandidates() {
+    let nowMs: Int64 = 1_700_000_000_000
+    let created = nowMs - 31 * 24 * 60 * 60 * 1000
+    let metadata = [
+        MemoryMetadataKeys.type: MemoryType.note.rawValue,
+        MemoryMetadataKeys.durability: MemoryDurability.working.rawValue,
+        MemoryMetadataKeys.createdAtMs: String(created),
+    ]
+    #expect(MemoryRetention.isQuarantineCandidate(metadata: metadata, stats: nil, nowMs: nowMs))
+}
+
+@Test
+func coldTierIsHiddenFromDefaultHybridAndVisibleToText() {
+    let nowMs: Int64 = 1_700_000_000_000
+    let metadata = [
+        MemoryMetadataKeys.type: MemoryType.decision.rawValue,
+        MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+        MemoryMetadataKeys.tier: MemoryTier.cold.rawValue,
+        MemoryMetadataKeys.createdAtMs: String(nowMs - 40 * 24 * 60 * 60 * 1000),
+    ]
+    #expect(
+        MemoryRetention.isVisibleInDefaultRecall(
+            metadata: metadata,
+            stats: nil,
+            nowMs: nowMs,
+            query: "what should we never auto-delete",
+            mode: .hybrid(alpha: 0.5)
+        ) == false
+    )
+    #expect(
+        MemoryRetention.isVisibleInDefaultRecall(
+            metadata: metadata,
+            stats: nil,
+            nowMs: nowMs,
+            query: "WAXCOLD-ZX9",
+            mode: .textOnly
+        )
+    )
+}
+
+@Test
+func legacyAccessStatsJSONMapsAccessCountOntoEngagement() throws {
+    let json = """
+    {
+      "frameId": 7,
+      "accessCount": 12,
+      "lastAccessMs": 1700000000000,
+      "firstAccessMs": 1690000000000
+    }
+    """
+    let stats = try JSONDecoder().decode(FrameAccessStats.self, from: Data(json.utf8))
+    #expect(stats.frameId == 7)
+    #expect(stats.impressionCount == 12)
+    #expect(stats.engagementCount == 12)
+    #expect(stats.lastEngagementMs == 1_700_000_000_000)
+    #expect(AccessFrequencyRanker.adjustment(stats: stats, nowMs: 1_700_000_000_000) > 0)
+}
+
+@Test
+func retentionSettingsReadEnvSeconds() {
+    let settings = MemoryRetentionSettings.fromEnvironment([
+        "WAX_SESSION_RECENTLY_CLOSED_SECS": "60",
+        "WAX_WORKING_QUARANTINE_SECS": "120",
+        "WAX_KEEP_COLD_THRESHOLD": "0.4",
+        "WAX_COLD_MIN_AGE_SECS": "30",
+    ])
+    #expect(settings.recentlyClosedMs == 60_000)
+    #expect(settings.workingQuarantineMs == 120_000)
+    #expect(settings.keepColdThreshold == 0.4)
+    #expect(settings.coldMinAgeMs == 30_000)
+}

--- a/Tests/WaxTests/MemoryRetentionPolicyTests.swift
+++ b/Tests/WaxTests/MemoryRetentionPolicyTests.swift
@@ -66,7 +66,6 @@ func coldTierIsHiddenFromDefaultHybridAndVisibleToText() {
     #expect(
         MemoryRetention.isVisibleInDefaultRecall(
             metadata: metadata,
-            stats: nil,
             nowMs: nowMs,
             query: "what should we never auto-delete",
             mode: .hybrid(alpha: 0.5)
@@ -75,11 +74,33 @@ func coldTierIsHiddenFromDefaultHybridAndVisibleToText() {
     #expect(
         MemoryRetention.isVisibleInDefaultRecall(
             metadata: metadata,
-            stats: nil,
             nowMs: nowMs,
             query: "WAXCOLD-ZX9",
             mode: .textOnly
         )
+    )
+}
+
+@Test
+func untaggedAgedDurableLibraryStaysVisibleInHybridRecall() {
+    let nowMs: Int64 = 1_700_000_000_000
+    let metadata = [
+        MemoryMetadataKeys.type: MemoryType.decision.rawValue,
+        MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+        MemoryMetadataKeys.createdAtMs: String(nowMs - 40 * 24 * 60 * 60 * 1000),
+    ]
+    #expect(
+        MemoryRetention.isCold(metadata: metadata, stats: nil, nowMs: nowMs),
+        "keep-score may classify untagged library as cold for a future archive pass"
+    )
+    #expect(
+        MemoryRetention.isVisibleInDefaultRecall(
+            metadata: metadata,
+            nowMs: nowMs,
+            query: "what should we never auto-delete",
+            mode: .hybrid(alpha: 0.5)
+        ),
+        "unset wax.tier must stay hot in default hybrid recall"
     )
 }
 

--- a/Tests/WaxTests/SessionHarvestSoakTests.swift
+++ b/Tests/WaxTests/SessionHarvestSoakTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func sessionHarvestSoakPromotesNeedleAndReclaimsStore() async throws {
+    let distractorCount = max(
+        50,
+        ProcessInfo.processInfo.environment["WAX_HARVEST_SOAK_COUNT"].flatMap(Int.init) ?? 50
+    )
+    let needle = "WAXSOAK-\(UUID().uuidString.prefix(8))"
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-harvest-soak-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("soak-agent"),
+                "run_id": .string("soak-run"),
+                "project": .string("soak-qa"),
+                "repo": .string("soak-qa"),
+            ]
+        ))
+        #expect(started.ok == true, "session_start failed: \(started.error ?? "nil")")
+        let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)
+
+        let needleWrite = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Decision: \(needle) is the soak harvest gold token."),
+                "session_id": .string(sessionID),
+                "memory_type": .string("decision"),
+                "durability": .string("working"),
+                "project": .string("soak-qa"),
+                "repo": .string("soak-qa"),
+            ]
+        ))
+        #expect(needleWrite.ok == true, "needle remember failed: \(needleWrite.error ?? "nil")")
+
+        for index in 0..<distractorCount {
+            let write = await service.handle(.init(
+                command: "remember",
+                arguments: [
+                    "content": .string("Soak distractor \(index) has no gold token and should stay unpromoted."),
+                    "session_id": .string(sessionID),
+                    "memory_type": .string("note"),
+                    "durability": .string("working"),
+                    "project": .string("soak-qa"),
+                    "repo": .string("soak-qa"),
+                ]
+            ))
+            #expect(write.ok == true, "distractor \(index) remember failed: \(write.error ?? "nil")")
+        }
+
+        let ended = await service.handle(.init(
+            command: "session_end",
+            arguments: ["session_id": .string(sessionID)]
+        ))
+        #expect(ended.ok == true, "session_end failed: \(ended.error ?? "nil")")
+        #expect(ended.payload?.objectValue?["harvested"]?.boolValue == true)
+
+        let recall = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(needle),
+                "mode": .string("text"),
+                "scope": .string("project"),
+                "project": .string("soak-qa"),
+                "repo": .string("soak-qa"),
+                "limit": .int(8),
+            ]
+        ))
+        #expect(recall.ok == true, "recall failed: \(recall.error ?? "nil")")
+        let top = recall.payload?.objectValue?["results"]?.arrayValue?.first?.objectValue?["text"]?.stringValue ?? ""
+        #expect(top.contains(needle), "soak durable recall missed needle; top=\(top)")
+
+        let uuid = try #require(UUID(uuidString: sessionID))
+        var manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: uuid)
+        manifest.reclaimAfterMs = 1
+        try BrokerSessionPersistence.saveManifest(
+            manifest,
+            to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: uuid)
+        )
+        let applied = await service.handle(.init(
+            command: "memory_maintain",
+            arguments: ["apply": .bool(true)]
+        ))
+        #expect(applied.ok == true, "soak reclaim failed: \(applied.error ?? "nil")")
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: sessionRootURL.appendingPathComponent("\(sessionID).wax").path
+            )
+        )
+
+        let after = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(needle),
+                "mode": .string("text"),
+                "scope": .string("project"),
+                "project": .string("soak-qa"),
+                "repo": .string("soak-qa"),
+                "limit": .int(8),
+            ]
+        ))
+        let afterTop = after.payload?.objectValue?["results"]?.arrayValue?.first?.objectValue?["text"]?.stringValue ?? ""
+        #expect(afterTop.contains(needle))
+        try await service.close()
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}

--- a/Tests/WaxTests/SessionHarvestTests.swift
+++ b/Tests/WaxTests/SessionHarvestTests.swift
@@ -1,0 +1,640 @@
+import Foundation
+import Testing
+@testable import Wax
+
+private let harvestProject = "harvest-qa"
+
+private func withHarvestBroker<T>(
+    _ body: (AgentBrokerService, URL) async throws -> T
+) async throws -> T {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-harvest-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        let result = try await body(service, sessionRootURL)
+        try await service.close()
+        return result
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+private func requireObject(_ value: AgentBrokerValue?) throws -> [String: AgentBrokerValue] {
+    try #require(value?.objectValue)
+}
+
+private func requireString(_ object: [String: AgentBrokerValue], _ key: String) throws -> String {
+    try #require(object[key]?.stringValue)
+}
+
+private func firstHitText(_ payload: [String: AgentBrokerValue]) -> String {
+    let first = payload["results"]?.arrayValue?.first?.objectValue
+    return first?["text"]?.stringValue
+        ?? first?["preview"]?.stringValue
+        ?? ""
+}
+
+private func startHarvestSession(
+    _ service: AgentBrokerService,
+    runID: String
+) async throws -> String {
+    let started = await service.handle(.init(
+        command: "session_start",
+        arguments: [
+            "agent_id": .string("harvest-agent"),
+            "run_id": .string(runID),
+            "project": .string(harvestProject),
+            "repo": .string(harvestProject),
+        ]
+    ))
+    #expect(started.ok == true, "session_start failed: \(started.error ?? "nil")")
+    return try requireString(try requireObject(started.payload), "session_id")
+}
+
+private func rememberSession(
+    _ service: AgentBrokerService,
+    sessionID: String,
+    content: String,
+    memoryType: String,
+    durability: String = "working"
+) async throws {
+    let write = await service.handle(.init(
+        command: "remember",
+        arguments: [
+            "content": .string(content),
+            "session_id": .string(sessionID),
+            "memory_type": .string(memoryType),
+            "durability": .string(durability),
+            "project": .string(harvestProject),
+            "repo": .string(harvestProject),
+        ]
+    ))
+    #expect(write.ok == true, "remember failed: \(write.error ?? "nil")")
+}
+
+private func endSession(_ service: AgentBrokerService, sessionID: String) async throws -> [String: AgentBrokerValue] {
+    let ended = await service.handle(.init(
+        command: "session_end",
+        arguments: ["session_id": .string(sessionID)]
+    ))
+    #expect(ended.ok == true, "session_end failed: \(ended.error ?? "nil")")
+    return try requireObject(ended.payload)
+}
+
+private func projectRecall(
+    _ service: AgentBrokerService,
+    query: String,
+    mode: String = "text"
+) async throws -> [String: AgentBrokerValue] {
+    let recall = await service.handle(.init(
+        command: "recall",
+        arguments: [
+            "query": .string(query),
+            "mode": .string(mode),
+            "scope": .string("project"),
+            "project": .string(harvestProject),
+            "repo": .string(harvestProject),
+            "limit": .int(8),
+        ]
+    ))
+    #expect(recall.ok == true, "recall failed: \(recall.error ?? "nil")")
+    return try requireObject(recall.payload)
+}
+
+private func sessionStoreURL(root: URL, sessionID: String) -> URL {
+    root.appendingPathComponent("\(sessionID).wax")
+}
+
+@Test
+func sessionCloseHarvestsAlwaysPromotableNeedleIntoDurableRecall() async throws {
+    let needle = "WAXHVST-\(UUID().uuidString.prefix(8))"
+    try await withHarvestBroker { service, sessionRoot in
+        let sessionID = try await startHarvestSession(service, runID: "harvest-needle")
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Decision: keep \(needle) as the harvest gold token.",
+            memoryType: "decision"
+        )
+        for index in 0..<8 {
+            try await rememberSession(
+                service,
+                sessionID: sessionID,
+                content: "Working distractor \(index) about ranking noise without the gold token.",
+                memoryType: "note"
+            )
+        }
+
+        let ended = try await endSession(service, sessionID: sessionID)
+        #expect(ended["harvested"]?.boolValue == true)
+        #expect((ended["promoted_count"]?.intValue ?? 0) >= 1)
+        #expect(ended["reclaimed"]?.boolValue == false)
+        #expect(FileManager.default.fileExists(atPath: sessionStoreURL(root: sessionRoot, sessionID: sessionID).path))
+
+        let payload = try await projectRecall(service, query: needle)
+        #expect(
+            firstHitText(payload).contains(needle),
+            "durable recall missed harvested needle; top=\(firstHitText(payload))"
+        )
+        #expect(payload["results"]?.arrayValue?.contains { result in
+            result.objectValue?["text"]?.stringValue?.contains("Working distractor") == true
+        } != true)
+    }
+}
+
+@Test
+func emptyPromotableSessionUnlinksImmediately() async throws {
+    let needle = "WAXHVIM-\(UUID().uuidString.prefix(8))"
+    try await withHarvestBroker { service, sessionRoot in
+        let sessionID = try await startHarvestSession(service, runID: "harvest-immediate")
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Decision: \(needle) is the only session fact.",
+            memoryType: "decision"
+        )
+        let ended = try await endSession(service, sessionID: sessionID)
+        #expect(ended["harvested"]?.boolValue == true)
+        #expect(ended["reclaimed"]?.boolValue == true)
+        #expect(!FileManager.default.fileExists(atPath: sessionStoreURL(root: sessionRoot, sessionID: sessionID).path))
+
+        let manifest = try BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRoot,
+            sessionID: UUID(uuidString: sessionID)!
+        )
+        #expect(manifest.reclaimedAtMs != nil)
+        #expect(manifest.status == .ended)
+
+        let payload = try await projectRecall(service, query: needle)
+        #expect(firstHitText(payload).contains(needle))
+    }
+}
+
+@Test
+func secondCloseIsIdempotentAndDoesNotDuplicateHarvest() async throws {
+    let needle = "WAXHVID-\(UUID().uuidString.prefix(8))"
+    try await withHarvestBroker { service, _ in
+        let sessionID = try await startHarvestSession(service, runID: "harvest-idempotent")
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Decision: \(needle) must appear once after two closes.",
+            memoryType: "decision"
+        )
+        _ = try await endSession(service, sessionID: sessionID)
+
+        let closed = await service.handle(.init(
+            command: "session_close",
+            arguments: [
+                "session_id": .string(sessionID),
+                "content": .string("already ended"),
+                "project": .string(harvestProject),
+            ]
+        ))
+        #expect(closed.ok == true, "session_close failed: \(closed.error ?? "nil")")
+        let payload = try requireObject(closed.payload)
+        #expect(payload["already_ended"]?.boolValue == true)
+        #expect(payload["active"]?.boolValue == false)
+
+        let recall = try await projectRecall(service, query: needle)
+        let matches = recall["results"]?.arrayValue?.filter {
+            $0.objectValue?["text"]?.stringValue?.contains(needle) == true
+        } ?? []
+        #expect(matches.count == 1, "harvest duplicated durable copies: \(matches.count)")
+    }
+}
+
+@Test
+func statsExposeReclaimableBytesAfterWindowElapses() async throws {
+    try await withHarvestBroker { service, sessionRoot in
+        let sessionID = try await startHarvestSession(service, runID: "harvest-stats")
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Decision: stats reclaim token WAXHVST-STATS.",
+            memoryType: "decision"
+        )
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Working leftover that stays unpromoted without recalls.",
+            memoryType: "note"
+        )
+        _ = try await endSession(service, sessionID: sessionID)
+
+        var manifest = try BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRoot,
+            sessionID: UUID(uuidString: sessionID)!
+        )
+        manifest.reclaimAfterMs = 1
+        try BrokerSessionPersistence.saveManifest(
+            manifest,
+            to: BrokerSessionPersistence.manifestURL(
+                rootURL: sessionRoot,
+                sessionID: manifest.sessionID
+            )
+        )
+
+        let stats = await service.handle(.init(command: "stats"))
+        #expect(stats.ok == true, "stats failed: \(stats.error ?? "nil")")
+        let sessions = try #require(try requireObject(stats.payload)["sessions"]?.objectValue)
+        #expect((sessions["reclaimable_bytes"]?.intValue ?? 0) > 0)
+        #expect((sessions["reclaimable"]?.intValue ?? 0) >= 1)
+    }
+}
+
+@Test
+func memoryMaintainDryRunDoesNotUnlinkOrQuarantine() async throws {
+    try await withHarvestBroker { service, sessionRoot in
+        let sessionID = try await startHarvestSession(service, runID: "maintain-dry")
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Decision: dry-run must not unlink WAXHVST-DRY.",
+            memoryType: "decision"
+        )
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Working leftover stays on disk during dry-run.",
+            memoryType: "note"
+        )
+        _ = try await endSession(service, sessionID: sessionID)
+        let storePath = sessionStoreURL(root: sessionRoot, sessionID: sessionID).path
+        #expect(FileManager.default.fileExists(atPath: storePath))
+
+        var manifest = try BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRoot,
+            sessionID: UUID(uuidString: sessionID)!
+        )
+        manifest.reclaimAfterMs = 1
+        try BrokerSessionPersistence.saveManifest(
+            manifest,
+            to: BrokerSessionPersistence.manifestURL(rootURL: sessionRoot, sessionID: manifest.sessionID)
+        )
+
+        let dry = await service.handle(.init(command: "memory_maintain"))
+        #expect(dry.ok == true, "memory_maintain dry-run failed: \(dry.error ?? "nil")")
+        let payload = try requireObject(dry.payload)
+        #expect(payload["dry_run"]?.boolValue == true)
+        #expect((payload["unlinks"]?.intValue ?? 0) >= 1)
+        #expect(FileManager.default.fileExists(atPath: storePath))
+    }
+}
+
+@Test
+func memoryMaintainApplyReclaimsPastWindowAndKeepsNeedle() async throws {
+    let needle = "WAXHVAP-\(UUID().uuidString.prefix(8))"
+    try await withHarvestBroker { service, sessionRoot in
+        let sessionID = try await startHarvestSession(service, runID: "maintain-apply")
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Decision: \(needle) survives reclaim.",
+            memoryType: "decision"
+        )
+        try await rememberSession(
+            service,
+            sessionID: sessionID,
+            content: "Working leftover for recently-closed window.",
+            memoryType: "note"
+        )
+        _ = try await endSession(service, sessionID: sessionID)
+
+        var manifest = try BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRoot,
+            sessionID: UUID(uuidString: sessionID)!
+        )
+        manifest.reclaimAfterMs = 1
+        try BrokerSessionPersistence.saveManifest(
+            manifest,
+            to: BrokerSessionPersistence.manifestURL(rootURL: sessionRoot, sessionID: manifest.sessionID)
+        )
+
+        let applied = await service.handle(.init(
+            command: "memory_maintain",
+            arguments: ["apply": .bool(true)]
+        ))
+        #expect(applied.ok == true, "memory_maintain apply failed: \(applied.error ?? "nil")")
+        #expect(!FileManager.default.fileExists(atPath: sessionStoreURL(root: sessionRoot, sessionID: sessionID).path))
+        let afterReclaim = try await projectRecall(service, query: needle)
+        #expect(firstHitText(afterReclaim).contains(needle))
+    }
+}
+
+@Test
+func zombieActiveLeaseIsEndedAndHarvestedByMaintain() async throws {
+    let needle = "WAXHVZB-\(UUID().uuidString.prefix(8))"
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-zombie-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let sessionID: String
+    let first = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        sessionID = try await startHarvestSession(first, runID: "zombie-run")
+        try await rememberSession(
+            first,
+            sessionID: sessionID,
+            content: "Decision: \(needle) must be harvested from a zombie lease.",
+            memoryType: "decision"
+        )
+        try await first.close()
+    } catch {
+        try? await first.close()
+        throw error
+    }
+
+    var manifest = try BrokerSessionPersistence.loadManifest(
+        rootURL: sessionRootURL,
+        sessionID: UUID(uuidString: sessionID)!
+    )
+    #expect(manifest.status == .active)
+    manifest.leaseExpiresAtMs = 1
+    try BrokerSessionPersistence.saveManifest(
+        manifest,
+        to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
+    )
+
+    let second = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        let applied = await second.handle(.init(
+            command: "memory_maintain",
+            arguments: ["apply": .bool(true)]
+        ))
+        #expect(applied.ok == true, "zombie maintain failed: \(applied.error ?? "nil")")
+        let harvested = try BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRootURL,
+            sessionID: UUID(uuidString: sessionID)!
+        )
+        #expect(harvested.status == .ended)
+        #expect(harvested.harvestedAtMs != nil)
+        let zombieRecall = try await projectRecall(second, query: needle)
+        #expect(firstHitText(zombieRecall).contains(needle))
+        try await second.close()
+    } catch {
+        try? await second.close()
+        throw error
+    }
+}
+
+@Test
+func harvestErrorBlocksReclaimUntilForce() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-harvest-error-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let sessionID: String
+    let first = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        sessionID = try await startHarvestSession(first, runID: "harvest-error")
+        try await rememberSession(
+            first,
+            sessionID: sessionID,
+            content: "Decision: this session store will be corrupted before harvest.",
+            memoryType: "decision"
+        )
+        try await first.close()
+    } catch {
+        try? await first.close()
+        throw error
+    }
+
+    let waxURL = sessionStoreURL(root: sessionRootURL, sessionID: sessionID)
+    try Data("not-a-wax-store".utf8).write(to: waxURL)
+    var manifest = try BrokerSessionPersistence.loadManifest(
+        rootURL: sessionRootURL,
+        sessionID: UUID(uuidString: sessionID)!
+    )
+    manifest.leaseExpiresAtMs = 1
+    try BrokerSessionPersistence.saveManifest(
+        manifest,
+        to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: manifest.sessionID)
+    )
+
+    let second = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        let applied = await second.handle(.init(
+            command: "memory_maintain",
+            arguments: ["apply": .bool(true)]
+        ))
+        #expect(applied.ok == true, "maintain after corrupt harvest failed: \(applied.error ?? "nil")")
+        let afterHarvest = try BrokerSessionPersistence.loadManifest(
+            rootURL: sessionRootURL,
+            sessionID: UUID(uuidString: sessionID)!
+        )
+        #expect(afterHarvest.status == .ended)
+        #expect(afterHarvest.harvestError != nil)
+        #expect(FileManager.default.fileExists(atPath: waxURL.path))
+
+        let forced = await second.handle(.init(
+            command: "memory_maintain",
+            arguments: [
+                "apply": .bool(true),
+                "force_reclaim": .bool(true),
+            ]
+        ))
+        #expect(forced.ok == true, "force reclaim failed: \(forced.error ?? "nil")")
+        #expect(!FileManager.default.fileExists(atPath: waxURL.path))
+        try await second.close()
+    } catch {
+        try? await second.close()
+        throw error
+    }
+}
+
+@Test
+func oldSessionManifestsDecodeWithoutHarvestFields() throws {
+    let json = """
+    {
+      "sessionID": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+      "agentID": "legacy-agent",
+      "runID": "legacy-run",
+      "storePath": "/tmp/legacy.wax",
+      "eventLogPath": "/tmp/legacy.events.jsonl",
+      "status": "ended",
+      "createdAtMs": 1,
+      "updatedAtMs": 1
+    }
+    """
+    let manifest = try JSONDecoder().decode(BrokerSessionManifest.self, from: Data(json.utf8))
+    #expect(manifest.endedAtMs == nil)
+    #expect(manifest.harvestedAtMs == nil)
+    #expect(manifest.promotedCount == 0)
+    #expect(manifest.reclaimAfterMs == nil)
+    #expect(manifest.reclaimedAtMs == nil)
+    #expect(manifest.harvestError == nil)
+}
+
+@Test
+func maintainDoesNotQuarantineLockedLibraryRows() async throws {
+    let needle = "WAXLOCK-\(UUID().uuidString.prefix(8))"
+    let created = Int64(Date().timeIntervalSince1970 * 1000) - 400 * 24 * 60 * 60 * 1000
+    try await withHarvestBroker { service, _ in
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Decision: \(needle) is locked library and must not be quarantined."),
+                "memory_type": .string("decision"),
+                "durability": .string("locked"),
+                "project": .string(harvestProject),
+                "repo": .string(harvestProject),
+                "metadata": .object([
+                    MemoryMetadataKeys.createdAtMs: .string(String(created)),
+                ]),
+            ]
+        ))
+        #expect(write.ok == true, "locked remember failed: \(write.error ?? "nil")")
+
+        let applied = await service.handle(.init(
+            command: "memory_maintain",
+            arguments: ["apply": .bool(true)]
+        ))
+        #expect(applied.ok == true, "maintain apply failed: \(applied.error ?? "nil")")
+        let lockedRecall = try await projectRecall(service, query: needle)
+        #expect(firstHitText(lockedRecall).contains(needle))
+    }
+}
+
+@Test
+func maintainApplySoftDeletesAgedWorkingNotes() async throws {
+    let needle = "WAXQUAR-\(UUID().uuidString.prefix(8))"
+    let created = Int64(Date().timeIntervalSince1970 * 1000) - 31 * 24 * 60 * 60 * 1000
+    try await withHarvestBroker { service, _ in
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Working scratch \(needle) should be quarantined after 30 days."),
+                "memory_type": .string("note"),
+                "durability": .string("working"),
+                "project": .string(harvestProject),
+                "repo": .string(harvestProject),
+                "metadata": .object([
+                    MemoryMetadataKeys.createdAtMs: .string(String(created)),
+                ]),
+            ]
+        ))
+        #expect(write.ok == true, "working remember failed: \(write.error ?? "nil")")
+        let before = try await projectRecall(service, query: needle)
+        #expect(firstHitText(before).contains(needle))
+
+        let dry = await service.handle(.init(command: "memory_maintain"))
+        let dryPayload = try requireObject(dry.payload)
+        #expect((dryPayload["quarantine_soft_deletes"]?.intValue ?? 0) >= 1)
+        let stillThere = try await projectRecall(service, query: needle)
+        #expect(firstHitText(stillThere).contains(needle))
+
+        let applied = await service.handle(.init(
+            command: "memory_maintain",
+            arguments: ["apply": .bool(true)]
+        ))
+        #expect(applied.ok == true, "quarantine apply failed: \(applied.error ?? "nil")")
+        let after = try await projectRecall(service, query: needle)
+        #expect(!firstHitText(after).contains(needle))
+    }
+}
+
+@Test
+func coldDurableFramesAreOmittedFromHybridParaphraseRecall() async throws {
+    let needle = "WAXCOLD-\(UUID().uuidString.prefix(8))"
+    try await withHarvestBroker { service, _ in
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Decision: locked library rows must never be auto-deleted by LFU. \(needle)."),
+                "memory_type": .string("decision"),
+                "durability": .string("durable"),
+                "project": .string(harvestProject),
+                "repo": .string(harvestProject),
+                "metadata": .object([
+                    MemoryMetadataKeys.tier: .string(MemoryTier.cold.rawValue),
+                ]),
+            ]
+        ))
+        #expect(write.ok == true, "cold remember failed: \(write.error ?? "nil")")
+
+        let paraphrase = try await projectRecall(
+            service,
+            query: "must never be auto-deleted by LFU",
+            mode: "hybrid"
+        )
+        #expect(!firstHitText(paraphrase).contains(needle))
+
+        let identifier = try await projectRecall(service, query: needle, mode: "text")
+        #expect(firstHitText(identifier).contains(needle))
+    }
+}
+
+@Test
+func recallRecordsImpressionsWithoutEngagement() async throws {
+    let needle = "WAXIMP-\(UUID().uuidString.prefix(8))"
+    try await withHarvestBroker { service, _ in
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Decision: \(needle) is used to split impression from engagement."),
+                "memory_type": .string("decision"),
+                "durability": .string("durable"),
+                "project": .string(harvestProject),
+                "repo": .string(harvestProject),
+            ]
+        ))
+        #expect(write.ok == true, "remember failed: \(write.error ?? "nil")")
+        let frameID = try #require(try requireObject(write.payload)["frame_id"]?.intValue)
+
+        _ = try await projectRecall(service, query: needle)
+        let afterRecall = await service.longTermMemory.accessStatsSnapshot()[UInt64(frameID)]
+        #expect((afterRecall?.impressionCount ?? 0) >= 1)
+        #expect(afterRecall?.engagementCount == 0)
+
+        let got = await service.handle(.init(
+            command: "memory_get",
+            arguments: ["memory_id": .string("durable:\(frameID)")]
+        ))
+        #expect(got.ok == true, "memory_get failed: \(got.error ?? "nil")")
+        let afterGet = await service.longTermMemory.accessStatsSnapshot()[UInt64(frameID)]
+        #expect((afterGet?.engagementCount ?? 0) >= 1)
+    }
+}

--- a/Tests/WaxTests/SessionHarvestTests.swift
+++ b/Tests/WaxTests/SessionHarvestTests.swift
@@ -155,7 +155,7 @@ func sessionCloseHarvestsAlwaysPromotableNeedleIntoDurableRecall() async throws 
 }
 
 @Test
-func emptyPromotableSessionUnlinksImmediately() async throws {
+func emptyPromotableSessionIsReclaimedByMaintainWithoutWaiting() async throws {
     let needle = "WAXHVIM-\(UUID().uuidString.prefix(8))"
     try await withHarvestBroker { service, sessionRoot in
         let sessionID = try await startHarvestSession(service, runID: "harvest-immediate")
@@ -167,18 +167,48 @@ func emptyPromotableSessionUnlinksImmediately() async throws {
         )
         let ended = try await endSession(service, sessionID: sessionID)
         #expect(ended["harvested"]?.boolValue == true)
-        #expect(ended["reclaimed"]?.boolValue == true)
-        #expect(!FileManager.default.fileExists(atPath: sessionStoreURL(root: sessionRoot, sessionID: sessionID).path))
+        #expect(ended["reclaimed"]?.boolValue != true)
+        let storePath = sessionStoreURL(root: sessionRoot, sessionID: sessionID).path
+        #expect(FileManager.default.fileExists(atPath: storePath))
 
         let manifest = try BrokerSessionPersistence.loadManifest(
             rootURL: sessionRoot,
             sessionID: UUID(uuidString: sessionID)!
         )
-        #expect(manifest.reclaimedAtMs != nil)
         #expect(manifest.status == .ended)
+        #expect(manifest.reclaimAfterMs == manifest.harvestedAtMs)
+
+        let applied = await service.handle(.init(
+            command: "memory_maintain",
+            arguments: ["apply": .bool(true)]
+        ))
+        #expect(applied.ok == true, "immediate maintain reclaim failed: \(applied.error ?? "nil")")
+        #expect(!FileManager.default.fileExists(atPath: storePath))
 
         let payload = try await projectRecall(service, query: needle)
         #expect(firstHitText(payload).contains(needle))
+    }
+}
+
+@Test
+func closeDoesNotPromoteImplicitMustNotesIntoDurableRecall() async throws {
+    let token = "ENDED-WORKING-\(UUID().uuidString.prefix(8))"
+    try await withHarvestBroker { service, _ in
+        let sessionID = try await startHarvestSession(service, runID: "harvest-implicit-note")
+        let write = await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("Ended-session working note \(token) must not leak unscoped."),
+                "session_id": .string(sessionID),
+                "project": .string(harvestProject),
+                "repo": .string(harvestProject),
+            ]
+        ))
+        #expect(write.ok == true, "remember failed: \(write.error ?? "nil")")
+        _ = try await endSession(service, sessionID: sessionID)
+
+        let payload = try await projectRecall(service, query: token)
+        #expect(!firstHitText(payload).contains(token))
     }
 }
 

--- a/Tests/WaxTests/SessionHarvestTests.swift
+++ b/Tests/WaxTests/SessionHarvestTests.swift
@@ -638,3 +638,36 @@ func recallRecordsImpressionsWithoutEngagement() async throws {
         #expect((afterGet?.engagementCount ?? 0) >= 1)
     }
 }
+
+@Test
+func applyHarvestPersistsPromotionsWhenHarvestedWithError() {
+    var manifest = BrokerSessionManifest(
+        sessionID: UUID(),
+        agentID: "agent",
+        runID: "run",
+        project: nil,
+        repo: nil,
+        storePath: "/tmp/partial.wax",
+        eventLogPath: "/tmp/partial.events.jsonl",
+        status: .ended,
+        brokerLeaseOwnerID: nil,
+        leaseExpiresAtMs: nil,
+        createdAtMs: 1,
+        updatedAtMs: 1
+    )
+    let report = SessionHarvest.Report(
+        harvested: true,
+        promotedCount: 3,
+        leftoverDocumentCount: 1,
+        leftoverLockedCount: 0,
+        reclaimAfterMs: 99,
+        error: "remember failed",
+        alreadyHarvested: false
+    )
+    VirtualSessionStore.applyHarvest(report, to: &manifest, nowMs: 50)
+    #expect(manifest.harvestedAtMs == 50)
+    #expect(manifest.promotedCount == 3)
+    #expect(manifest.harvestError == "remember failed")
+    #expect(manifest.reclaimAfterMs == 99)
+    #expect(!report.immediateReclaimEligible)
+}

--- a/Tests/WaxTests/WaxCLISurfaceParityTests.swift
+++ b/Tests/WaxTests/WaxCLISurfaceParityTests.swift
@@ -21,6 +21,7 @@ import Testing
         "MarkdownExportCommand.self",
         "MarkdownSyncCommand.self",
         "CompactStoreCommand.self",
+        "MemoryMaintainCommand.self",
         "EmbedBackfillCommand.self",
     ]
 


### PR DESCRIPTION
## Summary
- `session_close` / `session_end` now harvest promotable session facts into durable memory automatically (existing promotion heuristics), then schedule Recently Closed unlink (7 days) or unlink immediately when nothing is left.
- Operator CLI `wax-cli memory-maintain` (dry-run default, `--apply`, `--force-reclaim`) harvests zombie leases, reclaims ended stores, and soft-deletes aged working/ephemeral notes. No new agent MCP prune verb.
- Ranking uses engagement (`memory_get` / promote / compact short), not recall impressions. Default hybrid recall omits `wax.tier=cold` unless the query is text or exact-intent.

Left as one PR: harvest, reclaim, access stats, and hot/cold all share `AgentBrokerService`, `AccessStats`, and `LayeredRecall`, so stacked intermediate PRs would not compile or test independently.

## Test plan
- [x] `swift test --filter SessionHarvestTests`
- [x] `swift test --filter MemoryRetentionPolicyTests`
- [x] `swift test --filter sessionHarvestSoakPromotesNeedleAndReclaimsStore`
- [x] `swift test --filter BrokerPromotionHeuristicTests`
- [x] `swift test --filter AccessFrequencyRankingTests`
- [x] `swift test --traits MCPServer --filter toolsListContainsExpectedTools`
- [ ] `bash Resources/scripts/quality/production_readiness_gates.sh full` on CI


Made with [Cursor](https://cursor.com)