### PR TITLE
fix(mcp): wait for MiniLM on first recall and teach session_open

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,13 +360,13 @@ Use the project or user `AGENTS.md`, `CLAUDE.md`, or `.cursor/rules`. Same text 
 Wax is the shared memory layer. Chat dies; Wax does not. Skip one-line Q&A. Use on any multi-step coding, debug, or research task.
 
 Open every multi-step session:
-1. Prefer `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Or call `handoff_latest` first then `session_start` once. Keep `session_id`. Do not invent one.
+1. Call `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Keep `session_id`. Do not invent one. Do not call `handoff_latest` then `session_start` as the default open.
 2. Call `recall` with default `scope: project` (hard-filters to resolved project; unlabeled/foreign frames excluded). Empty lane returns an explicit miss — pass `scope: global` only for cross-project reads. `recall` with `session_id` merges that session with durable memory under project scope.
 
 Workflow rules:
 - Use `remember` to store decisions, discoveries, and short factual notes. Prefer `scope: session` (requires top-level `session_id`) or `scope: durable` (forbids `session_id`). Do not put `session_id` inside `metadata`.
 - Use `recall` for assembled context and `search` for raw ranked hits.
-- Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
+- Prefer `mode: "hybrid"` when the embedder is ready; otherwise use `mode: "text"`.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
@@ -408,7 +408,7 @@ SOUL.md is identity. **Append** this section. Do not replace the rest of the sou
 
 You have Wax. Chat is not memory.
 
-On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`) or `handoff_latest` → `session_start` → keep `session_id`.
+On every multi-step task: call `session_open` (`project`, `agent_id`, `run_id`, optional `recall_query`). Keep `session_id`.
 
 Write as you go:
 - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).
@@ -450,7 +450,7 @@ Finally, paste this prompt into your **main (coordinator) bot** — it sets up i
 You have a memory tool server called "wax". Use it as your primary memory, and make it the primary memory for every bot on our team.
 
 Your own memory:
-- Starting any multi-step job: call handoff_latest (or session_start with project set to my name), keep the returned session_id, then recall before you act.
+- Starting any multi-step job: call session_open (project set to my name, stable agent_id/run_id, optional recall_query), keep the returned session_id, then recall before you act.
 - While working: remember task state as you go (scope: session with your session_id); store decisions, corrections, preferences, and facts durably (scope: durable).
 - Finishing: session_close with a summary and pending_tasks so your next session resumes cleanly.
 - Never store passwords, tokens, or secrets. If the wax tools are missing, stop and tell me instead of improvising.

--- a/Resources/docs/wax-mcp-hosts.md
+++ b/Resources/docs/wax-mcp-hosts.md
@@ -86,7 +86,7 @@ claude mcp add wax -t http -s user -- http://127.0.0.1:3000/mcp
 claude install-skill ~/.local/share/waxmcp/skills/wax-mcp
 ```
 
-Confirm: `claude mcp get wax` and a new Claude session that can see `handoff_latest`.
+Confirm: `claude mcp get wax` and a new Claude session that can see `session_open`.
 
 ---
 
@@ -107,7 +107,7 @@ cp -a ~/.local/share/waxmcp/skills/wax-mcp ~/.codex/skills/wax-mcp
 
 If the host still ignores skills, paste `references/project-rules.md` into the **project** `AGENTS.md` — not into `~/.codex/AGENTS.md`. The user-global file is behavior-only.
 
-Restart Codex. Confirm `handoff_latest` is in the tool list.
+Restart Codex. Confirm `session_open` is in the tool list.
 
 ---
 
@@ -198,7 +198,7 @@ That file is the whole always-on prompt. Do not invent a `PROMPT.md`.
 
 Same rules on every host (from the paste block):
 
-1. Prefer `session_open` (`project`, stable `agent_id`/`run_id`, optional `recall_query`) — or `handoff_latest` → `session_start` (keep `session_id`)
+1. Call `session_open` (`project`, stable `agent_id`/`run_id`, optional `recall_query`). Keep `session_id`. Do not call `handoff_latest` then `session_start` as the default open.
 2. Tactical writes: `remember` **with** `session_id` or `scope: session` (`task_state` / `working`) when a plan locks, a path fails, or you are about to stop
 3. Strategic writes: `remember` with `scope: durable` (or without `session_id`) for decision / lesson / constraint / preference / fact
 4. `recall` defaults to `scope: project` (hard-filters; empty lane is an explicit miss). Pass `scope: global` only for cross-project reads. With `session_id`, recall merges that session with durable under project scope. Prefer `mode: "text"` for exact names.
@@ -208,7 +208,7 @@ Same rules on every host (from the paste block):
 
 - Prefer `mode: "text"` for recent facts, exact names, and identity. Hybrid/vector can rank old embedder-test frames first.
 - `memory_get` IDs look like `durable:1695` or `episodic:<session-uuid>:0`. A bare frame number fails.
-- Do not invent a `session_id`. Use the value from `session_start` / `session_resume`.
+- Do not invent a `session_id`. Use the value from `session_open` / `session_start` / `session_resume`.
 - Do not manage `--store-path` or `flush` in normal agent flows.
 - If tools vanish after a burst of bad calls, check that HTTP `:3000` is still up before restarting the broker. The host MCP client can circuit-break while the server is healthy.
 
@@ -220,6 +220,6 @@ Ask the agent: “Load Wax, start a session, and tell me the latest handoff.”
 
 Pass if it:
 
-1. Calls `handoff_latest` then `session_start`
+1. Calls `session_open` (not `handoff_latest` then `session_start` as the default open)
 2. Does not ask you to restate prior context that the handoff already contains
 3. Can `stats` and reports vector search on (or honestly says it is off)

--- a/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/SKILL.md
@@ -20,9 +20,8 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 ## Session Lifecycle (required)
 
 1. **Start**
-   - Call `handoff_latest` first (optionally with `project`) to load prior context.
-   - Call `session_start` once. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
-   - Keep the returned `session_id` for the rest of the session.
+   - Call `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Keep `session_id`. Do not invent one.
+   - Do not call `handoff_latest` then `session_start` as the default open. Those tools remain callable for compatibility.
 2. **Work**
    - Before answering from memory, call `recall` (default) or `search` (raw hits). `recall` with `session_id` merges that session with durable long-term memory.
    - When you learn something durable, call `remember` with concise factual text.
@@ -30,9 +29,9 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - Never put `session_id` inside `metadata`.
    - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a complete distinct-store copy after a dry run; choose quarantine (default) or drop for orphaned records.
 3. **End**
-   - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
+   - Prefer `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
-   - Prefer `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or call `session_end` (pass `session_id` when multiple sessions may be active).
+   - Or call `handoff` then `session_end` (pass `session_id` when multiple sessions may be active).
    - Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or `memory-maintain` in the agent loop; `wax-cli memory-maintain` is operator-only.
    - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
@@ -47,8 +46,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 
 Search mode guidance:
 
-- Prefer `mode: "hybrid"` when semantic recall helps.
-- Use `mode: "text"` for fast or deterministic lexical lookup.
+- Prefer `mode: "hybrid"` when the embedder is ready; otherwise use `mode: "text"`.
 
 Response guidance:
 
@@ -75,8 +73,8 @@ Write quality rules:
 
 - Do not manage `SESSION_STORE`, `--store-path`, `flush`, or `memory-maintain` in normal agent flows.
   The broker owns long-term memory and virtual session stores. `wax-cli memory-maintain` is operator-only.
-- Do not skip `handoff_latest` at session start and re-ask the user for prior context.
-- Do not invent a `session_id`; only use values returned by `session_start` / `session_resume`.
+- Do not skip `session_open` at session start and re-ask the user for prior context.
+- Do not invent a `session_id`; only use values returned by `session_open` / `session_start` / `session_resume`.
 - Do not put `session_id` inside `metadata`.
 - Do not treat `search` as the default when `recall` is enough.
 - Do not use structured fact tools for transient debug notes.
@@ -129,8 +127,10 @@ replacing the soul.
 
 | Tool | When |
 |------|------|
-| `handoff_latest` | Session start continuity |
-| `session_start` / `session_end` | Broker session lifecycle |
+| `session_open` | Default one-shot open + optional recall |
+| `handoff_latest` | Fetch latest handoff (compatibility; not the default open) |
+| `session_start` / `session_end` | Broker session lifecycle (prefer `session_open` / `session_close`) |
+| `session_close` | Atomic handoff then end |
 | `session_resume` | Resume a known session after restart |
 | `remember` | Store durable free-text memory |
 | `recall` | Default read / RAG assembly |

--- a/Resources/npm/waxmcp/skills/wax-mcp/agents/openai.yaml
+++ b/Resources/npm/waxmcp/skills/wax-mcp/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Wax MCP Memory"
   short_description: "Use Wax MCP tools for durable agent memory"
-  default_prompt: "Use $wax-mcp for session lifecycle, remember/recall, handoffs, and structured memory. Call handoff_latest then session_start at session start; handoff then session_end at session end."
+  default_prompt: "Use $wax-mcp for session lifecycle, remember/recall, handoffs, and structured memory. Call session_open at session start; session_close at session end. Do not use handoff_latest plus session_start as the default open."

--- a/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
+++ b/Resources/npm/waxmcp/skills/wax-mcp/references/project-rules.md
@@ -13,13 +13,13 @@ Agent Quick Start details.
 Wax is the shared memory layer. Chat dies; Wax does not. Skip one-line Q&A. Use on any multi-step coding, debug, or research task.
 
 Open every multi-step session:
-1. Prefer `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Or call `handoff_latest` first then `session_start` once. Keep `session_id`. Do not invent one.
+1. Call `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Keep `session_id`. Do not invent one. Do not call `handoff_latest` then `session_start` as the default open.
 2. Call `recall` with default `scope: project` (hard-filters to resolved project; unlabeled/foreign frames excluded). Empty lane returns an explicit miss — pass `scope: global` only for cross-project reads. `recall` with `session_id` merges that session with durable memory under project scope.
 
 Workflow rules:
 - Use `remember` to store decisions, discoveries, and short factual notes. Prefer `scope: session` (requires top-level `session_id`) or `scope: durable` (forbids `session_id`). Do not put `session_id` inside `metadata`.
 - Use `recall` for assembled context and `search` for raw ranked hits.
-- Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
+- Prefer `mode: "hybrid"` when the embedder is ready; otherwise use `mode: "text"`.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
@@ -56,7 +56,7 @@ SOUL.md is identity. Append this section. Do not turn the whole soul into a tool
 
 You have Wax. Chat is not memory.
 
-On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`) or `handoff_latest` → `session_start` → keep `session_id`.
+On every multi-step task: call `session_open` (`project`, `agent_id`, `run_id`, optional `recall_query`). Keep `session_id`.
 
 Write as you go:
 - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).

--- a/Resources/skills/public/wax-mcp/SKILL.md
+++ b/Resources/skills/public/wax-mcp/SKILL.md
@@ -20,9 +20,8 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 ## Session Lifecycle (required)
 
 1. **Start**
-   - Call `handoff_latest` first (optionally with `project`) to load prior context.
-   - Call `session_start` once. Pass stable `agent_id` and `run_id` so a retry reuses the same session.
-   - Keep the returned `session_id` for the rest of the session.
+   - Call `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Keep `session_id`. Do not invent one.
+   - Do not call `handoff_latest` then `session_start` as the default open. Those tools remain callable for compatibility.
 2. **Work**
    - Before answering from memory, call `recall` (default) or `search` (raw hits). `recall` with `session_id` merges that session with durable long-term memory.
    - When you learn something durable, call `remember` with concise factual text.
@@ -30,9 +29,9 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
    - Never put `session_id` inside `metadata`.
    - `task_state` is session-local working state: it requires an active session and rejects durable or locked writes. Repair legacy records with `task_state_migrate` into a complete distinct-store copy after a dry run; choose quarantine (default) or drop for orphaned records.
 3. **End**
-   - Call `handoff` with `content`, optional `project`, optional `pending_tasks`, optional `session_id`.
+   - Prefer `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end.
    - Keep `content` to a concise state summary. Put unfinished work only in `pending_tasks`; do not copy pending tasks into content or store transcripts.
-   - Prefer `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or call `session_end` (pass `session_id` when multiple sessions may be active).
+   - Or call `handoff` then `session_end` (pass `session_id` when multiple sessions may be active).
    - Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or `memory-maintain` in the agent loop; `wax-cli memory-maintain` is operator-only.
    - `session_end` `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
 
@@ -47,8 +46,7 @@ This is not the Swift framework skill. For embedding Wax in Swift apps, use the
 
 Search mode guidance:
 
-- Prefer `mode: "hybrid"` when semantic recall helps.
-- Use `mode: "text"` for fast or deterministic lexical lookup.
+- Prefer `mode: "hybrid"` when the embedder is ready; otherwise use `mode: "text"`.
 
 Response guidance:
 
@@ -75,8 +73,8 @@ Write quality rules:
 
 - Do not manage `SESSION_STORE`, `--store-path`, `flush`, or `memory-maintain` in normal agent flows.
   The broker owns long-term memory and virtual session stores. `wax-cli memory-maintain` is operator-only.
-- Do not skip `handoff_latest` at session start and re-ask the user for prior context.
-- Do not invent a `session_id`; only use values returned by `session_start` / `session_resume`.
+- Do not skip `session_open` at session start and re-ask the user for prior context.
+- Do not invent a `session_id`; only use values returned by `session_open` / `session_start` / `session_resume`.
 - Do not put `session_id` inside `metadata`.
 - Do not treat `search` as the default when `recall` is enough.
 - Do not use structured fact tools for transient debug notes.
@@ -129,8 +127,10 @@ replacing the soul.
 
 | Tool | When |
 |------|------|
-| `handoff_latest` | Session start continuity |
-| `session_start` / `session_end` | Broker session lifecycle |
+| `session_open` | Default one-shot open + optional recall |
+| `handoff_latest` | Fetch latest handoff (compatibility; not the default open) |
+| `session_start` / `session_end` | Broker session lifecycle (prefer `session_open` / `session_close`) |
+| `session_close` | Atomic handoff then end |
 | `session_resume` | Resume a known session after restart |
 | `remember` | Store durable free-text memory |
 | `recall` | Default read / RAG assembly |

--- a/Resources/skills/public/wax-mcp/agents/openai.yaml
+++ b/Resources/skills/public/wax-mcp/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Wax MCP Memory"
   short_description: "Use Wax MCP tools for durable agent memory"
-  default_prompt: "Use $wax-mcp for session lifecycle, remember/recall, handoffs, and structured memory. Call handoff_latest then session_start at session start; handoff then session_end at session end."
+  default_prompt: "Use $wax-mcp for session lifecycle, remember/recall, handoffs, and structured memory. Call session_open at session start; session_close at session end. Do not use handoff_latest plus session_start as the default open."

--- a/Resources/skills/public/wax-mcp/references/project-rules.md
+++ b/Resources/skills/public/wax-mcp/references/project-rules.md
@@ -13,13 +13,13 @@ Agent Quick Start details.
 Wax is the shared memory layer. Chat dies; Wax does not. Skip one-line Q&A. Use on any multi-step coding, debug, or research task.
 
 Open every multi-step session:
-1. Prefer `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Or call `handoff_latest` first then `session_start` once. Keep `session_id`. Do not invent one.
+1. Call `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Keep `session_id`. Do not invent one. Do not call `handoff_latest` then `session_start` as the default open.
 2. Call `recall` with default `scope: project` (hard-filters to resolved project; unlabeled/foreign frames excluded). Empty lane returns an explicit miss — pass `scope: global` only for cross-project reads. `recall` with `session_id` merges that session with durable memory under project scope.
 
 Workflow rules:
 - Use `remember` to store decisions, discoveries, and short factual notes. Prefer `scope: session` (requires top-level `session_id`) or `scope: durable` (forbids `session_id`). Do not put `session_id` inside `metadata`.
 - Use `recall` for assembled context and `search` for raw ranked hits.
-- Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
+- Prefer `mode: "hybrid"` when the embedder is ready; otherwise use `mode: "text"`.
 - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
 - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
 - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
@@ -56,7 +56,7 @@ SOUL.md is identity. Append this section. Do not turn the whole soul into a tool
 
 You have Wax. Chat is not memory.
 
-On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`) or `handoff_latest` → `session_start` → keep `session_id`.
+On every multi-step task: call `session_open` (`project`, `agent_id`, `run_id`, optional `recall_query`). Keep `session_id`.
 
 Write as you go:
 - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).

--- a/Sources/Wax/Broker/AgentBrokerClient.swift
+++ b/Sources/Wax/Broker/AgentBrokerClient.swift
@@ -131,7 +131,6 @@ package enum AgentBrokerClient {
             "--embedder", configuration.embedderChoice,
             "--socket-path", configuration.socketPath,
             "--idle-timeout-secs", String(idleTimeoutSeconds),
-            "--skip-prewarm",
         ]
         process.arguments?.append(contentsOf: configuration.embedderTuning.daemonArguments())
         if configuration.noEmbedder {

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -482,6 +482,14 @@ extension AgentBrokerService {
             frameFilter: parsedFilters.frameFilter,
             timeRange: parsedFilters.timeRange
         )
+        // Session stores attach on their own follow task. After MiniLM is ready,
+        // wait for that attach here so a session-scoped first recall is hybrid.
+        // Skip when long-term is still loading so a timeout does not become a
+        // second 30s hold on commandMutex.
+        if let sessionID = parsedFilters.sessionId,
+           await longTermMemory.isQueryEmbedderReady() {
+            await awaitQueryEmbedderIfNeeded(memory: try await memory(for: sessionID))
+        }
         let result = try await LayeredRecall.recall(request: request, stores: layeredRecallStores())
 
         var lines: [String] = []
@@ -617,6 +625,9 @@ extension AgentBrokerService {
         let topK = command.topK
         let parsedFilters = command.filters
         let memory = try await memory(for: parsedFilters.sessionId)
+        if parsedFilters.sessionId != nil, await longTermMemory.isQueryEmbedderReady() {
+            await awaitQueryEmbedderIfNeeded(memory: memory)
+        }
         let execution = try await memory.searchExecution(
             query: query,
             mode: mode,
@@ -1366,6 +1377,11 @@ extension AgentBrokerService {
 
         var recallPayload: AgentBrokerValue?
         if let recallQuery, !recallQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if let sessionID,
+               let uuid = UUID(uuidString: sessionID),
+               await longTermMemory.isQueryEmbedderReady() {
+                await awaitQueryEmbedderIfNeeded(memory: try await memory(for: uuid))
+            }
             var recallArgs: [String: AgentBrokerValue] = [
                 "query": .string(recallQuery),
                 "scope": .string("project"),

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -153,9 +153,23 @@ package actor AgentBrokerService {
                 }
             }
         }
+        // Wait for MiniLM outside commandMutex so a cold first recall does not
+        // stall unrelated commands the way remember already uses rememberMutex.
+        if Self.isQueryEmbedderWaitRequest(request) {
+            await awaitQueryEmbedderIfNeeded(memory: longTermMemory)
+        }
         let mutex = Self.isRememberRequest(request) ? rememberMutex : commandMutex
         return await mutex.withLock { [self] in
             await handleSerialized(request)
+        }
+    }
+
+    private static func isQueryEmbedderWaitRequest(_ request: AgentBrokerRequest) -> Bool {
+        switch request.command {
+        case "recall", "search", "session_open":
+            true
+        default:
+            false
         }
     }
 
@@ -457,6 +471,10 @@ extension AgentBrokerService {
             frameFilter: parsedFilters.frameFilter,
             timeRange: parsedFilters.timeRange
         )
+        await awaitQueryEmbedderIfNeeded(memory: longTermMemory)
+        if let sessionID = parsedFilters.sessionId {
+            await awaitQueryEmbedderIfNeeded(memory: try await memory(for: sessionID))
+        }
         let result = try await LayeredRecall.recall(request: request, stores: layeredRecallStores())
 
         var lines: [String] = []
@@ -530,6 +548,13 @@ extension AgentBrokerService {
             "results": .array(results),
             "display_text": .string(lines.joined(separator: "\n")),
         ]
+        if let warning = Self.retrievalDowngradeWarning(
+            requestedMode: result.requestedModeSummary,
+            effectiveMode: result.effectiveModeSummary,
+            queryEmbeddingState: result.queryEmbeddingState
+        ) {
+            payload["warning"] = .string(warning)
+        }
         if let scopeMissMessage = result.scopeMissMessage {
             payload["scope_miss_message"] = .string(scopeMissMessage)
         }
@@ -585,6 +610,7 @@ extension AgentBrokerService {
         let topK = command.topK
         let parsedFilters = command.filters
         let memory = try await memory(for: parsedFilters.sessionId)
+        await awaitQueryEmbedderIfNeeded(memory: memory)
         let execution = try await memory.searchExecution(
             query: query,
             mode: mode,
@@ -613,7 +639,7 @@ extension AgentBrokerService {
             )
         }
         let text = rows.isEmpty ? "No results." : rows.map(\.debugJSONString).joined(separator: "\n")
-        return .object([
+        var payload: [String: AgentBrokerValue] = [
             "query": .string(query),
             "topK": .from(topK),
             "requested_mode": .string(execution.requestedMode.diagnosticsSummary),
@@ -624,7 +650,15 @@ extension AgentBrokerService {
             "time_range_applied": .from(parsedFilters.timeRange != nil),
             "results": .array(rows),
             "display_text": .string(text),
-        ])
+        ]
+        if let warning = Self.retrievalDowngradeWarning(
+            requestedMode: execution.requestedMode.diagnosticsSummary,
+            effectiveMode: execution.effectiveMode.diagnosticsSummary,
+            queryEmbeddingState: execution.queryEmbeddingState.rawValue
+        ) {
+            payload["warning"] = .string(warning)
+        }
+        return .object(payload)
     }
 
     func memorySearch(_ command: BrokerCommand.MemorySearch) async throws -> AgentBrokerValue {
@@ -1073,6 +1107,7 @@ extension AgentBrokerService {
 
     package func prewarmEmbedder() async {
         guard !noEmbedder else { return }
+        await awaitQueryEmbedderIfNeeded(memory: longTermMemory)
         _ = try? await longTermMemory.searchExecution(
             query: "wax",
             mode: .hybrid(alpha: 0.5),
@@ -1080,6 +1115,40 @@ extension AgentBrokerService {
             frameFilter: nil,
             timeRange: nil
         )
+        guard await longTermMemory.isQueryEmbedderReady() else { return }
+        _ = try? await longTermMemory.backfillUnembedded()
+    }
+
+    /// Suspends while MiniLM (or the configured provider) is `.loading`, matching remember.
+    /// Missing providers and wait timeouts do not throw — callers degrade to text + warning.
+    func awaitQueryEmbedderIfNeeded(memory: MemoryOrchestrator) async {
+        guard !noEmbedder else { return }
+        let stats = await memory.runtimeStats()
+        guard stats.vectorSearchEnabled, await memory.shouldDeferRememberUntilEmbedderReady() else {
+            return
+        }
+        try? await Self.awaitRememberReady(memory: memory, timeout: .seconds(30))
+    }
+
+    /// Compact JSON warning when hybrid was requested but the query ran as text.
+    package static func retrievalDowngradeWarning(
+        requestedMode: String,
+        effectiveMode: String,
+        queryEmbeddingState: String
+    ) -> String? {
+        let requestedHybrid = requestedMode.hasPrefix("hybrid")
+        let usedText = effectiveMode == "text" || effectiveMode.hasPrefix("text")
+        guard requestedHybrid, usedText else { return nil }
+        let reason: String
+        switch queryEmbeddingState {
+        case "timeout":
+            reason = "embedder timeout"
+        case "circuit_open":
+            reason = "embedder circuit open"
+        default:
+            reason = "embedder missing"
+        }
+        return "WARNING: hybrid requested, \(reason), used text"
     }
 
     func flush() async throws -> AgentBrokerValue {
@@ -1107,12 +1176,12 @@ extension AgentBrokerService {
         let explicitRepo = command.repo
         var inferredScope = requestedCWD.map {
             MemorySemantics.inferScopeContext(currentDirectoryPath: $0)
-        } ?? scopeContext
+        } ?? MemoryScopeContext()
         if explicitProject != nil || explicitRepo != nil {
             inferredScope = MemoryScopeContext(
                 cwdPath: inferredScope.cwdPath,
                 repoRootPath: inferredScope.repoRootPath,
-                repoName: explicitRepo ?? inferredScope.repoName,
+                repoName: explicitRepo ?? explicitProject ?? inferredScope.repoName,
                 projectName: explicitProject ?? inferredScope.projectName
             )
         }
@@ -1274,7 +1343,7 @@ extension AgentBrokerService {
             }
         }
 
-        let inferred = cwd.map { MemorySemantics.inferScopeContext(currentDirectoryPath: $0) } ?? scopeContext
+        let inferred = cwd.map { MemorySemantics.inferScopeContext(currentDirectoryPath: $0) } ?? MemoryScopeContext()
         let resolvedProject: String?
         let resolvedRepo: String?
         if let sessionID, let uuid = UUID(uuidString: sessionID), let live = activeSessions[uuid] {
@@ -1308,6 +1377,9 @@ extension AgentBrokerService {
         ]
         if let recallPayload {
             payload["recall"] = recallPayload
+            if let warning = recallPayload.objectValue?["warning"] {
+                payload["warning"] = warning
+            }
         }
         return .object(payload)
     }
@@ -2231,7 +2303,6 @@ extension AgentBrokerService {
 
     func layeredRecallStores() -> LayeredRecall.Stores {
         let sessionsSnapshot = activeSessions
-        let defaultScope = scopeContext
         let noEmbedderFlag = noEmbedder
         let sessionRoot = sessionRootURL
 
@@ -2252,8 +2323,8 @@ extension AgentBrokerService {
             inferWriteScope: { sessionID, clientCWD in
                 if let sessionID, let state = sessionsSnapshot[sessionID] {
                     return LayeredRecall.Identity(
-                        project: state.manifest.project ?? defaultScope.projectName,
-                        repo: state.manifest.repo ?? defaultScope.repoName
+                        project: state.manifest.project,
+                        repo: state.manifest.repo
                     )
                 }
                 if let clientCWD {
@@ -2263,10 +2334,7 @@ extension AgentBrokerService {
                         repo: inferred.repoName
                     )
                 }
-                return LayeredRecall.Identity(
-                    project: defaultScope.projectName,
-                    repo: defaultScope.repoName
-                )
+                return LayeredRecall.Identity(project: nil, repo: nil)
             },
             preview: { text in
                 Wax.dehighlightedPreviewText(text ?? "")
@@ -2668,16 +2736,16 @@ extension AgentBrokerService {
     func writeScope(for sessionID: UUID?, clientCWD: String? = nil) -> MemoryScopeContext {
         if let sessionID, let session = activeSessions[sessionID] {
             return MemoryScopeContext(
-                cwdPath: clientCWD ?? scopeContext.cwdPath,
-                repoRootPath: scopeContext.repoRootPath,
-                repoName: session.manifest.repo ?? scopeContext.repoName,
-                projectName: session.manifest.project ?? scopeContext.projectName
+                cwdPath: clientCWD,
+                repoRootPath: nil,
+                repoName: session.manifest.repo,
+                projectName: session.manifest.project
             )
         }
         if let clientCWD {
             return MemorySemantics.inferScopeContext(currentDirectoryPath: clientCWD)
         }
-        return scopeContext
+        return MemoryScopeContext()
     }
 
     func agentFacingPreview(_ text: String?) -> String {

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -155,6 +155,8 @@ package actor AgentBrokerService {
         }
         // Wait for MiniLM outside commandMutex so a cold first recall does not
         // stall unrelated commands the way remember already uses rememberMutex.
+        // Do not wait again inside recall/search — a timeout here must not
+        // become a second 30s hold on the serialized path.
         if Self.isQueryEmbedderWaitRequest(request) {
             await awaitQueryEmbedderIfNeeded(memory: longTermMemory)
         }
@@ -165,11 +167,20 @@ package actor AgentBrokerService {
     }
 
     private static func isQueryEmbedderWaitRequest(_ request: AgentBrokerRequest) -> Bool {
-        switch request.command {
-        case "recall", "search", "session_open":
-            true
+        guard let command = try? BrokerCommand.decode(
+            command: request.command,
+            arguments: request.arguments
+        ) else {
+            return false
+        }
+        switch command {
+        case .recall, .search:
+            return true
+        case .sessionOpen(let open):
+            let query = open.recallQuery?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return !query.isEmpty
         default:
-            false
+            return false
         }
     }
 
@@ -471,10 +482,6 @@ extension AgentBrokerService {
             frameFilter: parsedFilters.frameFilter,
             timeRange: parsedFilters.timeRange
         )
-        await awaitQueryEmbedderIfNeeded(memory: longTermMemory)
-        if let sessionID = parsedFilters.sessionId {
-            await awaitQueryEmbedderIfNeeded(memory: try await memory(for: sessionID))
-        }
         let result = try await LayeredRecall.recall(request: request, stores: layeredRecallStores())
 
         var lines: [String] = []
@@ -610,7 +617,6 @@ extension AgentBrokerService {
         let topK = command.topK
         let parsedFilters = command.filters
         let memory = try await memory(for: parsedFilters.sessionId)
-        await awaitQueryEmbedderIfNeeded(memory: memory)
         let execution = try await memory.searchExecution(
             query: query,
             mode: mode,
@@ -1140,12 +1146,16 @@ extension AgentBrokerService {
         let usedText = effectiveMode == "text" || effectiveMode.hasPrefix("text")
         guard requestedHybrid, usedText else { return nil }
         let reason: String
-        switch queryEmbeddingState {
-        case "timeout":
+        switch RAGContext.QueryEmbeddingState(rawValue: queryEmbeddingState) {
+        case .timeout:
             reason = "embedder timeout"
-        case "circuit_open":
+        case .circuitOpen:
             reason = "embedder circuit open"
-        default:
+        case .failed:
+            reason = "embedder failed"
+        case .vectorDisabled:
+            reason = "vector search disabled"
+        case .noEmbedder, .notRequested, .available, .none:
             reason = "embedder missing"
         }
         return "WARNING: hybrid requested, \(reason), used text"

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -191,10 +191,14 @@ package enum MemorySemantics {
             normalized["session_id"] = sessionID.uuidString
         }
 
-        if let project = normalizedOrNil(semantics.project) ?? normalizedOrNil(normalized[MemoryMetadataKeys.project]) ?? normalizedOrNil(inferredScope?.projectName) {
+        let explicitProject = normalizedOrNil(semantics.project)
+            ?? normalizedOrNil(normalized[MemoryMetadataKeys.project])
+        let explicitRepo = normalizedOrNil(semantics.repo)
+            ?? normalizedOrNil(normalized[MemoryMetadataKeys.repo])
+        if let project = explicitProject ?? normalizedOrNil(inferredScope?.projectName) {
             normalized[MemoryMetadataKeys.project] = project
         }
-        if let repo = normalizedOrNil(semantics.repo) ?? normalizedOrNil(normalized[MemoryMetadataKeys.repo]) ?? normalizedOrNil(inferredScope?.repoName) {
+        if let repo = explicitRepo ?? explicitProject ?? normalizedOrNil(inferredScope?.repoName) {
             normalized[MemoryMetadataKeys.repo] = repo
         }
         if let confidence = semantics.confidence {

--- a/Sources/WaxCLI/WaxCLICommand.swift
+++ b/Sources/WaxCLI/WaxCLICommand.swift
@@ -758,13 +758,13 @@ enum WaxMCPAgentPlaybook {
         Wax is the shared memory layer. Chat dies; Wax does not. Skip one-line Q&A. Use on any multi-step coding, debug, or research task.
 
         Open every multi-step session:
-        1. Prefer `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Or call `handoff_latest` first then `session_start` once. Keep `session_id`. Do not invent one.
+        1. Call `session_open` (`project` = repo name, stable `agent_id`/`run_id`, optional `recall_query`). Keep `session_id`. Do not invent one. Do not call `handoff_latest` then `session_start` as the default open.
         2. Call `recall` with default `scope: project` (hard-filters to resolved project; unlabeled/foreign frames excluded). Empty lane returns an explicit miss — pass `scope: global` only for cross-project reads. `recall` with `session_id` merges that session with durable memory under project scope.
 
         Workflow rules:
         - Use `remember` to store decisions, discoveries, and short factual notes. Prefer `scope: session` (requires top-level `session_id`) or `scope: durable` (forbids `session_id`). Do not put `session_id` inside `metadata`.
         - Use `recall` for assembled context and `search` for raw ranked hits.
-        - Prefer `mode: "hybrid"` when semantic retrieval helps. Use `mode: "text"` when I want a fast or deterministic lexical lookup.
+        - Prefer `mode: "hybrid"` when the embedder is ready; otherwise use `mode: "text"`.
         - Do not manage `SESSION_STORE`, `--store-path`, or `flush` in normal agent flows. The broker owns long-term memory and virtual session stores.
         - Close with `session_close` (`session_id`, `content`, optional `project`/`pending_tasks`) — atomic handoff then end. Or `handoff` then `session_end`. Do not require end between turns of one host chat. Close harvests promotable session facts into durable memory automatically. Do not call `memory_promote` or operator `memory-maintain` in the agent loop.
         - Use `corpus_search` only when you need cross-session retrieval across broker-managed session history with provenance metadata.
@@ -798,7 +798,7 @@ enum WaxMCPAgentPlaybook {
 
         You have Wax. Chat is not memory.
 
-        On every multi-step task: prefer `session_open` (`project`, `agent_id`, `run_id`) or `handoff_latest` → `session_start` → keep `session_id`.
+        On every multi-step task: call `session_open` (`project`, `agent_id`, `run_id`, optional `recall_query`). Keep `session_id`.
 
         Write as you go:
         - This task: `remember` with `scope: session`, `session_id`, `memory_type: task_state`, `durability: working` (plan, failed path, landmine, milestone, before you stop or spawn another agent).

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -9,7 +9,7 @@ enum MCPAgentInstructions {
         Wax MCP durable agent memory (server v\(version)).
 
         Session lifecycle (required):
-        1) Prefer session_open(project?, agent_id?, run_id?, recall_query?) for a one-shot open, or call handoff_latest first (optional project) then session_start once and keep the returned session_id. The same agent_id+run_id resumes the active session.
+        1) Call session_open(project?, agent_id?, run_id?, recall_query?) for a one-shot open. Keep the returned session_id. Do not invent one. Do not call handoff_latest then session_start as the default open. The same agent_id+run_id resumes the active session. handoff_latest and session_start remain callable for compatibility.
         2) Before answering from memory, call recall (default) or search (raw ranked hits). Default recall scope is project: hard-filters to resolved project (explicit project, session project, or cwd/git root). Empty project lane returns an explicit miss — never auto-widens to global. Pass scope=global only when cross-project retrieval is intentional. Passing session_id merges that session with durable long-term memory under project scope.
         3) When you learn durable facts, call remember with concise factual content. Prefer scope=session|durable; session requires top-level session_id; durable forbids session_id. Never put session_id inside metadata.
         4) Near session end, prefer session_close(session_id, content, optional project/pending_tasks) for atomic handoff+end. Close harvests promotable session facts into durable memory automatically — do not call memory_promote or memory-maintain in the agent loop. Keep content to a concise state summary; put unfinished work only in pending_tasks and never store transcripts. Or call handoff then session_end. session_end/session_close `active` is THIS session (false after end). `remaining_active` / `active_session_count` are other live sessions in the broker.
@@ -20,7 +20,7 @@ enum MCPAgentInstructions {
 
         Tool selection:
         - recall: assembled RAG context (preferred read path); default scope=project
-        - search: raw ranked hits; prefer mode hybrid unless a lexical text search is requested
+        - search: raw ranked hits; prefer mode hybrid when the embedder is ready, otherwise text
         - corpus_search: cross-session history with provenance
         - entity_*/fact_*: stable structured knowledge, not transient debug notes
         - stats: health / embedder / store check

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -31,12 +31,12 @@ enum ToolSchemas {
         ),
         Tool(
             name: "recall",
-            description: "Preferred read path: assemble RAG context for a query. Call after handoff_latest/session_start when answering from memory. Passing session_id merges that session with durable long-term memory.",
+            description: "Preferred read path: assemble RAG context for a query. Call after session_open when answering from memory. Passing session_id merges that session with durable long-term memory.",
             inputSchema: waxRecall
         ),
         Tool(
             name: "search",
-            description: "Raw ranked search hits (not assembled RAG). Prefer mode hybrid for semantic retrieval; use mode text for lexical/deterministic lookup.",
+            description: "Raw ranked search hits (not assembled RAG). Prefer mode hybrid when the embedder is ready; otherwise use mode text.",
             inputSchema: waxSearch
         ),
         Tool(
@@ -71,7 +71,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "session_start",
-            description: "Create a broker-managed virtual session and return session_id. Call after handoff_latest at session start; keep session_id for later tools. The same agent_id+run_id reuses the active session instead of minting a sibling.",
+            description: "Create or reuse a broker-managed virtual session and return session_id. Prefer session_open. The same agent_id+run_id reuses the active session instead of minting a sibling.",
             inputSchema: waxSessionStart
         ),
         Tool(
@@ -91,7 +91,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "session_open",
-            description: "Open a session in one call. Returns session_id plus a bounded short handoff projection; optional non-empty recall_query adds capped project-scoped recall. Use handoff_latest for the complete handoff and pending tasks.",
+            description: "One-shot session open plus optional recall. Returns session_id plus a bounded short handoff projection; optional non-empty recall_query adds capped project-scoped recall. Prefer this over handoff_latest then session_start. Use handoff_latest only when you need the complete handoff.",
             inputSchema: waxSessionOpen
         ),
         Tool(
@@ -101,7 +101,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "handoff_latest",
-            description: "Call first at session start: fetch the latest handoff note (optional project) before session_start.",
+            description: "Fetch the latest handoff note (optional project). Not the default session open — prefer session_open.",
             inputSchema: waxHandoffLatest
         ),
         Tool(

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -185,8 +185,10 @@ private extension WaxMCPTools {
     }
 
     static func injectClientCWDIfNeeded(name: String, arguments: inout [String: Value]) {
-        guard clientCWDCommands.contains(name), arguments["cwd"] == nil else { return }
-        arguments["cwd"] = .string(FileManager.default.currentDirectoryPath)
+        // Leave omitted `cwd` omitted. Stamping the MCP process working directory
+        // made durable writes inherit the broker repo (e.g. wax.repo=Wax).
+        guard clientCWDCommands.contains(name) else { return }
+        _ = arguments
     }
 
     static func injectClientSessionIfNeeded(

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -83,7 +83,8 @@ enum WaxMCPTools {
             if let oversize = contentLimitError(name: params.name, arguments: forwarded) {
                 return oversize
             }
-            injectClientCWDIfNeeded(name: params.name, arguments: &forwarded)
+            // Do not stamp the MCP process working directory as `cwd`. Omitted cwd
+            // must stay omitted so durable writes do not inherit the broker repo.
             injectClientSessionIfNeeded(name: params.name, arguments: &forwarded, sessionHint: sessionHint)
             let verbosity = try responseVerbosity(from: forwarded) ?? "compact"
 
@@ -157,11 +158,6 @@ private extension WaxMCPTools {
     static let compactPresentationKeys: Set<String> = [
         "display_text", "storePath", "store_path", "event_log_path",
     ]
-    static let clientCWDCommands: Set<String> = [
-        "session_start", "session_open", "remember", "memory_append", "knowledge_capture",
-        "markdown_export", "recall",
-    ]
-
     static func contentLimitError(name: String, arguments: [String: Value]) -> CallTool.Result? {
         guard case .string(let content)? = arguments["content"] else { return nil }
         let maxBytes = AgentBrokerService.maxContentBytes
@@ -182,13 +178,6 @@ private extension WaxMCPTools {
             throw ToolValidationError.invalid("verbosity must be one of: compact, verbose")
         }
         return trimmed
-    }
-
-    static func injectClientCWDIfNeeded(name: String, arguments: inout [String: Value]) {
-        // Leave omitted `cwd` omitted. Stamping the MCP process working directory
-        // made durable writes inherit the broker repo (e.g. wax.repo=Wax).
-        guard clientCWDCommands.contains(name) else { return }
-        _ = arguments
     }
 
     static func injectClientSessionIfNeeded(

--- a/Sources/WaxMCPServer/main.swift
+++ b/Sources/WaxMCPServer/main.swift
@@ -119,6 +119,9 @@ struct WaxMCPServerCommand: ParsableCommand {
             requireVector: false,
             embedderTuning: embedderTuning
         )
+        // Owned daemon prewarms the embedder in a background Task unless --no-embedder
+        // (AgentBrokerClient no longer passes --skip-prewarm). First recall still waits
+        // up to 30s if MiniLM is still loading.
         let brokerStarted = try await AgentBrokerClient.ensureAvailable(configuration: brokerConfiguration)
         let structuredMemoryEnabled = memoryConfig.enableStructuredMemory
         defer {

--- a/Tests/WaxCLITests/WaxCLIMemoryTests.swift
+++ b/Tests/WaxCLITests/WaxCLIMemoryTests.swift
@@ -904,13 +904,17 @@ struct WaxCLIMemoryTests {
     }
 
     @Test func projectRulesPlaybookMentionsLifecycle() {
-        #expect(WaxMCPAgentPlaybook.projectRules.contains("handoff_latest"))
-        #expect(WaxMCPAgentPlaybook.projectRules.contains("session_start"))
+        #expect(WaxMCPAgentPlaybook.projectRules.contains("session_open"))
+        #expect(WaxMCPAgentPlaybook.projectRules.contains("session_close"))
         #expect(WaxMCPAgentPlaybook.projectRules.contains("session_id"))
         #expect(WaxMCPAgentPlaybook.projectRules.contains("task_state"))
         #expect(WaxMCPAgentPlaybook.projectRules.contains("compact_context"))
         #expect(WaxMCPAgentPlaybook.projectRules.contains("memory-maintain"))
+        #expect(WaxMCPAgentPlaybook.projectRules.contains("Call `session_open`"))
+        #expect(!WaxMCPAgentPlaybook.projectRules.contains("Or call `handoff_latest` first then `session_start`"))
         #expect(WaxMCPAgentPlaybook.soulRules.contains("## Memory (Wax)"))
+        #expect(WaxMCPAgentPlaybook.soulRules.contains("call `session_open`"))
+        #expect(!WaxMCPAgentPlaybook.soulRules.contains("or `handoff_latest` → `session_start`"))
         #expect(WaxMCPAgentPlaybook.githubSkillURL.contains("wax-mcp"))
     }
 
@@ -938,6 +942,19 @@ struct WaxCLIMemoryTests {
         #expect(readmeText.contains(WaxMCPAgentPlaybook.soulRules))
         #expect(readmeText.contains("Paste into AGENTS.md / CLAUDE.md / Cursor rules"))
         #expect(readmeText.contains("Paste into Hermes / OpenClaw SOUL.md"))
+
+        let publicOpenAI = try String(
+            contentsOf: repoRoot.appendingPathComponent("Resources/skills/public/wax-mcp/agents/openai.yaml"),
+            encoding: .utf8
+        )
+        let npmOpenAI = try String(
+            contentsOf: repoRoot.appendingPathComponent("Resources/npm/waxmcp/skills/wax-mcp/agents/openai.yaml"),
+            encoding: .utf8
+        )
+        #expect(publicOpenAI == npmOpenAI)
+        #expect(publicOpenAI.contains("session_open"))
+        #expect(publicOpenAI.contains("session_close"))
+        #expect(!publicOpenAI.contains("Call handoff_latest then session_start"))
     }
 
     @Test func embedderRuntimeOptionsOverrideEnvironment() throws {

--- a/Tests/WaxMCPServerTests/WaxMCPAgentDXPR1Tests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPAgentDXPR1Tests.swift
@@ -1,0 +1,480 @@
+#if MCPServer
+import Foundation
+import Testing
+import MCP
+@testable import Wax
+@testable import wax_mcp
+
+// MARK: - First-call hybrid wait + loud downgrade
+
+@Test
+func hybridRecallWaitsForLoadingEmbedderThenUsesHybrid() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-dx-wait-hybrid-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+
+    do {
+        var seedConfig = OrchestratorConfig.default
+        seedConfig.enableVectorSearch = false
+        let seeder = try await AgentBrokerService(
+            storePath: storeURL.path,
+            sessionRootPath: sessionRootURL.path,
+            noEmbedder: true,
+            embedderChoice: "auto",
+            requireVector: false,
+            orchestratorConfig: seedConfig
+        )
+        let remembered = await seeder.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("HYBRID_WAIT_NEEDLE Swift actors structured concurrency")]
+        ))
+        #expect(remembered.ok == true)
+        try await seeder.close()
+    }
+
+    let gate = DXGate()
+    let readiness = EmbeddingReadiness()
+    let factory: @Sendable () async throws -> any EmbeddingProvider = {
+        await gate.wait()
+        return DXDeterministicEmbedder()
+    }
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "minilm",
+        requireVector: false,
+        readiness: readiness,
+        factoryOverride: factory
+    )
+    defer { Task { try? await service.close() } }
+
+    let loading = try #require((await service.handle(.init(command: "stats"))).payload?.objectValue)
+    #expect(loading["embeddingStatus"]?.stringValue == "loading")
+
+    async let recalled = WaxMCPTools.handleCall(
+        params: .init(
+            name: "recall",
+            arguments: [
+                "query": "HYBRID_WAIT_NEEDLE",
+                "mode": "hybrid",
+                "scope": "global",
+                "limit": 5,
+            ]
+        ),
+        broker: service
+    )
+    try await Task.sleep(for: .milliseconds(80))
+    #expect(await gate.isClosed)
+    await gate.open()
+
+    let result = await recalled
+    #expect(result.isError != true)
+    let payload = try parseDXJSON(in: result)
+    #expect((payload["requested_mode"] as? String)?.hasPrefix("hybrid") == true)
+    #expect((payload["effective_mode"] as? String)?.hasPrefix("hybrid") == true)
+    #expect((payload["query_embedding_state"] as? String) == "available")
+}
+
+@Test
+func noEmbedderHybridRecallDoesNotHangAndWarns() async throws {
+    try await withDXBroker(noEmbedder: true) { service, _ in
+        let started = ContinuousClock.now
+        let result = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "recall",
+                arguments: [
+                    "query": "no embedder hybrid should be text",
+                    "mode": "hybrid",
+                    "scope": "global",
+                ]
+            ),
+            broker: service
+        )
+        let elapsed = ContinuousClock.now - started
+        #expect(elapsed < .seconds(5))
+        #expect(result.isError != true)
+        let payload = try parseDXJSON(in: result)
+        #expect((payload["effective_mode"] as? String) == "text")
+        let warning = try #require(payload["warning"] as? String)
+        #expect(warning.contains("hybrid requested"))
+        #expect(warning.contains("used text"))
+        #expect(payload["query"] != nil)
+    }
+}
+
+@Test
+func vectorOnlyWithoutEmbedderStillThrows() async throws {
+    try await withDXBroker(noEmbedder: true) { service, _ in
+        let result = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "search",
+                arguments: [
+                    "query": "vector only must not remap",
+                    "mode": "vector",
+                    "topK": 3,
+                ]
+            ),
+            broker: service
+        )
+        #expect(result.isError == true)
+        let text = dxFirstText(in: result).lowercased()
+        #expect(text.contains("embedder") || text.contains("vector"))
+    }
+}
+
+@Test
+func sessionOpenRecallQuerySurfacesDowngradeWarningAtTopLevel() async throws {
+    try await withDXBroker(noEmbedder: true) { service, _ in
+        let result = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": "rv",
+                    "agent_id": "dx-open-agent",
+                    "run_id": "dx-open-run",
+                    "recall_query": "session open nested hybrid recall",
+                ]
+            ),
+            broker: service
+        )
+        #expect(result.isError != true)
+        let payload = try parseDXJSON(in: result)
+        let warning = try #require(payload["warning"] as? String)
+        #expect(warning.contains("hybrid requested"))
+        #expect(warning.contains("used text"))
+        let recall = try #require(payload["recall"] as? [String: Any])
+        #expect((recall["effective_mode"] as? String) == "text")
+        #expect((recall["warning"] as? String)?.contains("hybrid requested") == true)
+    }
+}
+
+@Test
+func compactHybridWarningIsSingleJSONObject() async throws {
+    try await withDXBroker(noEmbedder: true) { service, _ in
+        let result = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "search",
+                arguments: [
+                    "query": "json warning shape",
+                    "mode": "hybrid",
+                    "topK": 1,
+                ]
+            ),
+            broker: service
+        )
+        let text = dxFirstText(in: result)
+        #expect(text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{"))
+        let object = try JSONSerialization.jsonObject(with: Data(text.utf8))
+        #expect(object is [String: Any])
+    }
+}
+
+// MARK: - Repo stamp
+
+@Test
+func omittedClientCwdWithProjectDoesNotStampProcessRepo() async throws {
+    try await withDXBroker(noEmbedder: true) { service, _ in
+        let processRepo = MemorySemantics.inferScopeContext().repoName
+        let write = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "remember",
+                arguments: [
+                    "content": "Omitted cwd project rv must not inherit process repo",
+                    "project": "rv",
+                ]
+            ),
+            broker: service
+        )
+        #expect(write.isError != true)
+
+        let search = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "search",
+                arguments: [
+                    "query": "Omitted cwd project rv must not inherit process repo",
+                    "mode": "text",
+                    "topK": 5,
+                ]
+            ),
+            broker: service
+        )
+        #expect(search.isError != true)
+        let payload = try parseDXJSON(in: search)
+        let results = try #require(payload["results"] as? [Any])
+        let hit = try #require(results.first as? [String: Any])
+        let metadata = try #require(hit["metadata"] as? [String: Any])
+        #expect(metadata["wax.project"] as? String == "rv")
+        #expect(metadata["wax.repo"] as? String == "rv")
+        if let processRepo, processRepo != "rv" {
+            #expect(metadata["wax.repo"] as? String != processRepo)
+        }
+    }
+}
+
+@Test
+func omittedClientCwdRecallDoesNotBindProcessProjectIdentity() async throws {
+    try await withDXBroker(noEmbedder: true) { service, _ in
+        let processRepo = MemorySemantics.inferScopeContext().repoName
+        let processProject = MemorySemantics.inferScopeContext().projectName
+        let recalled = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "recall",
+                arguments: [
+                    "query": "unscoped recall must not inherit process project",
+                    "mode": "text",
+                    "limit": 5,
+                ]
+            ),
+            broker: service
+        )
+        #expect(recalled.isError != true)
+        let payload = try parseDXJSON(in: recalled)
+        #expect(payload["project_miss"] as? Bool == true)
+        if let processProject {
+            #expect(payload["project"] as? String != processProject)
+        }
+        if let processRepo {
+            #expect(payload["repo"] as? String != processRepo)
+        }
+        let message = (payload["scope_miss_message"] as? String) ?? ""
+        #expect(message.contains("unresolved") || message.contains("no frames for project"))
+    }
+}
+
+@Test
+func injectClientCWDIfNeededDoesNotWriteProcessDirectory() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let source = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/WaxMCPServer/WaxMCPTools.swift"),
+        encoding: .utf8
+    )
+    let start = try #require(source.range(of: "static func injectClientCWDIfNeeded"))
+    let end = try #require(source[start.upperBound...].range(of: "static func injectClientSessionIfNeeded"))
+    let body = source[start.lowerBound..<end.lowerBound]
+    #expect(!body.contains("FileManager.default.currentDirectoryPath"))
+}
+
+@Test
+func agentBrokerClientStartsDaemonWithoutSkipPrewarmWhenEmbedderConfigured() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let source = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/AgentBrokerClient.swift"),
+        encoding: .utf8
+    )
+    let start = try #require(source.range(of: "private static func startBrokerIfNeeded("))
+    let end = try #require(source[start.upperBound...].range(of: "process.environment = ProcessInfo.processInfo.environment"))
+    let body = source[start.lowerBound..<end.lowerBound]
+    #expect(body.contains("daemon"))
+    #expect(!body.contains("\"--skip-prewarm\""))
+    #expect(body.contains("\"--no-embedder\""))
+}
+
+// MARK: - Backfill on prewarm
+
+@Test
+func prewarmEmbedderBackfillsUnembeddedFramesOnOpenStore() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-dx-backfill-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+
+    do {
+        var seedConfig = OrchestratorConfig.default
+        seedConfig.enableVectorSearch = false
+        let seeder = try await AgentBrokerService(
+            storePath: storeURL.path,
+            sessionRootPath: sessionRootURL.path,
+            noEmbedder: true,
+            embedderChoice: "auto",
+            requireVector: false,
+            orchestratorConfig: seedConfig
+        )
+        #expect((await seeder.handle(.init(
+            command: "remember",
+            arguments: ["content": .string("BACKFILL_PREWARM_NEEDLE unique unembedded frame")]
+        ))).ok == true)
+        try await seeder.close()
+    }
+
+    var hybridConfig = OrchestratorConfig.default
+    hybridConfig.enableVectorSearch = true
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "auto",
+        requireVector: false,
+        embedderOverride: DXDeterministicEmbedder(),
+        orchestratorConfig: hybridConfig
+    )
+    defer { Task { try? await service.close() } }
+
+    let before = try #require((await service.handle(.init(command: "stats"))).payload?.objectValue)
+    #expect((before["framesWithoutVectors"]?.intValue ?? 0) > 0)
+
+    await service.prewarmEmbedder()
+
+    let after = try #require((await service.handle(.init(command: "stats"))).payload?.objectValue)
+    #expect((after["framesWithoutVectors"]?.intValue ?? 1) == 0)
+}
+
+@Test
+func noEmbedderPrewarmDoesNotBackfillUnembeddedFrames() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-dx-nobackfill-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+
+    var seedConfig = OrchestratorConfig.default
+    seedConfig.enableVectorSearch = false
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: true,
+        embedderChoice: "auto",
+        requireVector: false,
+        orchestratorConfig: seedConfig
+    )
+    defer { Task { try? await service.close() } }
+
+    #expect((await service.handle(.init(
+        command: "remember",
+        arguments: ["content": .string("NO_EMBEDDER_PREWARM stays text only")]
+    ))).ok == true)
+
+    let before = try #require((await service.handle(.init(command: "stats"))).payload?.objectValue)
+    let beforeMissing = before["framesWithoutVectors"]?.intValue ?? 0
+
+    await service.prewarmEmbedder()
+
+    let after = try #require((await service.handle(.init(command: "stats"))).payload?.objectValue)
+    let afterMissing = after["framesWithoutVectors"]?.intValue ?? 0
+    #expect(afterMissing == beforeMissing)
+    #expect(afterMissing > 0)
+}
+
+@Test
+func prewarmEmbedderSourceBackfillsAfterSearchWhenEmbedderConfigured() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let source = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/AgentBrokerService.swift"),
+        encoding: .utf8
+    )
+    let start = try #require(source.range(of: "package func prewarmEmbedder() async {"))
+    let end = try #require(source[start.upperBound...].range(of: "func flush() async throws"))
+    let body = source[start.lowerBound..<end.lowerBound]
+    #expect(body.contains("guard !noEmbedder"))
+    #expect(body.contains("backfillUnembedded()"))
+    let guardRange = try #require(body.range(of: "guard !noEmbedder"))
+    let backfillRange = try #require(body.range(of: "backfillUnembedded()"))
+    #expect(guardRange.lowerBound < backfillRange.lowerBound)
+}
+
+// MARK: - Helpers
+
+private func withDXBroker<T>(
+    noEmbedder: Bool,
+    _ body: (AgentBrokerService, URL) async throws -> T
+) async throws -> T {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-dx-broker-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: noEmbedder,
+        embedderChoice: "auto",
+        requireVector: false
+    )
+    do {
+        let result = try await body(service, sessionRootURL)
+        try await service.close()
+        return result
+    } catch {
+        try? await service.close()
+        throw error
+    }
+}
+
+private func parseDXJSON(in result: CallTool.Result) throws -> [String: Any] {
+    let text = dxFirstText(in: result)
+    guard let data = text.data(using: .utf8),
+          let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw NSError(
+            domain: "WaxMCPAgentDXPR1Tests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Result is not a JSON object: \(text.prefix(200))"]
+        )
+    }
+    return object
+}
+
+private func dxFirstText(in result: CallTool.Result) -> String {
+    for content in result.content {
+        if case .text(text: let text, annotations: _, _meta: _) = content {
+            return text
+        }
+    }
+    return ""
+}
+
+private struct DXDeterministicEmbedder: EmbeddingProvider, Sendable {
+    let dimensions: Int = 2
+    let normalize: Bool = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "DXTest",
+        model: "Deterministic",
+        dimensions: 2,
+        normalized: true
+    )
+
+    func embed(_ text: String) async throws -> [Float] {
+        let a = Float(text.utf8.count % 97) / 97.0
+        let b = Float(text.unicodeScalars.count % 89) / 89.0
+        let norm = sqrt(a * a + b * b)
+        guard norm > 0 else { return [1, 0] }
+        return [a / norm, b / norm]
+    }
+}
+
+private actor DXGate {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    var isClosed: Bool { !opened }
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        opened = true
+        for waiter in waiters {
+            waiter.resume()
+        }
+        waiters.removeAll()
+    }
+}
+#endif

--- a/Tests/WaxMCPServerTests/WaxMCPAgentDXPR1Tests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPAgentDXPR1Tests.swift
@@ -127,6 +127,167 @@ func vectorOnlyWithoutEmbedderStillThrows() async throws {
 }
 
 @Test
+func retrievalDowngradeWarningMapsEmbeddingStates() {
+    #expect(
+        AgentBrokerService.retrievalDowngradeWarning(
+            requestedMode: "hybrid(alpha=0.500)",
+            effectiveMode: "text",
+            queryEmbeddingState: "timeout"
+        ) == "WARNING: hybrid requested, embedder timeout, used text"
+    )
+    #expect(
+        AgentBrokerService.retrievalDowngradeWarning(
+            requestedMode: "hybrid(alpha=0.500)",
+            effectiveMode: "text",
+            queryEmbeddingState: "circuit_open"
+        ) == "WARNING: hybrid requested, embedder circuit open, used text"
+    )
+    #expect(
+        AgentBrokerService.retrievalDowngradeWarning(
+            requestedMode: "hybrid(alpha=0.500)",
+            effectiveMode: "text",
+            queryEmbeddingState: "failed"
+        ) == "WARNING: hybrid requested, embedder failed, used text"
+    )
+    #expect(
+        AgentBrokerService.retrievalDowngradeWarning(
+            requestedMode: "hybrid(alpha=0.500)",
+            effectiveMode: "text",
+            queryEmbeddingState: "vector_disabled"
+        ) == "WARNING: hybrid requested, vector search disabled, used text"
+    )
+    #expect(
+        AgentBrokerService.retrievalDowngradeWarning(
+            requestedMode: "hybrid(alpha=0.500)",
+            effectiveMode: "text",
+            queryEmbeddingState: "no_embedder"
+        ) == "WARNING: hybrid requested, embedder missing, used text"
+    )
+    #expect(
+        AgentBrokerService.retrievalDowngradeWarning(
+            requestedMode: "text",
+            effectiveMode: "text",
+            queryEmbeddingState: "no_embedder"
+        ) == nil
+    )
+    #expect(
+        AgentBrokerService.retrievalDowngradeWarning(
+            requestedMode: "hybrid(alpha=0.500)",
+            effectiveMode: "hybrid(alpha=0.500)",
+            queryEmbeddingState: "available"
+        ) == nil
+    )
+}
+
+@Test
+func sessionOpenWithoutRecallQueryDoesNotWaitForLoadingEmbedder() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-dx-open-nowait-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+
+    let gate = DXGate()
+    let readiness = EmbeddingReadiness()
+    let factory: @Sendable () async throws -> any EmbeddingProvider = {
+        await gate.wait()
+        return DXDeterministicEmbedder()
+    }
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "minilm",
+        requireVector: false,
+        readiness: readiness,
+        factoryOverride: factory
+    )
+    defer {
+        Task {
+            await gate.open()
+            try? await service.close()
+        }
+    }
+
+    let started = ContinuousClock.now
+    let result = await WaxMCPTools.handleCall(
+        params: .init(
+            name: "session_open",
+            arguments: [
+                "project": "rv",
+                "agent_id": "dx-open-nowait",
+                "run_id": "dx-open-nowait-run",
+            ]
+        ),
+        broker: service
+    )
+    let elapsed = ContinuousClock.now - started
+    #expect(elapsed < .seconds(5))
+    #expect(result.isError != true)
+    let payload = try parseDXJSON(in: result)
+    #expect((payload["session_id"] as? String)?.isEmpty == false)
+    #expect(payload["recall"] == nil)
+    #expect(await gate.isClosed)
+}
+
+@Test
+func sessionOpenRecallQueryWaitsForLoadingEmbedderThenUsesHybrid() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-dx-open-wait-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let storeURL = rootURL.appendingPathComponent("memory.wax")
+    let sessionRootURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+
+    let gate = DXGate()
+    let readiness = EmbeddingReadiness()
+    let factory: @Sendable () async throws -> any EmbeddingProvider = {
+        await gate.wait()
+        return DXDeterministicEmbedder()
+    }
+    let service = try await AgentBrokerService(
+        storePath: storeURL.path,
+        sessionRootPath: sessionRootURL.path,
+        noEmbedder: false,
+        embedderChoice: "minilm",
+        requireVector: false,
+        readiness: readiness,
+        factoryOverride: factory
+    )
+    defer {
+        Task {
+            await gate.open()
+            try? await service.close()
+        }
+    }
+
+    async let opened = WaxMCPTools.handleCall(
+        params: .init(
+            name: "session_open",
+            arguments: [
+                "project": "rv",
+                "agent_id": "dx-open-wait",
+                "run_id": "dx-open-wait-run",
+                "recall_query": "session open nested hybrid recall",
+            ]
+        ),
+        broker: service
+    )
+    try await Task.sleep(for: .milliseconds(80))
+    #expect(await gate.isClosed)
+    await gate.open()
+
+    let result = await opened
+    #expect(result.isError != true)
+    let payload = try parseDXJSON(in: result)
+    let recall = try #require(payload["recall"] as? [String: Any])
+    #expect((recall["requested_mode"] as? String)?.hasPrefix("hybrid") == true)
+    #expect((recall["effective_mode"] as? String)?.hasPrefix("hybrid") == true)
+    #expect((recall["query_embedding_state"] as? String) == "available")
+}
+
+@Test
 func sessionOpenRecallQuerySurfacesDowngradeWarningAtTopLevel() async throws {
     try await withDXBroker(noEmbedder: true) { service, _ in
         let result = await WaxMCPTools.handleCall(
@@ -246,7 +407,7 @@ func omittedClientCwdRecallDoesNotBindProcessProjectIdentity() async throws {
 }
 
 @Test
-func injectClientCWDIfNeededDoesNotWriteProcessDirectory() throws {
+func waxMCPToolsDoesNotInjectProcessWorkingDirectoryAsCwd() throws {
     let repoRoot = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
@@ -255,10 +416,28 @@ func injectClientCWDIfNeededDoesNotWriteProcessDirectory() throws {
         contentsOf: repoRoot.appendingPathComponent("Sources/WaxMCPServer/WaxMCPTools.swift"),
         encoding: .utf8
     )
-    let start = try #require(source.range(of: "static func injectClientCWDIfNeeded"))
-    let end = try #require(source[start.upperBound...].range(of: "static func injectClientSessionIfNeeded"))
-    let body = source[start.lowerBound..<end.lowerBound]
-    #expect(!body.contains("FileManager.default.currentDirectoryPath"))
+    #expect(!source.contains("arguments[\"cwd\"] = .string(FileManager.default.currentDirectoryPath)"))
+    #expect(!source.contains("injectClientCWDIfNeeded"))
+}
+
+@Test
+func recallAndSearchDoNotRepeatEmbedderWaitInsideSerializedHandler() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let source = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/Broker/AgentBrokerService.swift"),
+        encoding: .utf8
+    )
+    let recallStart = try #require(source.range(of: "func recall(_ command: BrokerCommand.Recall)"))
+    let searchStart = try #require(source.range(of: "func search(_ command: BrokerCommand.Search)"))
+    let memorySearchStart = try #require(source.range(of: "func memorySearch(_ command: BrokerCommand.MemorySearch)"))
+    let recallBody = source[recallStart.lowerBound..<searchStart.lowerBound]
+    let searchBody = source[searchStart.lowerBound..<memorySearchStart.lowerBound]
+    #expect(!recallBody.contains("awaitQueryEmbedderIfNeeded"))
+    #expect(!searchBody.contains("awaitQueryEmbedderIfNeeded"))
+    #expect(source.contains("isQueryEmbedderWaitRequest(request)"))
 }
 
 @Test

--- a/Tests/WaxMCPServerTests/WaxMCPAgentDXPR1Tests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPAgentDXPR1Tests.swift
@@ -203,32 +203,33 @@ func sessionOpenWithoutRecallQueryDoesNotWaitForLoadingEmbedder() async throws {
         readiness: readiness,
         factoryOverride: factory
     )
-    defer {
-        Task {
-            await gate.open()
-            try? await service.close()
-        }
+    do {
+        let started = ContinuousClock.now
+        let result = await WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": "rv",
+                    "agent_id": "dx-open-nowait",
+                    "run_id": "dx-open-nowait-run",
+                ]
+            ),
+            broker: service
+        )
+        let elapsed = ContinuousClock.now - started
+        #expect(elapsed < .seconds(5))
+        #expect(result.isError != true)
+        let payload = try parseDXJSON(in: result)
+        #expect((payload["session_id"] as? String)?.isEmpty == false)
+        #expect(payload["recall"] == nil)
+        #expect(await gate.isClosed)
+        await gate.open()
+        try await service.close()
+    } catch {
+        await gate.open()
+        try? await service.close()
+        throw error
     }
-
-    let started = ContinuousClock.now
-    let result = await WaxMCPTools.handleCall(
-        params: .init(
-            name: "session_open",
-            arguments: [
-                "project": "rv",
-                "agent_id": "dx-open-nowait",
-                "run_id": "dx-open-nowait-run",
-            ]
-        ),
-        broker: service
-    )
-    let elapsed = ContinuousClock.now - started
-    #expect(elapsed < .seconds(5))
-    #expect(result.isError != true)
-    let payload = try parseDXJSON(in: result)
-    #expect((payload["session_id"] as? String)?.isEmpty == false)
-    #expect(payload["recall"] == nil)
-    #expect(await gate.isClosed)
 }
 
 @Test
@@ -255,36 +256,36 @@ func sessionOpenRecallQueryWaitsForLoadingEmbedderThenUsesHybrid() async throws 
         readiness: readiness,
         factoryOverride: factory
     )
-    defer {
-        Task {
-            await gate.open()
-            try? await service.close()
-        }
+    do {
+        async let opened = WaxMCPTools.handleCall(
+            params: .init(
+                name: "session_open",
+                arguments: [
+                    "project": "rv",
+                    "agent_id": "dx-open-wait",
+                    "run_id": "dx-open-wait-run",
+                    "recall_query": "session open nested hybrid recall",
+                ]
+            ),
+            broker: service
+        )
+        try await Task.sleep(for: .milliseconds(80))
+        #expect(await gate.isClosed)
+        await gate.open()
+
+        let result = await opened
+        #expect(result.isError != true)
+        let payload = try parseDXJSON(in: result)
+        let recall = try #require(payload["recall"] as? [String: Any])
+        #expect((recall["requested_mode"] as? String)?.hasPrefix("hybrid") == true)
+        #expect((recall["effective_mode"] as? String)?.hasPrefix("hybrid") == true)
+        #expect((recall["query_embedding_state"] as? String) == "available")
+        try await service.close()
+    } catch {
+        await gate.open()
+        try? await service.close()
+        throw error
     }
-
-    async let opened = WaxMCPTools.handleCall(
-        params: .init(
-            name: "session_open",
-            arguments: [
-                "project": "rv",
-                "agent_id": "dx-open-wait",
-                "run_id": "dx-open-wait-run",
-                "recall_query": "session open nested hybrid recall",
-            ]
-        ),
-        broker: service
-    )
-    try await Task.sleep(for: .milliseconds(80))
-    #expect(await gate.isClosed)
-    await gate.open()
-
-    let result = await opened
-    #expect(result.isError != true)
-    let payload = try parseDXJSON(in: result)
-    let recall = try #require(payload["recall"] as? [String: Any])
-    #expect((recall["requested_mode"] as? String)?.hasPrefix("hybrid") == true)
-    #expect((recall["effective_mode"] as? String)?.hasPrefix("hybrid") == true)
-    #expect((recall["query_embedding_state"] as? String) == "available")
 }
 
 @Test
@@ -435,8 +436,10 @@ func recallAndSearchDoNotRepeatEmbedderWaitInsideSerializedHandler() throws {
     let memorySearchStart = try #require(source.range(of: "func memorySearch(_ command: BrokerCommand.MemorySearch)"))
     let recallBody = source[recallStart.lowerBound..<searchStart.lowerBound]
     let searchBody = source[searchStart.lowerBound..<memorySearchStart.lowerBound]
-    #expect(!recallBody.contains("awaitQueryEmbedderIfNeeded"))
-    #expect(!searchBody.contains("awaitQueryEmbedderIfNeeded"))
+    #expect(!recallBody.contains("awaitQueryEmbedderIfNeeded(memory: longTermMemory)"))
+    #expect(!searchBody.contains("awaitQueryEmbedderIfNeeded(memory: longTermMemory)"))
+    #expect(recallBody.contains("awaitQueryEmbedderIfNeeded(memory: try await memory(for: sessionID))"))
+    #expect(searchBody.contains("awaitQueryEmbedderIfNeeded(memory: memory)"))
     #expect(source.contains("isQueryEmbedderWaitRequest(request)"))
 }
 

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -460,6 +460,7 @@ func toolsListContainsExpectedTools() {
 func agentInstructionsDescribeSessionLifecycle() {
     let text = MCPAgentInstructions.text(version: "9.9.9")
     #expect(text.contains("server v9.9.9"))
+    #expect(text.contains("session_open"))
     #expect(text.contains("handoff_latest"))
     #expect(text.contains("session_start"))
     #expect(text.contains("session_end"))
@@ -467,6 +468,8 @@ func agentInstructionsDescribeSessionLifecycle() {
     #expect(text.contains("remaining_active"))
     #expect(text.contains("active_session_count"))
     #expect(text.contains("Do not manage SESSION_STORE"))
+    #expect(!text.contains("or call handoff_latest first"))
+    #expect(text.contains("Call session_open"))
 }
 
 @Test
@@ -474,10 +477,16 @@ func coreToolDescriptionsIncludeOperatorHints() {
     let tools = Dictionary(
         uniqueKeysWithValues: ToolSchemas.allTools.map { ($0.name, $0.description ?? "") }
     )
-    #expect(tools["handoff_latest"]?.contains("session start") == true)
-    #expect(tools["session_start"]?.contains("handoff_latest") == true)
+    #expect(tools["handoff_latest"]?.contains("Call first at session start") != true)
+    #expect(tools["handoff_latest"]?.localizedCaseInsensitiveContains("latest handoff") == true)
+    #expect(tools["session_start"]?.contains("Prefer `session_open`") == true
+            || tools["session_start"]?.contains("Prefer session_open") == true)
+    #expect(tools["session_open"]?.localizedCaseInsensitiveContains("one-shot") == true
+            || tools["session_open"]?.localizedCaseInsensitiveContains("one call") == true)
+    #expect(tools["session_open"]?.contains("handoff_latest then") != true)
     #expect(tools["remember"]?.contains("session_id") == true)
     #expect(tools["recall"]?.contains("Preferred read path") == true)
+    #expect(tools["recall"]?.contains("session_open") == true)
     #expect(tools["handoff"]?.contains("end-of-session") == true)
 }
 
@@ -866,6 +875,7 @@ func brokerBackedF152RecallAndSearchSupportFilters() async throws {
                 "query": .string(queryToken),
                 "mode": .string("text"),
                 "limit": .int(10),
+                "scope": .string("global"),
                 "filters": filters,
             ]
         ))
@@ -1818,7 +1828,7 @@ func toolsRememberRecallSearchFlushStatsHappyPath() async throws {
         #expect(rememberResult.isError != true)
 
         let recallResult = await WaxMCPTools.handleCall(
-            params: .init(name: "recall", arguments: ["query": "actors", "limit": 3]),
+            params: .init(name: "recall", arguments: ["query": "actors", "limit": 3, "scope": "global"]),
             broker: service
         )
         #expect(recallResult.isError != true)
@@ -2330,7 +2340,7 @@ func rememberDefaultAutoCommitMakesDataImmediatelyRecallable() async throws {
         #expect((statsJSON["pendingFrames"] as? Int ?? -1) == 0)
 
         let recallResult = await WaxMCPTools.handleCall(
-            params: .init(name: "recall", arguments: ["query": .string(queryToken), "limit": .int(5)]),
+            params: .init(name: "recall", arguments: ["query": .string(queryToken), "limit": .int(5), "scope": .string("global")]),
             broker: service
         )
         #expect(recallResult.isError != true)
@@ -2439,7 +2449,7 @@ func recallAndSearchSupportMetadataExactFilters() async throws {
         #expect(!firstText(in: filteredSearch).contains(blockedNeedle))
 
         let baselineRecall = await WaxMCPTools.handleCall(
-            params: .init(name: "recall", arguments: ["query": .string(queryToken), "limit": .int(10)]),
+            params: .init(name: "recall", arguments: ["query": .string(queryToken), "limit": .int(10), "scope": .string("global")]),
             broker: service
         )
         #expect(baselineRecall.isError != true)
@@ -2451,6 +2461,7 @@ func recallAndSearchSupportMetadataExactFilters() async throws {
                 arguments: [
                     "query": .string(queryToken),
                     "limit": .int(10),
+                    "scope": .string("global"),
                     "filters": .object([
                         "metadata": .object([
                             "exact": .object(["group": .string("allowed")]),
@@ -3178,6 +3189,9 @@ func vectorFallbackIsSurfacedInSearchAndStats() async throws {
         #expect((payload["requested_mode"] as? String) == "hybrid(alpha=0.500)")
         #expect((payload["effective_mode"] as? String) == "text")
         #expect((payload["query_embedding_state"] as? String) == "timeout")
+        let warning = try #require(payload["warning"] as? String)
+        #expect(warning.contains("hybrid requested"))
+        #expect(warning.contains("used text"))
         let results = try requireArray(payload, key: "results")
         #expect(!results.isEmpty)
         let firstResult = try requireObject(results[0])
@@ -3224,7 +3238,7 @@ func recallJSONResourceIncludesStructuredResults() async throws {
         let recall = await WaxMCPTools.handleCall(
             params: .init(
                 name: "recall",
-                arguments: ["query": "payload marker", "limit": 3]
+                arguments: ["query": "payload marker", "limit": 3, "scope": "global"]
             ),
             broker: service
         )
@@ -3502,6 +3516,7 @@ func vectorSearchRememberFlushRecallHappyPath() async throws {
         let recall = await WaxMCPTools.handleCall(
             params: .init(name: "recall", arguments: [
                 "query": .string("actors"),
+                "scope": .string("global"),
             ]),
             broker: service
         )
@@ -3635,6 +3650,7 @@ func rememberSearchAndRecallExposeTypedExplainableMemory() async throws {
             params: .init(name: "recall", arguments: [
                 "query": .string("release notes preference"),
                 "limit": .int(3),
+                "scope": .string("global"),
             ]),
             broker: service
         )
@@ -7171,6 +7187,7 @@ struct WaxMCPProcessTests {
             arguments: [
                 "query": "SESSION_ONLY_XYZ",
                 "session_id": sessionID,
+                "scope": "global",
                 "limit": 10,
             ],
             timeout: 20
@@ -8161,7 +8178,7 @@ struct WaxMCPProcessTests {
         let recallResp = try await harness.callTool(
             id: 3,
             name: "recall",
-            arguments: ["query": "Swift concurrency", "limit": 3],
+            arguments: ["query": "Swift concurrency", "limit": 3, "scope": "global"],
             timeout: 30
         )
         #expect(recallResp.contains("result"))


### PR DESCRIPTION
Four agent-DX behaviors, one PR. No new tools, no UUID auto-bind, no ranking rewrite.

Replacement for #179, which was closed after `main` was force-pushed and the head branch deleted. Rebased onto current `main`.

## Why

Live Grok/Pi sessions scored Wax MCP 72/100. Retrieval already paid for itself; friction was the playbook fork, silent first hybrid recall, process-cwd repo stamps, and unembedded frames while MCP holds the store lock.

## What changed

1. **One playbook.** Daily path is `session_open` → `remember` / `recall` → `session_close`. `handoff_latest` and `session_start` stay callable. Public skill bytes equal the npm ship copy.
2. **First recall waits.** `recall` / `search` wait for MiniLM the way `remember` already does (30s), outside `commandMutex`. `session_open` waits only when `recall_query` is set. Hybrid that still falls to text puts a compact JSON `warning`. `vectorOnly` still throws. MCP-spawned daemons no longer pass `--skip-prewarm`.
3. **Repo stamp.** MCP no longer injects the server process cwd. Explicit `repo` wins; else if `project` is set, `wax.repo = project`; else infer from client cwd; never from the broker process folder.
4. **Backfill on the open store.** After embedder prewarm succeeds, `backfillUnembedded()` runs in the background on the broker store. `--no-embedder` skips it.

## Review fixes (on this head)

- Do not wait for MiniLM a second time inside `recall`/`search` (that doubled a 30s timeout onto `commandMutex`).
- Session-store attach wait runs only after MiniLM is already ready.
- Downgrade warning maps `QueryEmbeddingState` (`failed` / `vector_disabled` are not “embedder missing”).
- Removed the no-op process-cwd injector.

## Tests

```bash
swift test --filter projectRulesPlaybook
swift test --traits MCPServer --filter WaxMCPAgentDXPR1Tests
swift test --traits MCPServer --filter WaxMCP0128BrokerFixTests
swift test --traits MCPServer --filter vectorFallbackIsSurfacedInSearchAndStats
```

## Out of scope

Host copies under `~/.grok/` were updated locally and are not in this PR. `Claude.md` remains gitignored.