### PR TITLE
refactor(broker): type MemoryID for horizon-scoped frame refs

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -77,7 +77,7 @@ extension AgentBrokerService {
             managed: document.metadata[MemoryMetadataKeys.sourceManaged] != "false",
             sourceKind: kind.rawValue,
             frameID: document.frameId,
-            memoryID: Self.makeMemoryReference(.durable, frameID: document.frameId),
+            memoryID: Self.makeMemoryReference(frameID: document.frameId),
             hash: Self.stableHash(document.text),
             sessionID: document.metadata[MemoryMetadataKeys.promotedFromSession] ?? document.metadata["session_id"],
             sourceFrameID: document.metadata[MemoryMetadataKeys.promotedFromFrame].flatMap(UInt64.init),
@@ -421,7 +421,7 @@ extension AgentBrokerService {
         guard marker.hash == previousHash else { return false }
 
         if let markerMemoryID = marker.memoryID {
-            let canonicalMemoryID = Self.makeMemoryReference(.durable, frameID: document.frameId)
+            let canonicalMemoryID = Self.makeMemoryReference(frameID: document.frameId)
             let storedMemoryID = document.metadata[MemoryMetadataKeys.sourceMemoryID]
             guard markerMemoryID == canonicalMemoryID || markerMemoryID == storedMemoryID else { return false }
         }

--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -77,7 +77,7 @@ extension AgentBrokerService {
             managed: document.metadata[MemoryMetadataKeys.sourceManaged] != "false",
             sourceKind: kind.rawValue,
             frameID: document.frameId,
-            memoryID: Self.makeMemoryReference(.durable, sessionID: nil, frameID: document.frameId),
+            memoryID: Self.makeMemoryReference(.durable, frameID: document.frameId),
             hash: Self.stableHash(document.text),
             sessionID: document.metadata[MemoryMetadataKeys.promotedFromSession] ?? document.metadata["session_id"],
             sourceFrameID: document.metadata[MemoryMetadataKeys.promotedFromFrame].flatMap(UInt64.init),
@@ -421,7 +421,7 @@ extension AgentBrokerService {
         guard marker.hash == previousHash else { return false }
 
         if let markerMemoryID = marker.memoryID {
-            let canonicalMemoryID = Self.makeMemoryReference(.durable, sessionID: nil, frameID: document.frameId)
+            let canonicalMemoryID = Self.makeMemoryReference(.durable, frameID: document.frameId)
             let storedMemoryID = document.metadata[MemoryMetadataKeys.sourceMemoryID]
             guard markerMemoryID == canonicalMemoryID || markerMemoryID == storedMemoryID else { return false }
         }

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -3054,13 +3054,13 @@ extension AgentBrokerService {
         try MemoryID.parse(raw)
     }
 
-    static func itemKindLabel(_ kind: RAGContext.ItemKind?) -> String {
+    static func itemKindLabel(_ kind: RAGContext.ItemKind) -> String {
         switch kind {
         case .expanded:
             return "expanded"
         case .surrogate:
             return "surrogate"
-        case .snippet, .none:
+        case .snippet:
             return "snippet"
         }
     }
@@ -3159,8 +3159,8 @@ extension AgentBrokerService {
         return trimmed
     }
 
-    static func makeMemoryReference(_ horizon: MemoryHorizon, frameID: UInt64) -> String {
-        LayeredRecall.makeMemoryReference(horizon, frameID: frameID)
+    static func makeMemoryReference(frameID: UInt64) -> String {
+        LayeredRecall.makeMemoryReference(frameID: frameID)
     }
 
     static func makeMemoryReference(_ horizon: MemoryHorizon, sessionID: UUID, frameID: UInt64) -> String {

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -339,7 +339,7 @@ extension AgentBrokerService {
 
     typealias MemoryHorizon = LayeredRecall.Horizon
     typealias LayeredMemoryHit = LayeredRecall.Hit
-    typealias MemoryReference = LayeredRecall.MemoryReference
+    typealias MemoryReference = MemoryID
 
     struct MarkdownProjectionReport {
         var memoryMarkdownPath: String
@@ -510,17 +510,17 @@ extension AgentBrokerService {
         }
         lines.append("Applied filters: \(parsedFilters.summary.debugJSONString)")
         for (index, hit) in result.hits.enumerated() {
-            let kind = hit.kind ?? "snippet"
+            let kind = Self.itemKindLabel(hit.kind)
             lines.append("\(index + 1). [\(kind)] frame=\(hit.frameID) score=\(String(format: "%.4f", hit.score)) \(hit.text)")
         }
 
         let results: [AgentBrokerValue] = result.hits.enumerated().map { index, hit in
             .object([
                 "rank": .from(index + 1),
-                "kind": .string(hit.kind ?? "snippet"),
+                "kind": .string(Self.itemKindLabel(hit.kind)),
                 "frameId": .from(hit.frameID),
                 "score": .double(Double(hit.score)),
-                "sources": .array(hit.sources.map(AgentBrokerValue.string)),
+                "sources": .array(hit.sources.map { .string($0.rawValue) }),
                 "text": .string(hit.text),
                 "metadata": .object(hit.metadata.mapValues(AgentBrokerValue.string)),
                 "explanations": .array(hit.explanations.map(AgentBrokerValue.string)),
@@ -2440,24 +2440,17 @@ extension AgentBrokerService {
                         ) ?? item.frameId
                         hits.append(
                             LayeredRecall.Hit(
-                                reference: LayeredRecall.makeMemoryReference(
-                                    .episodic,
-                                    sessionID: manifest.sessionID,
-                                    frameID: canonicalFrameID
-                                ),
-                                horizon: .episodic,
-                                sessionID: manifest.sessionID,
+                                id: .episodic(sessionID: manifest.sessionID, frameID: canonicalFrameID),
                                 agentID: manifest.agentID,
                                 runID: manifest.runID,
-                                frameID: canonicalFrameID,
                                 score: item.score,
                                 text: item.text,
                                 preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
                                 metadata: item.metadata,
                                 explanations: ["recent session episode"] + item.explanations,
                                 timestampMs: manifest.updatedAtMs,
-                                kind: "\(item.kind)",
-                                sources: item.sources.map(\.rawValue)
+                                kind: item.kind,
+                                sources: item.sources
                             )
                         )
                     }
@@ -2469,17 +2462,12 @@ extension AgentBrokerService {
     }
 
     func layeredMemoryGet(reference: MemoryReference) async throws -> LayeredMemoryHit {
-        switch reference.horizon {
-        case .durable:
-            let document = try await requireDocument(frameID: reference.frameID, memory: longTermMemory)
+        switch reference {
+        case .durable(let frameID):
+            let document = try await requireDocument(frameID: frameID, memory: longTermMemory)
             await longTermMemory.recordAccess(frameId: document.frameId)
             return LayeredMemoryHit(
-                reference: Self.makeMemoryReference(.durable, sessionID: nil, frameID: reference.frameID),
-                horizon: .durable,
-                sessionID: nil,
-                agentID: nil,
-                runID: nil,
-                frameID: document.frameId,
+                id: .durable(frameID: frameID),
                 score: 0,
                 text: document.text,
                 preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
@@ -2487,21 +2475,15 @@ extension AgentBrokerService {
                 explanations: ["durable memory"],
                 timestampMs: document.timestampMs
             )
-        case .working, .episodic:
-            guard let sessionID = reference.sessionID else {
-                throw BrokerValidationError.invalid("session-backed memory references require a session_id")
-            }
+        case .working(let sessionID, let frameID), .episodic(let sessionID, let frameID):
             let manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)
             let loader: (MemoryOrchestrator) async throws -> LayeredMemoryHit = { memory in
-                let document = try await self.requireDocument(frameID: reference.frameID, memory: memory)
+                let document = try await self.requireDocument(frameID: frameID, memory: memory)
                 await memory.recordAccess(frameId: document.frameId)
                 return LayeredMemoryHit(
-                    reference: Self.makeMemoryReference(reference.horizon, sessionID: sessionID, frameID: reference.frameID),
-                    horizon: reference.horizon,
-                    sessionID: sessionID,
+                    id: MemoryID.make(horizon: reference.horizon, sessionID: sessionID, frameID: frameID),
                     agentID: manifest.agentID,
                     runID: manifest.runID,
-                    frameID: document.frameId,
                     score: 0,
                     text: document.text,
                     preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
@@ -3069,26 +3051,17 @@ extension AgentBrokerService {
     }
 
     func parseMemoryReference(_ raw: String) throws -> MemoryReference {
-        let parts = raw.split(separator: ":").map(String.init)
-        guard parts.count >= 2 else {
-            throw BrokerValidationError.invalid("memory_id must be in the form '<horizon>:<frame>' or '<horizon>:<session_id>:<frame>'")
-        }
-        guard let horizon = MemoryHorizon(rawValue: parts[0]) else {
-            throw BrokerValidationError.invalid("memory_id horizon must be one of: working, episodic, durable")
-        }
-        switch horizon {
-        case .durable:
-            guard parts.count == 2, let frameID = UInt64(parts[1]) else {
-                throw BrokerValidationError.invalid("durable memory_id must be 'durable:<frame_id>'")
-            }
-            return MemoryReference(horizon: .durable, sessionID: nil, frameID: frameID)
-        case .working, .episodic:
-            guard parts.count == 3,
-                  let sessionID = UUID(uuidString: parts[1]),
-                  let frameID = UInt64(parts[2]) else {
-                throw BrokerValidationError.invalid("session memory_id must be '\(horizon.rawValue):<session_id>:<frame_id>'")
-            }
-            return MemoryReference(horizon: horizon, sessionID: sessionID, frameID: frameID)
+        try MemoryID.parse(raw)
+    }
+
+    static func itemKindLabel(_ kind: RAGContext.ItemKind?) -> String {
+        switch kind {
+        case .expanded:
+            return "expanded"
+        case .surrogate:
+            return "surrogate"
+        case .snippet, .none:
+            return "snippet"
         }
     }
 
@@ -3186,7 +3159,11 @@ extension AgentBrokerService {
         return trimmed
     }
 
-    static func makeMemoryReference(_ horizon: MemoryHorizon, sessionID: UUID?, frameID: UInt64) -> String {
+    static func makeMemoryReference(_ horizon: MemoryHorizon, frameID: UInt64) -> String {
+        LayeredRecall.makeMemoryReference(horizon, frameID: frameID)
+    }
+
+    static func makeMemoryReference(_ horizon: MemoryHorizon, sessionID: UUID, frameID: UInt64) -> String {
         LayeredRecall.makeMemoryReference(horizon, sessionID: sessionID, frameID: frameID)
     }
 

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -38,7 +38,7 @@ package enum LayeredRecall {
         package var metadata: [String: String]
         package var explanations: [String]
         package var timestampMs: Int64
-        package var kind: RAGContext.ItemKind?
+        package var kind: RAGContext.ItemKind
         package var sources: [RAGContext.Source]
 
         package var reference: String { id.wire }
@@ -56,7 +56,7 @@ package enum LayeredRecall {
             metadata: [String: String],
             explanations: [String],
             timestampMs: Int64,
-            kind: RAGContext.ItemKind? = nil,
+            kind: RAGContext.ItemKind = .snippet,
             sources: [RAGContext.Source] = []
         ) {
             self.id = id
@@ -280,7 +280,7 @@ package enum LayeredRecall {
         id.wire
     }
 
-    package static func makeMemoryReference(_ horizon: Horizon, frameID: UInt64) -> String {
+    package static func makeMemoryReference(frameID: UInt64) -> String {
         MemoryID.durable(frameID: frameID).wire
     }
 
@@ -496,7 +496,7 @@ package enum LayeredRecall {
         hit(from: item, id: MemoryID.make(horizon: horizon, sessionID: sessionID, frameID: item.frameId))
     }
 
-    package static func hit(from item: RAGContext.Item, horizon: Horizon) -> Hit {
+    package static func hit(from item: RAGContext.Item) -> Hit {
         hit(from: item, id: .durable(frameID: item.frameId))
     }
 
@@ -523,10 +523,10 @@ package enum LayeredRecall {
         let sessionHits = sessionItems.map {
             hit(from: $0, horizon: .working, sessionID: UUID())
         }
-        let durableHits = durableItems.map { hit(from: $0, horizon: .durable) }
+        let durableHits = durableItems.map { hit(from: $0) }
         return mergeHits(sessionHits: sessionHits, durableHits: durableHits, limit: limit).map { hit in
             RAGContext.Item(
-                kind: hit.kind ?? .snippet,
+                kind: hit.kind,
                 frameId: hit.frameID,
                 score: hit.score,
                 sources: hit.sources.isEmpty ? [.unknown] : hit.sources,
@@ -542,7 +542,7 @@ package enum LayeredRecall {
         project: String?,
         repo: String?
     ) -> [RAGContext.Item] {
-        let hits = items.map { hit(from: $0, horizon: .durable) }
+        let hits = items.map { hit(from: $0) }
         let filtered = filterHitsByProject(hits, project: project, repo: repo)
         let allowed = Set(filtered.map(\.frameID))
         return items.filter { allowed.contains($0.frameId) }
@@ -633,7 +633,7 @@ package enum LayeredRecall {
             )
             durableExecution = execution
             durableHits = execution.context.items.map {
-                hit(from: $0, horizon: .durable)
+                hit(from: $0)
             }
             let nowMs = stores.nowMs()
             durableHits = durableHits.filter { hit in

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -29,44 +29,39 @@ package enum LayeredRecall {
     }
 
     package struct Hit: Sendable, Equatable {
-        package var reference: String
-        package var horizon: Horizon
-        package var sessionID: UUID?
+        package var id: MemoryID
         package var agentID: String?
         package var runID: String?
-        package var frameID: UInt64
         package var score: Float
         package var text: String
         package var preview: String
         package var metadata: [String: String]
         package var explanations: [String]
         package var timestampMs: Int64
-        /// Present for recall-shaped hits (maps from `RAGContext.Item.kind`).
-        package var kind: String?
-        package var sources: [String]
+        package var kind: RAGContext.ItemKind?
+        package var sources: [RAGContext.Source]
+
+        package var reference: String { id.wire }
+        package var horizon: Horizon { id.horizon }
+        package var sessionID: UUID? { id.sessionID }
+        package var frameID: UInt64 { id.frameID }
 
         package init(
-            reference: String,
-            horizon: Horizon,
-            sessionID: UUID? = nil,
+            id: MemoryID,
             agentID: String? = nil,
             runID: String? = nil,
-            frameID: UInt64,
             score: Float,
             text: String,
             preview: String,
             metadata: [String: String],
             explanations: [String],
             timestampMs: Int64,
-            kind: String? = nil,
-            sources: [String] = []
+            kind: RAGContext.ItemKind? = nil,
+            sources: [RAGContext.Source] = []
         ) {
-            self.reference = reference
-            self.horizon = horizon
-            self.sessionID = sessionID
+            self.id = id
             self.agentID = agentID
             self.runID = runID
-            self.frameID = frameID
             self.score = score
             self.text = text
             self.preview = preview
@@ -78,17 +73,7 @@ package enum LayeredRecall {
         }
     }
 
-    package struct MemoryReference: Sendable, Equatable {
-        package var horizon: Horizon
-        package var sessionID: UUID?
-        package var frameID: UInt64
-
-        package init(horizon: Horizon, sessionID: UUID?, frameID: UInt64) {
-            self.horizon = horizon
-            self.sessionID = sessionID
-            self.frameID = frameID
-        }
-    }
+    package typealias MemoryReference = MemoryID
 
     package struct WorkingLane: Sendable {
         package var sessionID: UUID
@@ -291,17 +276,16 @@ package enum LayeredRecall {
         package var durableExecution: MemoryOrchestrator.RecallExecution?
     }
 
-    package static func makeMemoryReference(
-        _ horizon: Horizon,
-        sessionID: UUID?,
-        frameID: UInt64
-    ) -> String {
-        switch horizon {
-        case .durable:
-            return "durable:\(frameID)"
-        case .working, .episodic:
-            return "\(horizon.rawValue):\(sessionID?.uuidString ?? "unknown"):\(frameID)"
-        }
+    package static func makeMemoryReference(_ id: MemoryID) -> String {
+        id.wire
+    }
+
+    package static func makeMemoryReference(_ horizon: Horizon, frameID: UInt64) -> String {
+        MemoryID.durable(frameID: frameID).wire
+    }
+
+    package static func makeMemoryReference(_ horizon: Horizon, sessionID: UUID, frameID: UInt64) -> String {
+        MemoryID.make(horizon: horizon, sessionID: sessionID, frameID: frameID).wire
     }
 
     package static func normalize(_ value: String?) -> String? {
@@ -508,52 +492,26 @@ package enum LayeredRecall {
         return (filtered, false, nil)
     }
 
-    package static func hit(from item: RAGContext.Item, horizon: Horizon, sessionID: UUID?) -> Hit {
+    package static func hit(from item: RAGContext.Item, horizon: Horizon, sessionID: UUID) -> Hit {
+        hit(from: item, id: MemoryID.make(horizon: horizon, sessionID: sessionID, frameID: item.frameId))
+    }
+
+    package static func hit(from item: RAGContext.Item, horizon: Horizon) -> Hit {
+        hit(from: item, id: .durable(frameID: item.frameId))
+    }
+
+    package static func hit(from item: RAGContext.Item, id: MemoryID) -> Hit {
         Hit(
-            reference: makeMemoryReference(horizon, sessionID: sessionID, frameID: item.frameId),
-            horizon: horizon,
-            sessionID: sessionID,
-            frameID: item.frameId,
+            id: id,
             score: item.score,
             text: item.text,
             preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
             metadata: item.metadata,
             explanations: item.explanations,
             timestampMs: item.metadata[MemoryMetadataKeys.createdAtMs].flatMap(Int64.init) ?? 0,
-            kind: "\(item.kind)",
-            sources: item.sources.map(\.rawValue)
+            kind: item.kind,
+            sources: item.sources
         )
-    }
-
-    private static func itemKind(from raw: String?) -> RAGContext.ItemKind {
-        switch raw {
-        case "expanded":
-            return .expanded
-        case "surrogate":
-            return .surrogate
-        default:
-            return .snippet
-        }
-    }
-
-    private static func ragSources(from raw: [String]) -> [RAGContext.Source] {
-        let mapped: [RAGContext.Source] = raw.compactMap { value in
-            switch value {
-            case "text":
-                return .text
-            case "vector":
-                return .vector
-            case "timeline":
-                return .timeline
-            case "structured":
-                return .structured
-            case "unknown":
-                return .unknown
-            default:
-                return nil
-            }
-        }
-        return mapped.isEmpty ? [.unknown] : mapped
     }
 
     /// Bridge for callers that still speak `RAGContext.Item` (tests / gradual migrate).
@@ -562,14 +520,16 @@ package enum LayeredRecall {
         durableItems: [RAGContext.Item],
         limit: Int
     ) -> [RAGContext.Item] {
-        let sessionHits = sessionItems.map { hit(from: $0, horizon: .working, sessionID: nil) }
-        let durableHits = durableItems.map { hit(from: $0, horizon: .durable, sessionID: nil) }
+        let sessionHits = sessionItems.map {
+            hit(from: $0, horizon: .working, sessionID: UUID())
+        }
+        let durableHits = durableItems.map { hit(from: $0, horizon: .durable) }
         return mergeHits(sessionHits: sessionHits, durableHits: durableHits, limit: limit).map { hit in
             RAGContext.Item(
-                kind: itemKind(from: hit.kind),
+                kind: hit.kind ?? .snippet,
                 frameId: hit.frameID,
                 score: hit.score,
-                sources: ragSources(from: hit.sources),
+                sources: hit.sources.isEmpty ? [.unknown] : hit.sources,
                 text: hit.text,
                 metadata: hit.metadata,
                 explanations: hit.explanations
@@ -582,7 +542,7 @@ package enum LayeredRecall {
         project: String?,
         repo: String?
     ) -> [RAGContext.Item] {
-        let hits = items.map { hit(from: $0, horizon: .durable, sessionID: nil) }
+        let hits = items.map { hit(from: $0, horizon: .durable) }
         let filtered = filterHitsByProject(hits, project: project, repo: repo)
         let allowed = Set(filtered.map(\.frameID))
         return items.filter { allowed.contains($0.frameId) }
@@ -634,24 +594,17 @@ package enum LayeredRecall {
                     }
                 sessionHits = documents.prefix(topK).map { document in
                     Hit(
-                        reference: makeMemoryReference(
-                            .working,
-                            sessionID: working.sessionID,
-                            frameID: document.frameId
-                        ),
-                        horizon: .working,
-                        sessionID: working.sessionID,
+                        id: .working(sessionID: working.sessionID, frameID: document.frameId),
                         agentID: working.agentID,
                         runID: working.runID,
-                        frameID: document.frameId,
                         score: 0.2,
                         text: document.text,
                         preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
                         metadata: document.metadata,
                         explanations: ["current session", "recent session note"],
                         timestampMs: document.timestampMs,
-                        kind: "snippet",
-                        sources: [RAGContext.Source.text.rawValue]
+                        kind: .snippet,
+                        sources: [.text]
                     )
                 }
             } else {
@@ -680,7 +633,7 @@ package enum LayeredRecall {
             )
             durableExecution = execution
             durableHits = execution.context.items.map {
-                hit(from: $0, horizon: .durable, sessionID: nil)
+                hit(from: $0, horizon: .durable)
             }
             let nowMs = stores.nowMs()
             durableHits = durableHits.filter { hit in
@@ -805,23 +758,16 @@ package enum LayeredRecall {
                 }
                 hits.append(
                     Hit(
-                        reference: makeMemoryReference(
-                            .working,
-                            sessionID: sessionID,
-                            frameID: canonicalFrameID
-                        ),
-                        horizon: .working,
-                        sessionID: sessionID,
+                        id: .working(sessionID: sessionID, frameID: canonicalFrameID),
                         agentID: lane.agentID,
                         runID: lane.runID,
-                        frameID: canonicalFrameID,
                         score: result.score + 0.25,
                         text: stores.preview(result.previewText),
                         preview: stores.preview(result.previewText),
                         metadata: result.metadata,
                         explanations: ["current session"] + result.explanations,
                         timestampMs: lane.updatedAtMs,
-                        sources: result.sources.map(\.rawValue)
+                        sources: result.sources
                     )
                 )
             }
@@ -851,17 +797,14 @@ package enum LayeredRecall {
                 }
                 hits.append(
                     Hit(
-                        reference: makeMemoryReference(.durable, sessionID: nil, frameID: canonicalFrameID),
-                        horizon: .durable,
-                        sessionID: nil,
-                        frameID: canonicalFrameID,
+                        id: .durable(frameID: canonicalFrameID),
                         score: result.score + 0.10,
                         text: stores.preview(result.previewText),
                         preview: stores.preview(result.previewText),
                         metadata: result.metadata,
                         explanations: ["durable memory"] + result.explanations,
                         timestampMs: result.metadata[MemoryMetadataKeys.createdAtMs].flatMap(Int64.init) ?? 0,
-                        sources: result.sources.map(\.rawValue)
+                        sources: result.sources
                     )
                 )
             }
@@ -896,16 +839,9 @@ package enum LayeredRecall {
                     explanations.append(contentsOf: laneHit.explanations)
                     hits.append(
                         Hit(
-                            reference: makeMemoryReference(
-                                .episodic,
-                                sessionID: manifest.sessionID,
-                                frameID: canonicalFrameID
-                            ),
-                            horizon: .episodic,
-                            sessionID: manifest.sessionID,
+                            id: .episodic(sessionID: manifest.sessionID, frameID: canonicalFrameID),
                             agentID: manifest.agentID,
                             runID: manifest.runID,
-                            frameID: canonicalFrameID,
                             score: laneHit.score + recencyBoost,
                             text: stores.preview(laneHit.previewText),
                             preview: stores.preview(laneHit.previewText),
@@ -948,12 +884,7 @@ package enum LayeredRecall {
         for hit in hits {
             var copy = hit
             if let canonical = await stores.canonicalFrameID(hit.frameID, memory) {
-                copy.frameID = canonical
-                copy.reference = makeMemoryReference(
-                    hit.horizon,
-                    sessionID: hit.sessionID,
-                    frameID: canonical
-                )
+                copy.id = copy.id.replacingFrameID(canonical)
             }
             canonicalized.append(copy)
         }

--- a/Sources/Wax/Broker/MemoryID.swift
+++ b/Sources/Wax/Broker/MemoryID.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Closed identity of a recall/get hit: durable frame, or working/episodic frame in a session.
+package enum MemoryID: Hashable, Sendable {
+    case durable(frameID: UInt64)
+    case working(sessionID: UUID, frameID: UInt64)
+    case episodic(sessionID: UUID, frameID: UInt64)
+
+    package var horizon: LayeredRecall.Horizon {
+        switch self {
+        case .durable:
+            return .durable
+        case .working:
+            return .working
+        case .episodic:
+            return .episodic
+        }
+    }
+
+    package var sessionID: UUID? {
+        switch self {
+        case .durable:
+            return nil
+        case .working(let sessionID, _), .episodic(let sessionID, _):
+            return sessionID
+        }
+    }
+
+    package var frameID: UInt64 {
+        switch self {
+        case .durable(let frameID), .working(_, let frameID), .episodic(_, let frameID):
+            return frameID
+        }
+    }
+
+    package var wire: String {
+        switch self {
+        case .durable(let frameID):
+            return "durable:\(frameID)"
+        case .working(let sessionID, let frameID):
+            return "working:\(sessionID.uuidString):\(frameID)"
+        case .episodic(let sessionID, let frameID):
+            return "episodic:\(sessionID.uuidString):\(frameID)"
+        }
+    }
+
+    package func replacingFrameID(_ frameID: UInt64) -> MemoryID {
+        switch self {
+        case .durable:
+            return .durable(frameID: frameID)
+        case .working(let sessionID, _):
+            return .working(sessionID: sessionID, frameID: frameID)
+        case .episodic(let sessionID, _):
+            return .episodic(sessionID: sessionID, frameID: frameID)
+        }
+    }
+
+    package static func make(
+        horizon: LayeredRecall.Horizon,
+        sessionID: UUID,
+        frameID: UInt64
+    ) -> MemoryID {
+        switch horizon {
+        case .durable:
+            return .durable(frameID: frameID)
+        case .working:
+            return .working(sessionID: sessionID, frameID: frameID)
+        case .episodic:
+            return .episodic(sessionID: sessionID, frameID: frameID)
+        }
+    }
+
+    package static func parse(_ raw: String) throws -> MemoryID {
+        let parts = raw.split(separator: ":").map(String.init)
+        guard parts.count >= 2 else {
+            throw BrokerValidationError.invalid(
+                "memory_id must be in the form '<horizon>:<frame>' or '<horizon>:<session_id>:<frame>'"
+            )
+        }
+        guard let horizon = LayeredRecall.Horizon(rawValue: parts[0]) else {
+            throw BrokerValidationError.invalid("memory_id horizon must be one of: working, episodic, durable")
+        }
+        switch horizon {
+        case .durable:
+            guard parts.count == 2, let frameID = UInt64(parts[1]) else {
+                throw BrokerValidationError.invalid("durable memory_id must be 'durable:<frame_id>'")
+            }
+            return .durable(frameID: frameID)
+        case .working, .episodic:
+            guard parts.count == 3,
+                  let sessionID = UUID(uuidString: parts[1]),
+                  let frameID = UInt64(parts[2])
+            else {
+                throw BrokerValidationError.invalid(
+                    "session memory_id must be '\(horizon.rawValue):<session_id>:<frame_id>'"
+                )
+            }
+            return make(horizon: horizon, sessionID: sessionID, frameID: frameID)
+        }
+    }
+}

--- a/Tests/WaxTests/CompactAssemblyTests.swift
+++ b/Tests/WaxTests/CompactAssemblyTests.swift
@@ -72,7 +72,7 @@ func compactAssemblyPackEmptyLanesYieldDefaultSummary() async {
 func compactAssemblyPackDedupesByReference() async {
     let first = compactHit(frameID: 1, text: "one", horizon: .durable, score: 0.9)
     var duplicate = compactHit(frameID: 1, text: "one-dup", horizon: .durable, score: 0.2)
-    duplicate.reference = first.reference
+    duplicate.id = first.id
 
     let packed = await CompactAssembly.pack(
         query: "q",
@@ -160,10 +160,17 @@ private func compactHit(
     horizon: LayeredRecall.Horizon,
     score: Float = 1
 ) -> LayeredRecall.Hit {
-    LayeredRecall.Hit(
-        reference: LayeredRecall.makeMemoryReference(horizon, sessionID: nil, frameID: frameID),
-        horizon: horizon,
-        frameID: frameID,
+    let id: MemoryID
+    switch horizon {
+    case .durable:
+        id = .durable(frameID: frameID)
+    case .working:
+        id = .working(sessionID: UUID(), frameID: frameID)
+    case .episodic:
+        id = .episodic(sessionID: UUID(), frameID: frameID)
+    }
+    return LayeredRecall.Hit(
+        id: id,
         score: score,
         text: text,
         preview: text,

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -116,7 +116,7 @@ func layeredRecallFrameFilterInjectsProjectMetadataForScopedRetrieval() {
 @Test
 func layeredRecallMakeMemoryReferenceFormatsHorizons() {
     let sessionID = UUID()
-    #expect(LayeredRecall.makeMemoryReference(.durable, frameID: 42) == "durable:42")
+    #expect(LayeredRecall.makeMemoryReference(frameID: 42) == "durable:42")
     #expect(
         LayeredRecall.makeMemoryReference(.working, sessionID: sessionID, frameID: 7)
             == "working:\(sessionID.uuidString):7"
@@ -132,7 +132,7 @@ func layeredRecallHitMapsRAGItemKindAndSourcesWithoutStringRoundTrip() {
         sources: [.text],
         text: "hello"
     )
-    let durable = LayeredRecall.hit(from: item, horizon: .durable)
+    let durable = LayeredRecall.hit(from: item)
     #expect(durable.kind == .snippet)
     #expect(durable.sources == [.text])
     let working = LayeredRecall.hit(from: item, horizon: .working, sessionID: UUID())

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -116,11 +116,28 @@ func layeredRecallFrameFilterInjectsProjectMetadataForScopedRetrieval() {
 @Test
 func layeredRecallMakeMemoryReferenceFormatsHorizons() {
     let sessionID = UUID()
-    #expect(LayeredRecall.makeMemoryReference(.durable, sessionID: nil, frameID: 42) == "durable:42")
+    #expect(LayeredRecall.makeMemoryReference(.durable, frameID: 42) == "durable:42")
     #expect(
         LayeredRecall.makeMemoryReference(.working, sessionID: sessionID, frameID: 7)
             == "working:\(sessionID.uuidString):7"
     )
+}
+
+@Test
+func layeredRecallHitMapsRAGItemKindAndSourcesWithoutStringRoundTrip() {
+    let item = RAGContext.Item(
+        kind: .snippet,
+        frameId: 11,
+        score: 1,
+        sources: [.text],
+        text: "hello"
+    )
+    let durable = LayeredRecall.hit(from: item, horizon: .durable)
+    #expect(durable.kind == .snippet)
+    #expect(durable.sources == [.text])
+    let working = LayeredRecall.hit(from: item, horizon: .working, sessionID: UUID())
+    #expect(working.kind == .snippet)
+    #expect(working.sources == [.text])
 }
 
 private func layeredHit(
@@ -130,10 +147,17 @@ private func layeredHit(
     horizon: LayeredRecall.Horizon,
     metadata: [String: String] = [:]
 ) -> LayeredRecall.Hit {
-    LayeredRecall.Hit(
-        reference: LayeredRecall.makeMemoryReference(horizon, sessionID: nil, frameID: frameID),
-        horizon: horizon,
-        frameID: frameID,
+    let id: MemoryID
+    switch horizon {
+    case .durable:
+        id = .durable(frameID: frameID)
+    case .working:
+        id = .working(sessionID: UUID(), frameID: frameID)
+    case .episodic:
+        id = .episodic(sessionID: UUID(), frameID: frameID)
+    }
+    return LayeredRecall.Hit(
+        id: id,
         score: score,
         text: text,
         preview: text,

--- a/Tests/WaxTests/MemoryIDTests.swift
+++ b/Tests/WaxTests/MemoryIDTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func memoryIDParseRoundTripsDurableWire() throws {
+    let id = try MemoryID.parse("durable:42")
+    #expect(id == .durable(frameID: 42))
+    #expect(id.wire == "durable:42")
+    #expect(id.horizon == .durable)
+    #expect(id.sessionID == nil)
+    #expect(id.frameID == 42)
+}
+
+@Test
+func memoryIDParseRoundTripsWorkingWire() throws {
+    let sessionID = UUID()
+    let raw = "working:\(sessionID.uuidString):7"
+    let id = try MemoryID.parse(raw)
+    #expect(id == .working(sessionID: sessionID, frameID: 7))
+    #expect(id.wire == raw)
+    #expect(id.horizon == .working)
+    #expect(id.sessionID == sessionID)
+}
+
+@Test
+func memoryIDParseRoundTripsEpisodicWire() throws {
+    let sessionID = UUID()
+    let raw = "episodic:\(sessionID.uuidString):3"
+    let id = try MemoryID.parse(raw)
+    #expect(id == .episodic(sessionID: sessionID, frameID: 3))
+    #expect(id.wire == raw)
+}
+
+@Test
+func memoryIDParseRejectsDurableWithSessionToken() {
+    let sessionID = UUID()
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("durable:\(sessionID.uuidString):1")
+    }
+}
+
+@Test
+func memoryIDParseRejectsWorkingWithoutSession() {
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("working:1")
+    }
+}
+
+@Test
+func memoryIDWireNeverEmitsUnknownSessionToken() {
+    let sessionID = UUID()
+    #expect(!MemoryID.working(sessionID: sessionID, frameID: 1).wire.contains("unknown"))
+    #expect(!MemoryID.episodic(sessionID: sessionID, frameID: 1).wire.contains("unknown"))
+    #expect(!MemoryID.durable(frameID: 9).wire.contains("unknown"))
+}

--- a/Tests/WaxTests/MemoryIDTests.swift
+++ b/Tests/WaxTests/MemoryIDTests.swift
@@ -54,3 +54,13 @@ func memoryIDWireNeverEmitsUnknownSessionToken() {
     #expect(!MemoryID.episodic(sessionID: sessionID, frameID: 1).wire.contains("unknown"))
     #expect(!MemoryID.durable(frameID: 9).wire.contains("unknown"))
 }
+
+@Test
+func memoryIDParseRejectsUnknownSessionToken() {
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("working:unknown:1")
+    }
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("episodic:unknown:1")
+    }
+}


### PR DESCRIPTION
Package-internal `MemoryID` enum (`durable` / `working(session:)` / `episodic(session:)`) replaces string + optional-UUID memory references. Working/episodic require a session UUID, so `working:unknown:<frame>` cannot be produced. MCP wire format is unchanged. `LayeredRecall.Hit` keeps `RAGContext.ItemKind` / `Source` until JSON render.

**Ticket:** T1 from `spec/spec-architecture-type-system-seams.md` (gitignored; architecture pipeline run f876e26c)
**Reviews:** swift-adversarial-pr-review (fix pass) + final pass — APPROVE
**Gates:** `swift test --filter MemoryIDTests` (7), `LayeredRecallTests` (9), `CompactAssemblyTests` (8)

Does not change public `import Wax` API.