### PR TITLE
refactor(search): store LoadedVectorSearchEngine as the production backend

### DIFF
--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -4,9 +4,11 @@ import WaxTextSearch
 import WaxVectorSearch
 
 struct UnifiedSearchEngineOverrides {
-    var textEngine: FTS5SearchEngine?
-    var vectorEngine: (any VectorSearchEngine)?
-    var structuredEngine: FTS5SearchEngine?
+    var textEngine: FTS5SearchEngine? = nil
+    /// Test injection. Production search uses `loadedVectorEngine` or the cache enum.
+    var vectorEngine: (any VectorSearchEngine)? = nil
+    var loadedVectorEngine: LoadedVectorSearchEngine? = nil
+    var structuredEngine: FTS5SearchEngine? = nil
 }
 
 package extension Wax {
@@ -77,15 +79,24 @@ extension Wax {
             nil
         }
 
-        let vectorEngine: (any VectorSearchEngine)? = if includeVector, let embedding = request.embedding, !embedding.isEmpty {
+        enum ResolvedVectorEngine {
+            case loaded(LoadedVectorSearchEngine)
+            case override(any VectorSearchEngine)
+        }
+
+        let resolvedVectorEngine: ResolvedVectorEngine? = if includeVector, let embedding = request.embedding, !embedding.isEmpty {
             if let override = engineOverrides?.vectorEngine {
-                override
+                .override(override)
+            } else if let loaded = engineOverrides?.loadedVectorEngine {
+                .loaded(loaded)
+            } else if let loaded = try await cache.vectorEngine(
+                for: self,
+                queryEmbeddingDimensions: embedding.count,
+                preference: request.vectorEnginePreference
+            ) {
+                .loaded(loaded)
             } else {
-                try await cache.vectorEngine(
-                    for: self,
-                    queryEmbeddingDimensions: embedding.count,
-                    preference: request.vectorEnginePreference
-                )
+                nil
             }
         } else {
             nil
@@ -171,19 +182,17 @@ extension Wax {
         }()
 
         async let vectorResultsAsync: [(frameId: UInt64, score: Float)] = {
-            guard includeVector, let vectorEngine, let embedding = request.embedding, !embedding.isEmpty else { return [] }
-            var queryEmbedding = embedding
-            #if canImport(Metal)
-            let isMetalEngine = vectorEngine is MetalVectorEngine
-            if isMetalEngine, !VectorMath.isNormalizedL2(queryEmbedding) {
-                queryEmbedding = VectorMath.normalizeL2(queryEmbedding)
-            }
-            #endif
-            let vectorToSearch = queryEmbedding
+            guard includeVector, let resolvedVectorEngine, let embedding = request.embedding, !embedding.isEmpty else { return [] }
+            let vectorToSearch = embedding
             if let timeout = request.vectorSearchTimeout {
                 do {
                     return try await AsyncTimeout.run(timeout: timeout, operation: "vector search") {
-                        try await vectorEngine.search(vector: vectorToSearch, topK: candidateLimit)
+                        switch resolvedVectorEngine {
+                        case .loaded(let engine):
+                            return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
+                        case .override(let engine):
+                            return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
+                        }
                     }
                 } catch let error as AsyncTimeout.TimeoutError {
                     // Hybrid/text modes can degrade to non-vector lanes; vectorOnly should fail hard.
@@ -198,7 +207,12 @@ extension Wax {
                     return []
                 }
             } else {
-                return try await vectorEngine.search(vector: vectorToSearch, topK: candidateLimit)
+                switch resolvedVectorEngine {
+                case .loaded(let engine):
+                    return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
+                case .override(let engine):
+                    return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
+                }
             }
         }()
 

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -82,6 +82,15 @@ extension Wax {
         enum ResolvedVectorEngine {
             case loaded(LoadedVectorSearchEngine)
             case override(any VectorSearchEngine)
+
+            func search(vector: [Float], topK: Int) async throws -> [(frameId: UInt64, score: Float)] {
+                switch self {
+                case .loaded(let engine):
+                    return try await engine.search(vector: vector, topK: topK)
+                case .override(let engine):
+                    return try await engine.search(vector: vector, topK: topK)
+                }
+            }
         }
 
         let resolvedVectorEngine: ResolvedVectorEngine? = if includeVector, let embedding = request.embedding, !embedding.isEmpty {
@@ -183,16 +192,10 @@ extension Wax {
 
         async let vectorResultsAsync: [(frameId: UInt64, score: Float)] = {
             guard includeVector, let resolvedVectorEngine, let embedding = request.embedding, !embedding.isEmpty else { return [] }
-            let vectorToSearch = embedding
             if let timeout = request.vectorSearchTimeout {
                 do {
                     return try await AsyncTimeout.run(timeout: timeout, operation: "vector search") {
-                        switch resolvedVectorEngine {
-                        case .loaded(let engine):
-                            return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
-                        case .override(let engine):
-                            return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
-                        }
+                        try await resolvedVectorEngine.search(vector: embedding, topK: candidateLimit)
                     }
                 } catch let error as AsyncTimeout.TimeoutError {
                     // Hybrid/text modes can degrade to non-vector lanes; vectorOnly should fail hard.
@@ -207,12 +210,7 @@ extension Wax {
                     return []
                 }
             } else {
-                switch resolvedVectorEngine {
-                case .loaded(let engine):
-                    return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
-                case .override(let engine):
-                    return try await engine.search(vector: vectorToSearch, topK: candidateLimit)
-                }
+                return try await resolvedVectorEngine.search(vector: embedding, topK: candidateLimit)
             }
         }()
 

--- a/Sources/Wax/UnifiedSearch/UnifiedSearchEngineCache.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearchEngineCache.swift
@@ -42,7 +42,7 @@ actor UnifiedSearchEngineCache {
 
     private struct CachedVector {
         var key: VectorSourceKey
-        var engine: any VectorSearchEngine
+        var engine: LoadedVectorSearchEngine
     }
 
     private var textByWax: [ObjectIdentifier: CachedText] = [:]
@@ -109,7 +109,7 @@ actor UnifiedSearchEngineCache {
         for wax: Wax,
         queryEmbeddingDimensions: Int,
         preference: VectorEnginePreference = .auto
-    ) async throws -> (any VectorSearchEngine)? {
+    ) async throws -> LoadedVectorSearchEngine? {
         guard queryEmbeddingDimensions > 0 else { return nil }
         let pendingSnapshot = await wax.pendingEmbeddingMutations(since: nil)
         guard let descriptor = try await vectorLoadDescriptor(
@@ -133,8 +133,8 @@ actor UnifiedSearchEngineCache {
             preference: preference
         )
         incrementVectorDeserializations(for: waxId)
-        vectorByWax[waxId] = CachedVector(key: descriptor.key, engine: loaded.erased)
-        return loaded.erased
+        vectorByWax[waxId] = CachedVector(key: descriptor.key, engine: loaded)
+        return loaded
     }
 
     private func incrementTextDeserializations(for waxId: ObjectIdentifier) {

--- a/Sources/Wax/VectorSearchSession.swift
+++ b/Sources/Wax/VectorSearchSession.swift
@@ -6,7 +6,7 @@ package actor WaxVectorSearchSession {
     private typealias ConcreteVectorEngine = LoadedVectorSearchEngine
 
     package let wax: Wax
-    package let engine: any VectorSearchEngine
+    package var engine: any VectorSearchEngine { concreteEngine.erased }
     package let metric: VectorMetric
     package let dimensions: Int
     private let concreteEngine: ConcreteVectorEngine
@@ -29,7 +29,6 @@ package actor WaxVectorSearchSession {
             preference: preference
         )
         self.concreteEngine = loadedEngine
-        self.engine = loadedEngine.erased
 
         let snapshot = await wax.pendingEmbeddingMutations(since: nil)
         self.lastPendingEmbeddingSequence = snapshot.latestSequence

--- a/Sources/Wax/WaxSession.swift
+++ b/Sources/Wax/WaxSession.swift
@@ -49,7 +49,6 @@ package actor WaxSession {
     package let config: Config
 
     private let textEngine: FTS5SearchEngine?
-    private var vectorEngine: (any VectorSearchEngine)?
     private var concreteVectorEngine: ConcreteVectorEngine?
     private var lastPendingEmbeddingSequence: UInt64?
     /// Frame IDs removed from the vector index that must be re-applied after syncing pending embeddings.
@@ -77,7 +76,6 @@ package actor WaxSession {
             }
 
             let resolvedConcreteVectorEngine: ConcreteVectorEngine?
-            let resolvedVectorEngine: (any VectorSearchEngine)?
             let resolvedLastPendingEmbeddingSequence: UInt64?
 
             if config.enableVectorSearch {
@@ -90,23 +88,19 @@ package actor WaxSession {
                         preference: config.vectorEnginePreference
                     )
                     resolvedConcreteVectorEngine = loadedVectorEngine
-                    resolvedVectorEngine = loadedVectorEngine.erased
                     let snapshot = await wax.pendingEmbeddingMutations(since: nil)
                     resolvedLastPendingEmbeddingSequence = snapshot.latestSequence
                 } else {
                     resolvedConcreteVectorEngine = nil
-                    resolvedVectorEngine = nil
                     resolvedLastPendingEmbeddingSequence = nil
                 }
             } else {
                 resolvedConcreteVectorEngine = nil
-                resolvedVectorEngine = nil
                 resolvedLastPendingEmbeddingSequence = nil
             }
 
             self.textEngine = resolvedTextEngine
             self.concreteVectorEngine = resolvedConcreteVectorEngine
-            self.vectorEngine = resolvedVectorEngine
             self.lastPendingEmbeddingSequence = resolvedLastPendingEmbeddingSequence
         } catch {
             if let leaseId = acquiredWriterLeaseId {
@@ -144,7 +138,6 @@ package actor WaxSession {
             preference: config.vectorEnginePreference
         )
         concreteVectorEngine = loaded
-        vectorEngine = loaded.erased
         let snapshot = await wax.pendingEmbeddingMutations(since: nil)
         lastPendingEmbeddingSequence = snapshot.latestSequence
     }
@@ -155,7 +148,7 @@ package actor WaxSession {
         let searchVectorEngine = try await vectorEngineForSearch(request)
         let overrides = UnifiedSearchEngineOverrides(
             textEngine: textEngine,
-            vectorEngine: searchVectorEngine,
+            loadedVectorEngine: searchVectorEngine,
             structuredEngine: textEngine
         )
         return try await wax.search(request, engineOverrides: overrides)
@@ -520,8 +513,8 @@ package actor WaxSession {
         pendingRemovedFrameIds.removeAll(keepingCapacity: true)
     }
 
-    private func vectorEngineForSearch(_ request: SearchRequest) async throws -> (any VectorSearchEngine)? {
-        guard config.enableVectorSearch, let vectorEngine else {
+    private func vectorEngineForSearch(_ request: SearchRequest) async throws -> ConcreteVectorEngine? {
+        guard config.enableVectorSearch, let concreteVectorEngine else {
             return nil
         }
 
@@ -532,8 +525,8 @@ package actor WaxSession {
             break
         }
 
-        guard case .readWrite = mode, let concreteVectorEngine else {
-            return vectorEngine
+        guard case .readWrite = mode else {
+            return concreteVectorEngine
         }
 
         lastPendingEmbeddingSequence = try await WaxVectorSearchSession.syncPendingEmbeddings(
@@ -541,7 +534,7 @@ package actor WaxSession {
             into: concreteVectorEngine,
             watermark: lastPendingEmbeddingSequence
         )
-        return concreteVectorEngine.erased
+        return concreteVectorEngine
     }
 
     private static func resolveVectorDimensions(for wax: Wax, config: Config) async throws -> Int? {


### PR DESCRIPTION
Production vector search stores the closed `LoadedVectorSearchEngine` enum (`accelerate` | `metalANNS`) in `WaxSession`, `WaxVectorSearchSession`, and the unified-search cache. Test injection stays `any VectorSearchEngine` on `UnifiedSearchEngineOverrides`. Removes the dead `is MetalVectorEngine` branch; engines already normalize in `preparedVector`.

**Ticket:** T3 from `spec/spec-architecture-type-system-seams.md` (architecture pipeline run f876e26c)
**Reviews:** swift-adversarial-pr-review (fix pass) + final pass — APPROVE
**Gate:** `swift test --filter UnifiedSearchTests` (39)

Does not change public `import Wax` API.