### PR TITLE
refactor(broker): close remember writes as session vs durable destinations

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -77,7 +77,7 @@ extension AgentBrokerService {
             managed: document.metadata[MemoryMetadataKeys.sourceManaged] != "false",
             sourceKind: kind.rawValue,
             frameID: document.frameId,
-            memoryID: Self.makeMemoryReference(.durable, frameID: document.frameId),
+            memoryID: Self.makeMemoryReference(frameID: document.frameId),
             hash: Self.stableHash(document.text),
             sessionID: document.metadata[MemoryMetadataKeys.promotedFromSession] ?? document.metadata["session_id"],
             sourceFrameID: document.metadata[MemoryMetadataKeys.promotedFromFrame].flatMap(UInt64.init),
@@ -421,7 +421,7 @@ extension AgentBrokerService {
         guard marker.hash == previousHash else { return false }
 
         if let markerMemoryID = marker.memoryID {
-            let canonicalMemoryID = Self.makeMemoryReference(.durable, frameID: document.frameId)
+            let canonicalMemoryID = Self.makeMemoryReference(frameID: document.frameId)
             let storedMemoryID = document.metadata[MemoryMetadataKeys.sourceMemoryID]
             guard markerMemoryID == canonicalMemoryID || markerMemoryID == storedMemoryID else { return false }
         }

--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -77,7 +77,7 @@ extension AgentBrokerService {
             managed: document.metadata[MemoryMetadataKeys.sourceManaged] != "false",
             sourceKind: kind.rawValue,
             frameID: document.frameId,
-            memoryID: Self.makeMemoryReference(.durable, sessionID: nil, frameID: document.frameId),
+            memoryID: Self.makeMemoryReference(.durable, frameID: document.frameId),
             hash: Self.stableHash(document.text),
             sessionID: document.metadata[MemoryMetadataKeys.promotedFromSession] ?? document.metadata["session_id"],
             sourceFrameID: document.metadata[MemoryMetadataKeys.promotedFromFrame].flatMap(UInt64.init),
@@ -421,7 +421,7 @@ extension AgentBrokerService {
         guard marker.hash == previousHash else { return false }
 
         if let markerMemoryID = marker.memoryID {
-            let canonicalMemoryID = Self.makeMemoryReference(.durable, sessionID: nil, frameID: document.frameId)
+            let canonicalMemoryID = Self.makeMemoryReference(.durable, frameID: document.frameId)
             let storedMemoryID = document.metadata[MemoryMetadataKeys.sourceMemoryID]
             guard markerMemoryID == canonicalMemoryID || markerMemoryID == storedMemoryID else { return false }
         }

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -865,11 +865,15 @@ extension AgentBrokerService {
                 suggestedDurability: proposal.suggestedDurability,
                 suggestedConfidence: proposal.confidence
             )
+            let destination = try RememberDestination.decode(
+                sessionID: nil,
+                writeScope: .durable,
+                semantics: writeSemantics,
+                metadata: normalizedMetadata
+            )
             normalizedMetadata = try MemorySemantics.validatedWriteMetadata(
                 metadata: normalizedMetadata,
-                semantics: writeSemantics,
-                sessionID: nil,
-                scope: "durable",
+                destination: destination,
                 activeSession: false,
                 inferredScope: writeScope(for: resolvedPromotionSessionID, clientCWD: command.cwd),
                 nowMs: Self.nowMs()

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -3054,13 +3054,13 @@ extension AgentBrokerService {
         try MemoryID.parse(raw)
     }
 
-    static func itemKindLabel(_ kind: RAGContext.ItemKind?) -> String {
+    static func itemKindLabel(_ kind: RAGContext.ItemKind) -> String {
         switch kind {
         case .expanded:
             return "expanded"
         case .surrogate:
             return "surrogate"
-        case .snippet, .none:
+        case .snippet:
             return "snippet"
         }
     }
@@ -3159,8 +3159,8 @@ extension AgentBrokerService {
         return trimmed
     }
 
-    static func makeMemoryReference(_ horizon: MemoryHorizon, frameID: UInt64) -> String {
-        LayeredRecall.makeMemoryReference(horizon, frameID: frameID)
+    static func makeMemoryReference(frameID: UInt64) -> String {
+        LayeredRecall.makeMemoryReference(frameID: frameID)
     }
 
     static func makeMemoryReference(_ horizon: MemoryHorizon, sessionID: UUID, frameID: UInt64) -> String {

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -339,7 +339,7 @@ extension AgentBrokerService {
 
     typealias MemoryHorizon = LayeredRecall.Horizon
     typealias LayeredMemoryHit = LayeredRecall.Hit
-    typealias MemoryReference = LayeredRecall.MemoryReference
+    typealias MemoryReference = MemoryID
 
     struct MarkdownProjectionReport {
         var memoryMarkdownPath: String
@@ -510,17 +510,17 @@ extension AgentBrokerService {
         }
         lines.append("Applied filters: \(parsedFilters.summary.debugJSONString)")
         for (index, hit) in result.hits.enumerated() {
-            let kind = hit.kind ?? "snippet"
+            let kind = Self.itemKindLabel(hit.kind)
             lines.append("\(index + 1). [\(kind)] frame=\(hit.frameID) score=\(String(format: "%.4f", hit.score)) \(hit.text)")
         }
 
         let results: [AgentBrokerValue] = result.hits.enumerated().map { index, hit in
             .object([
                 "rank": .from(index + 1),
-                "kind": .string(hit.kind ?? "snippet"),
+                "kind": .string(Self.itemKindLabel(hit.kind)),
                 "frameId": .from(hit.frameID),
                 "score": .double(Double(hit.score)),
-                "sources": .array(hit.sources.map(AgentBrokerValue.string)),
+                "sources": .array(hit.sources.map { .string($0.rawValue) }),
                 "text": .string(hit.text),
                 "metadata": .object(hit.metadata.mapValues(AgentBrokerValue.string)),
                 "explanations": .array(hit.explanations.map(AgentBrokerValue.string)),
@@ -2440,24 +2440,17 @@ extension AgentBrokerService {
                         ) ?? item.frameId
                         hits.append(
                             LayeredRecall.Hit(
-                                reference: LayeredRecall.makeMemoryReference(
-                                    .episodic,
-                                    sessionID: manifest.sessionID,
-                                    frameID: canonicalFrameID
-                                ),
-                                horizon: .episodic,
-                                sessionID: manifest.sessionID,
+                                id: .episodic(sessionID: manifest.sessionID, frameID: canonicalFrameID),
                                 agentID: manifest.agentID,
                                 runID: manifest.runID,
-                                frameID: canonicalFrameID,
                                 score: item.score,
                                 text: item.text,
                                 preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
                                 metadata: item.metadata,
                                 explanations: ["recent session episode"] + item.explanations,
                                 timestampMs: manifest.updatedAtMs,
-                                kind: "\(item.kind)",
-                                sources: item.sources.map(\.rawValue)
+                                kind: item.kind,
+                                sources: item.sources
                             )
                         )
                     }
@@ -2469,17 +2462,12 @@ extension AgentBrokerService {
     }
 
     func layeredMemoryGet(reference: MemoryReference) async throws -> LayeredMemoryHit {
-        switch reference.horizon {
-        case .durable:
-            let document = try await requireDocument(frameID: reference.frameID, memory: longTermMemory)
+        switch reference {
+        case .durable(let frameID):
+            let document = try await requireDocument(frameID: frameID, memory: longTermMemory)
             await longTermMemory.recordAccess(frameId: document.frameId)
             return LayeredMemoryHit(
-                reference: Self.makeMemoryReference(.durable, sessionID: nil, frameID: reference.frameID),
-                horizon: .durable,
-                sessionID: nil,
-                agentID: nil,
-                runID: nil,
-                frameID: document.frameId,
+                id: .durable(frameID: frameID),
                 score: 0,
                 text: document.text,
                 preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
@@ -2487,21 +2475,15 @@ extension AgentBrokerService {
                 explanations: ["durable memory"],
                 timestampMs: document.timestampMs
             )
-        case .working, .episodic:
-            guard let sessionID = reference.sessionID else {
-                throw BrokerValidationError.invalid("session-backed memory references require a session_id")
-            }
+        case .working(let sessionID, let frameID), .episodic(let sessionID, let frameID):
             let manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)
             let loader: (MemoryOrchestrator) async throws -> LayeredMemoryHit = { memory in
-                let document = try await self.requireDocument(frameID: reference.frameID, memory: memory)
+                let document = try await self.requireDocument(frameID: frameID, memory: memory)
                 await memory.recordAccess(frameId: document.frameId)
                 return LayeredMemoryHit(
-                    reference: Self.makeMemoryReference(reference.horizon, sessionID: sessionID, frameID: reference.frameID),
-                    horizon: reference.horizon,
-                    sessionID: sessionID,
+                    id: MemoryID.make(horizon: reference.horizon, sessionID: sessionID, frameID: frameID),
                     agentID: manifest.agentID,
                     runID: manifest.runID,
-                    frameID: document.frameId,
                     score: 0,
                     text: document.text,
                     preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
@@ -3069,26 +3051,17 @@ extension AgentBrokerService {
     }
 
     func parseMemoryReference(_ raw: String) throws -> MemoryReference {
-        let parts = raw.split(separator: ":").map(String.init)
-        guard parts.count >= 2 else {
-            throw BrokerValidationError.invalid("memory_id must be in the form '<horizon>:<frame>' or '<horizon>:<session_id>:<frame>'")
-        }
-        guard let horizon = MemoryHorizon(rawValue: parts[0]) else {
-            throw BrokerValidationError.invalid("memory_id horizon must be one of: working, episodic, durable")
-        }
-        switch horizon {
-        case .durable:
-            guard parts.count == 2, let frameID = UInt64(parts[1]) else {
-                throw BrokerValidationError.invalid("durable memory_id must be 'durable:<frame_id>'")
-            }
-            return MemoryReference(horizon: .durable, sessionID: nil, frameID: frameID)
-        case .working, .episodic:
-            guard parts.count == 3,
-                  let sessionID = UUID(uuidString: parts[1]),
-                  let frameID = UInt64(parts[2]) else {
-                throw BrokerValidationError.invalid("session memory_id must be '\(horizon.rawValue):<session_id>:<frame_id>'")
-            }
-            return MemoryReference(horizon: horizon, sessionID: sessionID, frameID: frameID)
+        try MemoryID.parse(raw)
+    }
+
+    static func itemKindLabel(_ kind: RAGContext.ItemKind?) -> String {
+        switch kind {
+        case .expanded:
+            return "expanded"
+        case .surrogate:
+            return "surrogate"
+        case .snippet, .none:
+            return "snippet"
         }
     }
 
@@ -3186,7 +3159,11 @@ extension AgentBrokerService {
         return trimmed
     }
 
-    static func makeMemoryReference(_ horizon: MemoryHorizon, sessionID: UUID?, frameID: UInt64) -> String {
+    static func makeMemoryReference(_ horizon: MemoryHorizon, frameID: UInt64) -> String {
+        LayeredRecall.makeMemoryReference(horizon, frameID: frameID)
+    }
+
+    static func makeMemoryReference(_ horizon: MemoryHorizon, sessionID: UUID, frameID: UInt64) -> String {
         LayeredRecall.makeMemoryReference(horizon, sessionID: sessionID, frameID: frameID)
     }
 

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -356,9 +356,7 @@ extension AgentBrokerService {
         }
         let metadata = try MemorySemantics.validatedWriteMetadata(
             metadata: command.metadata,
-            semantics: command.writeSemantics,
-            sessionID: sessionID,
-            scope: command.writeScope?.rawValue,
+            destination: command.destination,
             activeSession: sessionID != nil,
             inferredScope: writeScope(for: sessionID, clientCWD: command.cwd),
             nowMs: Self.nowMs()
@@ -945,9 +943,7 @@ extension AgentBrokerService {
         }
         let metadata = try MemorySemantics.validatedWriteMetadata(
             metadata: command.metadata,
-            semantics: command.writeSemantics,
-            sessionID: command.sessionID,
-            scope: command.writeScope?.rawValue,
+            destination: command.destination,
             activeSession: command.sessionID != nil,
             inferredScope: writeScope(for: command.sessionID, clientCWD: command.cwd),
             nowMs: Self.nowMs()

--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -38,20 +38,20 @@ package enum BrokerCommand: Sendable, Equatable {
     case corpusSearch(CorpusSearch)
     case memoryMaintain(MemoryMaintain)
 
-    package enum RememberWriteScope: String, Sendable, Equatable {
-        case session
-        case durable
-    }
-
     package struct Remember: Sendable, Equatable {
         package var content: String
         package var destination: RememberDestination
-        package var writeScope: RememberWriteScope?
         package var metadata: [String: String]
         package var cwd: String?
 
         package var sessionID: UUID? { destination.sessionID }
         package var writeSemantics: MemoryWriteSemantics { destination.writeSemantics }
+        package var writeScope: RememberWriteScope {
+            switch destination {
+            case .session: return .session
+            case .durable: return .durable
+            }
+        }
     }
 
     package struct ParsedSearchFilters: Sendable, Equatable {
@@ -162,7 +162,6 @@ package enum BrokerCommand: Sendable, Equatable {
     package struct KnowledgeCapture: Sendable, Equatable {
         package var content: String
         package var destination: RememberDestination
-        package var writeScope: RememberWriteScope?
         package var metadata: [String: String]
         package var cwd: String?
         package var subject: String?
@@ -174,6 +173,12 @@ package enum BrokerCommand: Sendable, Equatable {
 
         package var sessionID: UUID? { destination.sessionID }
         package var writeSemantics: MemoryWriteSemantics { destination.writeSemantics }
+        package var writeScope: RememberWriteScope {
+            switch destination {
+            case .session: return .session
+            case .durable: return .durable
+            }
+        }
     }
 
     package struct SessionClose: Sendable, Equatable {
@@ -371,7 +376,6 @@ extension BrokerCommand.Remember {
         return Self(
             content: content,
             destination: destination,
-            writeScope: writeScope,
             metadata: rawMetadata,
             cwd: try args.optionalString("cwd")
         )
@@ -636,7 +640,6 @@ extension BrokerCommand.KnowledgeCapture {
                 maxBytes: BrokerLimits.maxContentBytes
             ),
             destination: destination,
-            writeScope: writeScope,
             metadata: metadata,
             cwd: try args.optionalString("cwd"),
             subject: try args.optionalString("subject"),

--- a/Sources/Wax/Broker/BrokerCommand.swift
+++ b/Sources/Wax/Broker/BrokerCommand.swift
@@ -45,11 +45,13 @@ package enum BrokerCommand: Sendable, Equatable {
 
     package struct Remember: Sendable, Equatable {
         package var content: String
-        package var sessionID: UUID?
+        package var destination: RememberDestination
         package var writeScope: RememberWriteScope?
         package var metadata: [String: String]
-        package var writeSemantics: MemoryWriteSemantics
         package var cwd: String?
+
+        package var sessionID: UUID? { destination.sessionID }
+        package var writeSemantics: MemoryWriteSemantics { destination.writeSemantics }
     }
 
     package struct ParsedSearchFilters: Sendable, Equatable {
@@ -159,10 +161,9 @@ package enum BrokerCommand: Sendable, Equatable {
 
     package struct KnowledgeCapture: Sendable, Equatable {
         package var content: String
-        package var sessionID: UUID?
+        package var destination: RememberDestination
         package var writeScope: RememberWriteScope?
         package var metadata: [String: String]
-        package var writeSemantics: MemoryWriteSemantics
         package var cwd: String?
         package var subject: String?
         package var kind: String?
@@ -170,6 +171,9 @@ package enum BrokerCommand: Sendable, Equatable {
         package var predicate: String?
         /// Raw wire object; handler parses to ``FactValue``.
         package var object: AgentBrokerValue?
+
+        package var sessionID: UUID? { destination.sessionID }
+        package var writeSemantics: MemoryWriteSemantics { destination.writeSemantics }
     }
 
     package struct SessionClose: Sendable, Equatable {
@@ -357,12 +361,18 @@ extension BrokerCommand.Remember {
         if rawMetadata["session_id"] != nil {
             throw BrokerValidationError.invalid("metadata.session_id is reserved; use top-level session_id")
         }
-        return Self(
-            content: content,
+        let writeSemantics = try BrokerCommand.parseWriteSemantics(args)
+        let destination = try RememberDestination.decode(
             sessionID: sessionID,
             writeScope: writeScope,
+            semantics: writeSemantics,
+            metadata: rawMetadata
+        )
+        return Self(
+            content: content,
+            destination: destination,
+            writeScope: writeScope,
             metadata: rawMetadata,
-            writeSemantics: try BrokerCommand.parseWriteSemantics(args),
             cwd: try args.optionalString("cwd")
         )
     }
@@ -614,15 +624,20 @@ extension BrokerCommand.KnowledgeCapture {
         if metadata["session_id"] != nil {
             throw BrokerValidationError.invalid("metadata.session_id is reserved; use top-level session_id")
         }
+        let destination = try RememberDestination.decode(
+            sessionID: sessionID,
+            writeScope: writeScope,
+            semantics: writeSemantics,
+            metadata: metadata
+        )
         return Self(
             content: try args.requiredStringPreservingWhitespace(
                 "content",
                 maxBytes: BrokerLimits.maxContentBytes
             ),
-            sessionID: sessionID,
+            destination: destination,
             writeScope: writeScope,
             metadata: metadata,
-            writeSemantics: writeSemantics,
             cwd: try args.optionalString("cwd"),
             subject: try args.optionalString("subject"),
             kind: try args.optionalString("kind"),

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -38,7 +38,7 @@ package enum LayeredRecall {
         package var metadata: [String: String]
         package var explanations: [String]
         package var timestampMs: Int64
-        package var kind: RAGContext.ItemKind?
+        package var kind: RAGContext.ItemKind
         package var sources: [RAGContext.Source]
 
         package var reference: String { id.wire }
@@ -56,7 +56,7 @@ package enum LayeredRecall {
             metadata: [String: String],
             explanations: [String],
             timestampMs: Int64,
-            kind: RAGContext.ItemKind? = nil,
+            kind: RAGContext.ItemKind = .snippet,
             sources: [RAGContext.Source] = []
         ) {
             self.id = id
@@ -280,7 +280,7 @@ package enum LayeredRecall {
         id.wire
     }
 
-    package static func makeMemoryReference(_ horizon: Horizon, frameID: UInt64) -> String {
+    package static func makeMemoryReference(frameID: UInt64) -> String {
         MemoryID.durable(frameID: frameID).wire
     }
 
@@ -496,7 +496,7 @@ package enum LayeredRecall {
         hit(from: item, id: MemoryID.make(horizon: horizon, sessionID: sessionID, frameID: item.frameId))
     }
 
-    package static func hit(from item: RAGContext.Item, horizon: Horizon) -> Hit {
+    package static func hit(from item: RAGContext.Item) -> Hit {
         hit(from: item, id: .durable(frameID: item.frameId))
     }
 
@@ -523,10 +523,10 @@ package enum LayeredRecall {
         let sessionHits = sessionItems.map {
             hit(from: $0, horizon: .working, sessionID: UUID())
         }
-        let durableHits = durableItems.map { hit(from: $0, horizon: .durable) }
+        let durableHits = durableItems.map { hit(from: $0) }
         return mergeHits(sessionHits: sessionHits, durableHits: durableHits, limit: limit).map { hit in
             RAGContext.Item(
-                kind: hit.kind ?? .snippet,
+                kind: hit.kind,
                 frameId: hit.frameID,
                 score: hit.score,
                 sources: hit.sources.isEmpty ? [.unknown] : hit.sources,
@@ -542,7 +542,7 @@ package enum LayeredRecall {
         project: String?,
         repo: String?
     ) -> [RAGContext.Item] {
-        let hits = items.map { hit(from: $0, horizon: .durable) }
+        let hits = items.map { hit(from: $0) }
         let filtered = filterHitsByProject(hits, project: project, repo: repo)
         let allowed = Set(filtered.map(\.frameID))
         return items.filter { allowed.contains($0.frameId) }
@@ -633,7 +633,7 @@ package enum LayeredRecall {
             )
             durableExecution = execution
             durableHits = execution.context.items.map {
-                hit(from: $0, horizon: .durable)
+                hit(from: $0)
             }
             let nowMs = stores.nowMs()
             durableHits = durableHits.filter { hit in

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -29,44 +29,39 @@ package enum LayeredRecall {
     }
 
     package struct Hit: Sendable, Equatable {
-        package var reference: String
-        package var horizon: Horizon
-        package var sessionID: UUID?
+        package var id: MemoryID
         package var agentID: String?
         package var runID: String?
-        package var frameID: UInt64
         package var score: Float
         package var text: String
         package var preview: String
         package var metadata: [String: String]
         package var explanations: [String]
         package var timestampMs: Int64
-        /// Present for recall-shaped hits (maps from `RAGContext.Item.kind`).
-        package var kind: String?
-        package var sources: [String]
+        package var kind: RAGContext.ItemKind?
+        package var sources: [RAGContext.Source]
+
+        package var reference: String { id.wire }
+        package var horizon: Horizon { id.horizon }
+        package var sessionID: UUID? { id.sessionID }
+        package var frameID: UInt64 { id.frameID }
 
         package init(
-            reference: String,
-            horizon: Horizon,
-            sessionID: UUID? = nil,
+            id: MemoryID,
             agentID: String? = nil,
             runID: String? = nil,
-            frameID: UInt64,
             score: Float,
             text: String,
             preview: String,
             metadata: [String: String],
             explanations: [String],
             timestampMs: Int64,
-            kind: String? = nil,
-            sources: [String] = []
+            kind: RAGContext.ItemKind? = nil,
+            sources: [RAGContext.Source] = []
         ) {
-            self.reference = reference
-            self.horizon = horizon
-            self.sessionID = sessionID
+            self.id = id
             self.agentID = agentID
             self.runID = runID
-            self.frameID = frameID
             self.score = score
             self.text = text
             self.preview = preview
@@ -78,17 +73,7 @@ package enum LayeredRecall {
         }
     }
 
-    package struct MemoryReference: Sendable, Equatable {
-        package var horizon: Horizon
-        package var sessionID: UUID?
-        package var frameID: UInt64
-
-        package init(horizon: Horizon, sessionID: UUID?, frameID: UInt64) {
-            self.horizon = horizon
-            self.sessionID = sessionID
-            self.frameID = frameID
-        }
-    }
+    package typealias MemoryReference = MemoryID
 
     package struct WorkingLane: Sendable {
         package var sessionID: UUID
@@ -291,17 +276,16 @@ package enum LayeredRecall {
         package var durableExecution: MemoryOrchestrator.RecallExecution?
     }
 
-    package static func makeMemoryReference(
-        _ horizon: Horizon,
-        sessionID: UUID?,
-        frameID: UInt64
-    ) -> String {
-        switch horizon {
-        case .durable:
-            return "durable:\(frameID)"
-        case .working, .episodic:
-            return "\(horizon.rawValue):\(sessionID?.uuidString ?? "unknown"):\(frameID)"
-        }
+    package static func makeMemoryReference(_ id: MemoryID) -> String {
+        id.wire
+    }
+
+    package static func makeMemoryReference(_ horizon: Horizon, frameID: UInt64) -> String {
+        MemoryID.durable(frameID: frameID).wire
+    }
+
+    package static func makeMemoryReference(_ horizon: Horizon, sessionID: UUID, frameID: UInt64) -> String {
+        MemoryID.make(horizon: horizon, sessionID: sessionID, frameID: frameID).wire
     }
 
     package static func normalize(_ value: String?) -> String? {
@@ -508,52 +492,26 @@ package enum LayeredRecall {
         return (filtered, false, nil)
     }
 
-    package static func hit(from item: RAGContext.Item, horizon: Horizon, sessionID: UUID?) -> Hit {
+    package static func hit(from item: RAGContext.Item, horizon: Horizon, sessionID: UUID) -> Hit {
+        hit(from: item, id: MemoryID.make(horizon: horizon, sessionID: sessionID, frameID: item.frameId))
+    }
+
+    package static func hit(from item: RAGContext.Item, horizon: Horizon) -> Hit {
+        hit(from: item, id: .durable(frameID: item.frameId))
+    }
+
+    package static func hit(from item: RAGContext.Item, id: MemoryID) -> Hit {
         Hit(
-            reference: makeMemoryReference(horizon, sessionID: sessionID, frameID: item.frameId),
-            horizon: horizon,
-            sessionID: sessionID,
-            frameID: item.frameId,
+            id: id,
             score: item.score,
             text: item.text,
             preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
             metadata: item.metadata,
             explanations: item.explanations,
             timestampMs: item.metadata[MemoryMetadataKeys.createdAtMs].flatMap(Int64.init) ?? 0,
-            kind: "\(item.kind)",
-            sources: item.sources.map(\.rawValue)
+            kind: item.kind,
+            sources: item.sources
         )
-    }
-
-    private static func itemKind(from raw: String?) -> RAGContext.ItemKind {
-        switch raw {
-        case "expanded":
-            return .expanded
-        case "surrogate":
-            return .surrogate
-        default:
-            return .snippet
-        }
-    }
-
-    private static func ragSources(from raw: [String]) -> [RAGContext.Source] {
-        let mapped: [RAGContext.Source] = raw.compactMap { value in
-            switch value {
-            case "text":
-                return .text
-            case "vector":
-                return .vector
-            case "timeline":
-                return .timeline
-            case "structured":
-                return .structured
-            case "unknown":
-                return .unknown
-            default:
-                return nil
-            }
-        }
-        return mapped.isEmpty ? [.unknown] : mapped
     }
 
     /// Bridge for callers that still speak `RAGContext.Item` (tests / gradual migrate).
@@ -562,14 +520,16 @@ package enum LayeredRecall {
         durableItems: [RAGContext.Item],
         limit: Int
     ) -> [RAGContext.Item] {
-        let sessionHits = sessionItems.map { hit(from: $0, horizon: .working, sessionID: nil) }
-        let durableHits = durableItems.map { hit(from: $0, horizon: .durable, sessionID: nil) }
+        let sessionHits = sessionItems.map {
+            hit(from: $0, horizon: .working, sessionID: UUID())
+        }
+        let durableHits = durableItems.map { hit(from: $0, horizon: .durable) }
         return mergeHits(sessionHits: sessionHits, durableHits: durableHits, limit: limit).map { hit in
             RAGContext.Item(
-                kind: itemKind(from: hit.kind),
+                kind: hit.kind ?? .snippet,
                 frameId: hit.frameID,
                 score: hit.score,
-                sources: ragSources(from: hit.sources),
+                sources: hit.sources.isEmpty ? [.unknown] : hit.sources,
                 text: hit.text,
                 metadata: hit.metadata,
                 explanations: hit.explanations
@@ -582,7 +542,7 @@ package enum LayeredRecall {
         project: String?,
         repo: String?
     ) -> [RAGContext.Item] {
-        let hits = items.map { hit(from: $0, horizon: .durable, sessionID: nil) }
+        let hits = items.map { hit(from: $0, horizon: .durable) }
         let filtered = filterHitsByProject(hits, project: project, repo: repo)
         let allowed = Set(filtered.map(\.frameID))
         return items.filter { allowed.contains($0.frameId) }
@@ -634,24 +594,17 @@ package enum LayeredRecall {
                     }
                 sessionHits = documents.prefix(topK).map { document in
                     Hit(
-                        reference: makeMemoryReference(
-                            .working,
-                            sessionID: working.sessionID,
-                            frameID: document.frameId
-                        ),
-                        horizon: .working,
-                        sessionID: working.sessionID,
+                        id: .working(sessionID: working.sessionID, frameID: document.frameId),
                         agentID: working.agentID,
                         runID: working.runID,
-                        frameID: document.frameId,
                         score: 0.2,
                         text: document.text,
                         preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
                         metadata: document.metadata,
                         explanations: ["current session", "recent session note"],
                         timestampMs: document.timestampMs,
-                        kind: "snippet",
-                        sources: [RAGContext.Source.text.rawValue]
+                        kind: .snippet,
+                        sources: [.text]
                     )
                 }
             } else {
@@ -680,7 +633,7 @@ package enum LayeredRecall {
             )
             durableExecution = execution
             durableHits = execution.context.items.map {
-                hit(from: $0, horizon: .durable, sessionID: nil)
+                hit(from: $0, horizon: .durable)
             }
             let nowMs = stores.nowMs()
             durableHits = durableHits.filter { hit in
@@ -805,23 +758,16 @@ package enum LayeredRecall {
                 }
                 hits.append(
                     Hit(
-                        reference: makeMemoryReference(
-                            .working,
-                            sessionID: sessionID,
-                            frameID: canonicalFrameID
-                        ),
-                        horizon: .working,
-                        sessionID: sessionID,
+                        id: .working(sessionID: sessionID, frameID: canonicalFrameID),
                         agentID: lane.agentID,
                         runID: lane.runID,
-                        frameID: canonicalFrameID,
                         score: result.score + 0.25,
                         text: stores.preview(result.previewText),
                         preview: stores.preview(result.previewText),
                         metadata: result.metadata,
                         explanations: ["current session"] + result.explanations,
                         timestampMs: lane.updatedAtMs,
-                        sources: result.sources.map(\.rawValue)
+                        sources: result.sources
                     )
                 )
             }
@@ -851,17 +797,14 @@ package enum LayeredRecall {
                 }
                 hits.append(
                     Hit(
-                        reference: makeMemoryReference(.durable, sessionID: nil, frameID: canonicalFrameID),
-                        horizon: .durable,
-                        sessionID: nil,
-                        frameID: canonicalFrameID,
+                        id: .durable(frameID: canonicalFrameID),
                         score: result.score + 0.10,
                         text: stores.preview(result.previewText),
                         preview: stores.preview(result.previewText),
                         metadata: result.metadata,
                         explanations: ["durable memory"] + result.explanations,
                         timestampMs: result.metadata[MemoryMetadataKeys.createdAtMs].flatMap(Int64.init) ?? 0,
-                        sources: result.sources.map(\.rawValue)
+                        sources: result.sources
                     )
                 )
             }
@@ -896,16 +839,9 @@ package enum LayeredRecall {
                     explanations.append(contentsOf: laneHit.explanations)
                     hits.append(
                         Hit(
-                            reference: makeMemoryReference(
-                                .episodic,
-                                sessionID: manifest.sessionID,
-                                frameID: canonicalFrameID
-                            ),
-                            horizon: .episodic,
-                            sessionID: manifest.sessionID,
+                            id: .episodic(sessionID: manifest.sessionID, frameID: canonicalFrameID),
                             agentID: manifest.agentID,
                             runID: manifest.runID,
-                            frameID: canonicalFrameID,
                             score: laneHit.score + recencyBoost,
                             text: stores.preview(laneHit.previewText),
                             preview: stores.preview(laneHit.previewText),
@@ -948,12 +884,7 @@ package enum LayeredRecall {
         for hit in hits {
             var copy = hit
             if let canonical = await stores.canonicalFrameID(hit.frameID, memory) {
-                copy.frameID = canonical
-                copy.reference = makeMemoryReference(
-                    hit.horizon,
-                    sessionID: hit.sessionID,
-                    frameID: canonical
-                )
+                copy.id = copy.id.replacingFrameID(canonical)
             }
             canonicalized.append(copy)
         }

--- a/Sources/Wax/Broker/MemoryID.swift
+++ b/Sources/Wax/Broker/MemoryID.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Closed identity of a recall/get hit: durable frame, or working/episodic frame in a session.
+package enum MemoryID: Hashable, Sendable {
+    case durable(frameID: UInt64)
+    case working(sessionID: UUID, frameID: UInt64)
+    case episodic(sessionID: UUID, frameID: UInt64)
+
+    package var horizon: LayeredRecall.Horizon {
+        switch self {
+        case .durable:
+            return .durable
+        case .working:
+            return .working
+        case .episodic:
+            return .episodic
+        }
+    }
+
+    package var sessionID: UUID? {
+        switch self {
+        case .durable:
+            return nil
+        case .working(let sessionID, _), .episodic(let sessionID, _):
+            return sessionID
+        }
+    }
+
+    package var frameID: UInt64 {
+        switch self {
+        case .durable(let frameID), .working(_, let frameID), .episodic(_, let frameID):
+            return frameID
+        }
+    }
+
+    package var wire: String {
+        switch self {
+        case .durable(let frameID):
+            return "durable:\(frameID)"
+        case .working(let sessionID, let frameID):
+            return "working:\(sessionID.uuidString):\(frameID)"
+        case .episodic(let sessionID, let frameID):
+            return "episodic:\(sessionID.uuidString):\(frameID)"
+        }
+    }
+
+    package func replacingFrameID(_ frameID: UInt64) -> MemoryID {
+        switch self {
+        case .durable:
+            return .durable(frameID: frameID)
+        case .working(let sessionID, _):
+            return .working(sessionID: sessionID, frameID: frameID)
+        case .episodic(let sessionID, _):
+            return .episodic(sessionID: sessionID, frameID: frameID)
+        }
+    }
+
+    package static func make(
+        horizon: LayeredRecall.Horizon,
+        sessionID: UUID,
+        frameID: UInt64
+    ) -> MemoryID {
+        switch horizon {
+        case .durable:
+            return .durable(frameID: frameID)
+        case .working:
+            return .working(sessionID: sessionID, frameID: frameID)
+        case .episodic:
+            return .episodic(sessionID: sessionID, frameID: frameID)
+        }
+    }
+
+    package static func parse(_ raw: String) throws -> MemoryID {
+        let parts = raw.split(separator: ":").map(String.init)
+        guard parts.count >= 2 else {
+            throw BrokerValidationError.invalid(
+                "memory_id must be in the form '<horizon>:<frame>' or '<horizon>:<session_id>:<frame>'"
+            )
+        }
+        guard let horizon = LayeredRecall.Horizon(rawValue: parts[0]) else {
+            throw BrokerValidationError.invalid("memory_id horizon must be one of: working, episodic, durable")
+        }
+        switch horizon {
+        case .durable:
+            guard parts.count == 2, let frameID = UInt64(parts[1]) else {
+                throw BrokerValidationError.invalid("durable memory_id must be 'durable:<frame_id>'")
+            }
+            return .durable(frameID: frameID)
+        case .working, .episodic:
+            guard parts.count == 3,
+                  let sessionID = UUID(uuidString: parts[1]),
+                  let frameID = UInt64(parts[2])
+            else {
+                throw BrokerValidationError.invalid(
+                    "session memory_id must be '\(horizon.rawValue):<session_id>:<frame_id>'"
+                )
+            }
+            return make(horizon: horizon, sessionID: sessionID, frameID: frameID)
+        }
+    }
+}

--- a/Sources/Wax/Broker/SessionHarvest.swift
+++ b/Sources/Wax/Broker/SessionHarvest.swift
@@ -113,6 +113,22 @@ package enum SessionHarvest {
                     leftoverDocumentCount += 1
                     continue
                 }
+                let destination: RememberDestination
+                do {
+                    destination = try RememberDestination.decode(
+                        sessionID: nil,
+                        writeScope: .durable,
+                        semantics: MemoryWriteSemantics(),
+                        metadata: metadata
+                    )
+                } catch {
+                    leftoverDocumentCount += 1
+                    continue
+                }
+                guard case .durable = destination else {
+                    leftoverDocumentCount += 1
+                    continue
+                }
                 do {
                     let written = try await longTermMemory.remember(document.text, metadata: metadata)
                     if let sourceStats = sessionStats[document.frameId] {

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -80,6 +80,288 @@ package struct MemoryWriteSemantics: Sendable, Equatable {
     }
 }
 
+/// Closed session vs durable remember write after wire decode.
+package enum RememberDestination: Sendable, Equatable {
+    case session(sessionID: UUID, write: SessionRememberWrite)
+    case durable(write: DurableRememberWrite)
+
+    package var sessionID: UUID? {
+        switch self {
+        case .session(let sessionID, _):
+            return sessionID
+        case .durable:
+            return nil
+        }
+    }
+
+    package var writeSemantics: MemoryWriteSemantics {
+        switch self {
+        case .session(_, let write):
+            return write.writeSemantics
+        case .durable(let write):
+            return write.writeSemantics
+        }
+    }
+
+    /// Maps MCP remember fields into a destination that cannot name illegal combos.
+    package static func decode(
+        sessionID: UUID?,
+        writeScope: BrokerCommand.RememberWriteScope?,
+        semantics: MemoryWriteSemantics,
+        metadata: [String: String]
+    ) throws -> RememberDestination {
+        let metadataType = metadata[MemoryMetadataKeys.type].flatMap(MemoryType.init(rawValue:))
+        let resolvedType = semantics.type ?? metadataType ?? .note
+        let metadataDurability = metadata[MemoryMetadataKeys.durability]
+            .flatMap(MemoryDurability.init(rawValue:))
+        let requestedDurability = semantics.lock
+            ? MemoryDurability.locked
+            : semantics.durability ?? metadataDurability
+
+        if resolvedType == .taskState {
+            if writeScope == .durable {
+                throw BrokerValidationError.invalid(
+                    "task_state cannot use scope durable; use scope session with an active session_id"
+                )
+            }
+            guard let sessionID else {
+                throw BrokerValidationError.invalid(
+                    "task_state requires an active session_id; durable task diaries are not supported"
+                )
+            }
+            if semantics.lock
+                || requestedDurability == .durable
+                || requestedDurability == .locked
+                || metadataDurability == .durable
+                || metadataDurability == .locked {
+                throw BrokerValidationError.invalid(
+                    "task_state cannot use durability durable or locked; use working session memory"
+                )
+            }
+            return .session(sessionID: sessionID, write: .taskState)
+        }
+
+        if writeScope == .durable, sessionID != nil {
+            throw BrokerValidationError.invalid("scope durable forbids session_id")
+        }
+        if writeScope == .session, sessionID == nil {
+            throw BrokerValidationError.invalid("scope session requires session_id")
+        }
+
+        let fields = RememberWriteFields(
+            project: semantics.project,
+            repo: semantics.repo,
+            confidence: semantics.confidence,
+            expiresInDays: semantics.expiresInDays,
+            reviewed: semantics.reviewed
+        )
+
+        if let sessionID, writeScope != .durable {
+            let sessionDurability: SessionRememberDurability
+            switch requestedDurability {
+            case .durable, .locked:
+                throw BrokerValidationError.invalid(
+                    "session writes cannot use durability durable or locked; use working session memory"
+                )
+            case .ephemeral:
+                sessionDurability = .ephemeral
+            case .working, .none:
+                sessionDurability = .working
+            }
+            let sessionType = try SessionRememberType(memoryType: resolvedType)
+            return .session(
+                sessionID: sessionID,
+                write: .typed(type: sessionType, durability: sessionDurability, fields: fields)
+            )
+        }
+
+        let durableType = try DurableRememberType(memoryType: resolvedType)
+        let durableDurability: DurableRememberDurability
+        if semantics.lock || requestedDurability == .locked {
+            durableDurability = .locked
+        } else if requestedDurability == .durable {
+            durableDurability = .durable
+        } else if requestedDurability == nil {
+            switch MemorySemantics.defaultDurability(for: resolvedType) {
+            case .locked:
+                durableDurability = .locked
+            case .durable, .working, .ephemeral:
+                durableDurability = .durable
+            }
+        } else {
+            durableDurability = .durable
+        }
+        return .durable(
+            write: DurableRememberWrite(type: durableType, durability: durableDurability, fields: fields)
+        )
+    }
+}
+
+package enum SessionRememberWrite: Sendable, Equatable {
+    /// Session-local working state; durability is always `working`.
+    case taskState
+    case typed(type: SessionRememberType, durability: SessionRememberDurability, fields: RememberWriteFields)
+
+    package var writeSemantics: MemoryWriteSemantics {
+        switch self {
+        case .taskState:
+            return MemoryWriteSemantics(type: .taskState, durability: .working, lock: false)
+        case .typed(let type, let durability, let fields):
+            return MemoryWriteSemantics(
+                type: type.memoryType,
+                durability: durability.memoryDurability,
+                project: fields.project,
+                repo: fields.repo,
+                confidence: fields.confidence,
+                expiresInDays: fields.expiresInDays,
+                reviewed: fields.reviewed,
+                lock: false
+            )
+        }
+    }
+}
+
+package enum SessionRememberType: Sendable, Equatable {
+    case note
+    case userPreference
+    case decision
+    case lesson
+    case handoff
+    case constraint
+    case fact
+
+    package var memoryType: MemoryType {
+        switch self {
+        case .note: return .note
+        case .userPreference: return .userPreference
+        case .decision: return .decision
+        case .lesson: return .lesson
+        case .handoff: return .handoff
+        case .constraint: return .constraint
+        case .fact: return .fact
+        }
+    }
+
+    package init(memoryType: MemoryType) throws {
+        switch memoryType {
+        case .taskState:
+            throw BrokerValidationError.invalid(
+                "task_state requires an active session_id; durable task diaries are not supported"
+            )
+        case .note: self = .note
+        case .userPreference: self = .userPreference
+        case .decision: self = .decision
+        case .lesson: self = .lesson
+        case .handoff: self = .handoff
+        case .constraint: self = .constraint
+        case .fact: self = .fact
+        }
+    }
+}
+
+package enum SessionRememberDurability: Sendable, Equatable {
+    case ephemeral
+    case working
+
+    package var memoryDurability: MemoryDurability {
+        switch self {
+        case .ephemeral: return .ephemeral
+        case .working: return .working
+        }
+    }
+}
+
+package enum DurableRememberType: Sendable, Equatable {
+    case note
+    case userPreference
+    case decision
+    case lesson
+    case handoff
+    case constraint
+    case fact
+
+    package var memoryType: MemoryType {
+        switch self {
+        case .note: return .note
+        case .userPreference: return .userPreference
+        case .decision: return .decision
+        case .lesson: return .lesson
+        case .handoff: return .handoff
+        case .constraint: return .constraint
+        case .fact: return .fact
+        }
+    }
+
+    package init(memoryType: MemoryType) throws {
+        switch memoryType {
+        case .taskState:
+            throw BrokerValidationError.invalid(
+                "task_state requires an active session_id; durable task diaries are not supported"
+            )
+        case .note: self = .note
+        case .userPreference: self = .userPreference
+        case .decision: self = .decision
+        case .lesson: self = .lesson
+        case .handoff: self = .handoff
+        case .constraint: self = .constraint
+        case .fact: self = .fact
+        }
+    }
+}
+
+package enum DurableRememberDurability: Sendable, Equatable {
+    case durable
+    case locked
+
+    package var memoryDurability: MemoryDurability {
+        switch self {
+        case .durable: return .durable
+        case .locked: return .locked
+        }
+    }
+}
+
+package struct RememberWriteFields: Sendable, Equatable {
+    package var project: String?
+    package var repo: String?
+    package var confidence: Float?
+    package var expiresInDays: Int?
+    package var reviewed: Bool
+
+    package init(
+        project: String? = nil,
+        repo: String? = nil,
+        confidence: Float? = nil,
+        expiresInDays: Int? = nil,
+        reviewed: Bool = false
+    ) {
+        self.project = project
+        self.repo = repo
+        self.confidence = confidence
+        self.expiresInDays = expiresInDays
+        self.reviewed = reviewed
+    }
+}
+
+package struct DurableRememberWrite: Sendable, Equatable {
+    package var type: DurableRememberType
+    package var durability: DurableRememberDurability
+    package var fields: RememberWriteFields
+
+    package var writeSemantics: MemoryWriteSemantics {
+        MemoryWriteSemantics(
+            type: type.memoryType,
+            durability: durability.memoryDurability,
+            project: fields.project,
+            repo: fields.repo,
+            confidence: fields.confidence,
+            expiresInDays: fields.expiresInDays,
+            reviewed: fields.reviewed,
+            lock: durability == .locked
+        )
+    }
+}
+
 package enum MemoryMetadataKeys {
     package static let type = "wax.memory_type"
     package static let durability = "wax.durability"
@@ -214,6 +496,32 @@ package enum MemorySemantics {
             normalized[MemoryMetadataKeys.expiresAtMs] = String(expiresAtMs)
         }
         return normalized
+    }
+
+    /// Validates a closed remember destination and returns normalized metadata.
+    package static func validatedWriteMetadata(
+        metadata: [String: String],
+        destination: RememberDestination,
+        activeSession: Bool,
+        inferredScope: MemoryScopeContext?,
+        nowMs: Int64
+    ) throws -> [String: String] {
+        let scope: String
+        switch destination {
+        case .session:
+            scope = "session"
+        case .durable:
+            scope = "durable"
+        }
+        return try validatedWriteMetadata(
+            metadata: metadata,
+            semantics: destination.writeSemantics,
+            sessionID: destination.sessionID,
+            scope: scope,
+            activeSession: activeSession,
+            inferredScope: inferredScope,
+            nowMs: nowMs
+        )
     }
 
     /// Validates the broker write contract and returns normalized metadata.

--- a/Sources/Wax/MemorySemantics.swift
+++ b/Sources/Wax/MemorySemantics.swift
@@ -106,7 +106,7 @@ package enum RememberDestination: Sendable, Equatable {
     /// Maps MCP remember fields into a destination that cannot name illegal combos.
     package static func decode(
         sessionID: UUID?,
-        writeScope: BrokerCommand.RememberWriteScope?,
+        writeScope: RememberWriteScope?,
         semantics: MemoryWriteSemantics,
         metadata: [String: String]
     ) throws -> RememberDestination {
@@ -117,6 +117,13 @@ package enum RememberDestination: Sendable, Equatable {
         let requestedDurability = semantics.lock
             ? MemoryDurability.locked
             : semantics.durability ?? metadataDurability
+        let fields = RememberWriteFields(
+            project: semantics.project,
+            repo: semantics.repo,
+            confidence: semantics.confidence,
+            expiresInDays: semantics.expiresInDays,
+            reviewed: semantics.reviewed
+        )
 
         if resolvedType == .taskState {
             if writeScope == .durable {
@@ -138,7 +145,7 @@ package enum RememberDestination: Sendable, Equatable {
                     "task_state cannot use durability durable or locked; use working session memory"
                 )
             }
-            return .session(sessionID: sessionID, write: .taskState)
+            return .session(sessionID: sessionID, write: .taskState(fields: fields))
         }
 
         if writeScope == .durable, sessionID != nil {
@@ -147,14 +154,6 @@ package enum RememberDestination: Sendable, Equatable {
         if writeScope == .session, sessionID == nil {
             throw BrokerValidationError.invalid("scope session requires session_id")
         }
-
-        let fields = RememberWriteFields(
-            project: semantics.project,
-            repo: semantics.repo,
-            confidence: semantics.confidence,
-            expiresInDays: semantics.expiresInDays,
-            reviewed: semantics.reviewed
-        )
 
         if let sessionID, writeScope != .durable {
             let sessionDurability: SessionRememberDurability
@@ -197,15 +196,29 @@ package enum RememberDestination: Sendable, Equatable {
     }
 }
 
+package enum RememberWriteScope: String, Sendable, Equatable {
+    case session
+    case durable
+}
+
 package enum SessionRememberWrite: Sendable, Equatable {
     /// Session-local working state; durability is always `working`.
-    case taskState
+    case taskState(fields: RememberWriteFields)
     case typed(type: SessionRememberType, durability: SessionRememberDurability, fields: RememberWriteFields)
 
     package var writeSemantics: MemoryWriteSemantics {
         switch self {
-        case .taskState:
-            return MemoryWriteSemantics(type: .taskState, durability: .working, lock: false)
+        case .taskState(let fields):
+            return MemoryWriteSemantics(
+                type: .taskState,
+                durability: .working,
+                project: fields.project,
+                repo: fields.repo,
+                confidence: fields.confidence,
+                expiresInDays: fields.expiresInDays,
+                reviewed: fields.reviewed,
+                lock: false
+            )
         case .typed(let type, let durability, let fields):
             return MemoryWriteSemantics(
                 type: type.memoryType,
@@ -246,7 +259,7 @@ package enum SessionRememberType: Sendable, Equatable {
         switch memoryType {
         case .taskState:
             throw BrokerValidationError.invalid(
-                "task_state requires an active session_id; durable task diaries are not supported"
+                "task_state cannot be a typed session write; use SessionRememberWrite.taskState"
             )
         case .note: self = .note
         case .userPreference: self = .userPreference

--- a/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
+++ b/Tests/WaxMCPServerTests/TaskStateSafetyTests.swift
@@ -59,6 +59,7 @@ func taskStateWritesRequireSessionAndWorkingDurability() async throws {
             ]
         ))
         #expect(!durable.ok)
+        #expect((durable.error ?? "").contains("task_state"))
 
         let locked = await service.handle(.init(
             command: "remember",
@@ -70,6 +71,7 @@ func taskStateWritesRequireSessionAndWorkingDurability() async throws {
             ]
         ))
         #expect(!locked.ok)
+        #expect((locked.error ?? "").contains("task_state"))
 
         let scopeDurable = await service.handle(.init(
             command: "remember",
@@ -81,6 +83,7 @@ func taskStateWritesRequireSessionAndWorkingDurability() async throws {
             ]
         ))
         #expect(!scopeDurable.ok)
+        #expect((scopeDurable.error ?? "").contains("scope durable forbids session_id"))
 
         let valid = await service.handle(.init(
             command: "remember",
@@ -162,6 +165,7 @@ func knowledgeCaptureTaskStateUsesSessionLane() async throws {
             ]
         ))
         #expect(!rejected.ok)
+        #expect((rejected.error ?? "").contains("task_state"))
 
         let started = await service.handle(.init(command: "session_start"))
         let sessionID = try #require(started.payload?.objectValue?["session_id"]?.stringValue)

--- a/Tests/WaxTests/CompactAssemblyTests.swift
+++ b/Tests/WaxTests/CompactAssemblyTests.swift
@@ -72,7 +72,7 @@ func compactAssemblyPackEmptyLanesYieldDefaultSummary() async {
 func compactAssemblyPackDedupesByReference() async {
     let first = compactHit(frameID: 1, text: "one", horizon: .durable, score: 0.9)
     var duplicate = compactHit(frameID: 1, text: "one-dup", horizon: .durable, score: 0.2)
-    duplicate.reference = first.reference
+    duplicate.id = first.id
 
     let packed = await CompactAssembly.pack(
         query: "q",
@@ -160,10 +160,17 @@ private func compactHit(
     horizon: LayeredRecall.Horizon,
     score: Float = 1
 ) -> LayeredRecall.Hit {
-    LayeredRecall.Hit(
-        reference: LayeredRecall.makeMemoryReference(horizon, sessionID: nil, frameID: frameID),
-        horizon: horizon,
-        frameID: frameID,
+    let id: MemoryID
+    switch horizon {
+    case .durable:
+        id = .durable(frameID: frameID)
+    case .working:
+        id = .working(sessionID: UUID(), frameID: frameID)
+    case .episodic:
+        id = .episodic(sessionID: UUID(), frameID: frameID)
+    }
+    return LayeredRecall.Hit(
+        id: id,
         score: score,
         text: text,
         preview: text,

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -116,7 +116,7 @@ func layeredRecallFrameFilterInjectsProjectMetadataForScopedRetrieval() {
 @Test
 func layeredRecallMakeMemoryReferenceFormatsHorizons() {
     let sessionID = UUID()
-    #expect(LayeredRecall.makeMemoryReference(.durable, frameID: 42) == "durable:42")
+    #expect(LayeredRecall.makeMemoryReference(frameID: 42) == "durable:42")
     #expect(
         LayeredRecall.makeMemoryReference(.working, sessionID: sessionID, frameID: 7)
             == "working:\(sessionID.uuidString):7"
@@ -132,7 +132,7 @@ func layeredRecallHitMapsRAGItemKindAndSourcesWithoutStringRoundTrip() {
         sources: [.text],
         text: "hello"
     )
-    let durable = LayeredRecall.hit(from: item, horizon: .durable)
+    let durable = LayeredRecall.hit(from: item)
     #expect(durable.kind == .snippet)
     #expect(durable.sources == [.text])
     let working = LayeredRecall.hit(from: item, horizon: .working, sessionID: UUID())

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -116,11 +116,28 @@ func layeredRecallFrameFilterInjectsProjectMetadataForScopedRetrieval() {
 @Test
 func layeredRecallMakeMemoryReferenceFormatsHorizons() {
     let sessionID = UUID()
-    #expect(LayeredRecall.makeMemoryReference(.durable, sessionID: nil, frameID: 42) == "durable:42")
+    #expect(LayeredRecall.makeMemoryReference(.durable, frameID: 42) == "durable:42")
     #expect(
         LayeredRecall.makeMemoryReference(.working, sessionID: sessionID, frameID: 7)
             == "working:\(sessionID.uuidString):7"
     )
+}
+
+@Test
+func layeredRecallHitMapsRAGItemKindAndSourcesWithoutStringRoundTrip() {
+    let item = RAGContext.Item(
+        kind: .snippet,
+        frameId: 11,
+        score: 1,
+        sources: [.text],
+        text: "hello"
+    )
+    let durable = LayeredRecall.hit(from: item, horizon: .durable)
+    #expect(durable.kind == .snippet)
+    #expect(durable.sources == [.text])
+    let working = LayeredRecall.hit(from: item, horizon: .working, sessionID: UUID())
+    #expect(working.kind == .snippet)
+    #expect(working.sources == [.text])
 }
 
 private func layeredHit(
@@ -130,10 +147,17 @@ private func layeredHit(
     horizon: LayeredRecall.Horizon,
     metadata: [String: String] = [:]
 ) -> LayeredRecall.Hit {
-    LayeredRecall.Hit(
-        reference: LayeredRecall.makeMemoryReference(horizon, sessionID: nil, frameID: frameID),
-        horizon: horizon,
-        frameID: frameID,
+    let id: MemoryID
+    switch horizon {
+    case .durable:
+        id = .durable(frameID: frameID)
+    case .working:
+        id = .working(sessionID: UUID(), frameID: frameID)
+    case .episodic:
+        id = .episodic(sessionID: UUID(), frameID: frameID)
+    }
+    return LayeredRecall.Hit(
+        id: id,
         score: score,
         text: text,
         preview: text,

--- a/Tests/WaxTests/MemoryIDTests.swift
+++ b/Tests/WaxTests/MemoryIDTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func memoryIDParseRoundTripsDurableWire() throws {
+    let id = try MemoryID.parse("durable:42")
+    #expect(id == .durable(frameID: 42))
+    #expect(id.wire == "durable:42")
+    #expect(id.horizon == .durable)
+    #expect(id.sessionID == nil)
+    #expect(id.frameID == 42)
+}
+
+@Test
+func memoryIDParseRoundTripsWorkingWire() throws {
+    let sessionID = UUID()
+    let raw = "working:\(sessionID.uuidString):7"
+    let id = try MemoryID.parse(raw)
+    #expect(id == .working(sessionID: sessionID, frameID: 7))
+    #expect(id.wire == raw)
+    #expect(id.horizon == .working)
+    #expect(id.sessionID == sessionID)
+}
+
+@Test
+func memoryIDParseRoundTripsEpisodicWire() throws {
+    let sessionID = UUID()
+    let raw = "episodic:\(sessionID.uuidString):3"
+    let id = try MemoryID.parse(raw)
+    #expect(id == .episodic(sessionID: sessionID, frameID: 3))
+    #expect(id.wire == raw)
+}
+
+@Test
+func memoryIDParseRejectsDurableWithSessionToken() {
+    let sessionID = UUID()
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("durable:\(sessionID.uuidString):1")
+    }
+}
+
+@Test
+func memoryIDParseRejectsWorkingWithoutSession() {
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("working:1")
+    }
+}
+
+@Test
+func memoryIDWireNeverEmitsUnknownSessionToken() {
+    let sessionID = UUID()
+    #expect(!MemoryID.working(sessionID: sessionID, frameID: 1).wire.contains("unknown"))
+    #expect(!MemoryID.episodic(sessionID: sessionID, frameID: 1).wire.contains("unknown"))
+    #expect(!MemoryID.durable(frameID: 9).wire.contains("unknown"))
+}

--- a/Tests/WaxTests/MemoryIDTests.swift
+++ b/Tests/WaxTests/MemoryIDTests.swift
@@ -54,3 +54,13 @@ func memoryIDWireNeverEmitsUnknownSessionToken() {
     #expect(!MemoryID.episodic(sessionID: sessionID, frameID: 1).wire.contains("unknown"))
     #expect(!MemoryID.durable(frameID: 9).wire.contains("unknown"))
 }
+
+@Test
+func memoryIDParseRejectsUnknownSessionToken() {
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("working:unknown:1")
+    }
+    #expect(throws: BrokerValidationError.self) {
+        try MemoryID.parse("episodic:unknown:1")
+    }
+}

--- a/Tests/WaxTests/MemoryWriteDestinationTests.swift
+++ b/Tests/WaxTests/MemoryWriteDestinationTests.swift
@@ -16,7 +16,10 @@ func rememberDestinationSessionTaskStateForcesWorking() throws {
         return
     }
     #expect(decodedSessionID == sessionID)
-    #expect(write == .taskState)
+    guard case .taskState = write else {
+        Issue.record("expected taskState write")
+        return
+    }
     #expect(destination.writeSemantics.type == .taskState)
     #expect(destination.writeSemantics.durability == .working)
     #expect(destination.writeSemantics.lock == false)
@@ -42,7 +45,7 @@ func rememberDestinationRejectsTaskStateWithoutSession() {
         )
         Issue.record("expected throw")
     } catch let error as BrokerValidationError {
-        #expect(String(describing: error).contains("task_state"))
+        #expect(String(describing: error).contains("task_state requires an active session_id"))
     } catch {
         Issue.record("unexpected error \(error)")
     }
@@ -60,7 +63,7 @@ func rememberDestinationRejectsTaskStateDurableLockedAndDurableScope() {
         )
         Issue.record("expected throw")
     } catch let error as BrokerValidationError {
-        #expect(String(describing: error).contains("task_state"))
+        #expect(String(describing: error).contains("task_state cannot use durability durable or locked"))
     } catch {
         Issue.record("unexpected error \(error)")
     }
@@ -74,7 +77,7 @@ func rememberDestinationRejectsTaskStateDurableLockedAndDurableScope() {
         )
         Issue.record("expected throw")
     } catch let error as BrokerValidationError {
-        #expect(String(describing: error).contains("task_state"))
+        #expect(String(describing: error).contains("task_state cannot use durability durable or locked"))
     } catch {
         Issue.record("unexpected error \(error)")
     }
@@ -88,7 +91,7 @@ func rememberDestinationRejectsTaskStateDurableLockedAndDurableScope() {
         )
         Issue.record("expected throw")
     } catch let error as BrokerValidationError {
-        #expect(String(describing: error).contains("task_state"))
+        #expect(String(describing: error).contains("task_state cannot use scope durable"))
     } catch {
         Issue.record("unexpected error \(error)")
     }
@@ -147,7 +150,7 @@ func rememberWireDecodeMapsClosedDestination() throws {
         Issue.record("expected remember")
         return
     }
-    #expect(remember.destination == .session(sessionID: sessionID, write: .taskState))
+    #expect(remember.destination == .session(sessionID: sessionID, write: .taskState(fields: RememberWriteFields())))
     #expect(remember.sessionID == sessionID)
     #expect(remember.writeScope == .session)
     #expect(remember.writeSemantics.type == .taskState)

--- a/Tests/WaxTests/MemoryWriteDestinationTests.swift
+++ b/Tests/WaxTests/MemoryWriteDestinationTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func rememberDestinationSessionTaskStateForcesWorking() throws {
+    let sessionID = UUID()
+    let destination = try RememberDestination.decode(
+        sessionID: sessionID,
+        writeScope: .session,
+        semantics: MemoryWriteSemantics(type: .taskState, durability: .ephemeral),
+        metadata: [:]
+    )
+    guard case .session(let decodedSessionID, let write) = destination else {
+        Issue.record("expected session destination")
+        return
+    }
+    #expect(decodedSessionID == sessionID)
+    #expect(write == .taskState)
+    #expect(destination.writeSemantics.type == .taskState)
+    #expect(destination.writeSemantics.durability == .working)
+    #expect(destination.writeSemantics.lock == false)
+    #expect(destination.sessionID == sessionID)
+}
+
+@Test
+func rememberDestinationRejectsTaskStateWithoutSession() {
+    #expect(throws: BrokerValidationError.self) {
+        _ = try RememberDestination.decode(
+            sessionID: nil,
+            writeScope: nil,
+            semantics: MemoryWriteSemantics(type: .taskState),
+            metadata: [:]
+        )
+    }
+    do {
+        _ = try RememberDestination.decode(
+            sessionID: nil,
+            writeScope: nil,
+            semantics: MemoryWriteSemantics(type: .taskState),
+            metadata: [:]
+        )
+        Issue.record("expected throw")
+    } catch let error as BrokerValidationError {
+        #expect(String(describing: error).contains("task_state"))
+    } catch {
+        Issue.record("unexpected error \(error)")
+    }
+}
+
+@Test
+func rememberDestinationRejectsTaskStateDurableLockedAndDurableScope() {
+    let sessionID = UUID()
+    do {
+        _ = try RememberDestination.decode(
+            sessionID: sessionID,
+            writeScope: nil,
+            semantics: MemoryWriteSemantics(type: .taskState, durability: .durable),
+            metadata: [:]
+        )
+        Issue.record("expected throw")
+    } catch let error as BrokerValidationError {
+        #expect(String(describing: error).contains("task_state"))
+    } catch {
+        Issue.record("unexpected error \(error)")
+    }
+
+    do {
+        _ = try RememberDestination.decode(
+            sessionID: sessionID,
+            writeScope: nil,
+            semantics: MemoryWriteSemantics(type: .taskState, lock: true),
+            metadata: [:]
+        )
+        Issue.record("expected throw")
+    } catch let error as BrokerValidationError {
+        #expect(String(describing: error).contains("task_state"))
+    } catch {
+        Issue.record("unexpected error \(error)")
+    }
+
+    do {
+        _ = try RememberDestination.decode(
+            sessionID: sessionID,
+            writeScope: .durable,
+            semantics: MemoryWriteSemantics(type: .taskState),
+            metadata: [:]
+        )
+        Issue.record("expected throw")
+    } catch let error as BrokerValidationError {
+        #expect(String(describing: error).contains("task_state"))
+    } catch {
+        Issue.record("unexpected error \(error)")
+    }
+}
+
+@Test
+func rememberDestinationDurableHasNoSessionID() throws {
+    let destination = try RememberDestination.decode(
+        sessionID: nil,
+        writeScope: .durable,
+        semantics: MemoryWriteSemantics(type: .decision, durability: .durable),
+        metadata: [:]
+    )
+    guard case .durable(let write) = destination else {
+        Issue.record("expected durable destination")
+        return
+    }
+    #expect(write.type == .decision)
+    #expect(write.durability == .durable)
+    #expect(destination.sessionID == nil)
+}
+
+@Test
+func rememberWireDecodeRejectsScopeDurableWithSessionID() {
+    do {
+        _ = try BrokerCommand.decode(
+            command: "remember",
+            arguments: [
+                "content": .string("x"),
+                "session_id": .string("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"),
+                "scope": .string("durable"),
+            ]
+        )
+        Issue.record("expected throw")
+    } catch let error as BrokerValidationError {
+        #expect(String(describing: error).contains("scope durable forbids session_id"))
+    } catch {
+        Issue.record("unexpected error \(error)")
+    }
+}
+
+@Test
+func rememberWireDecodeMapsClosedDestination() throws {
+    let sessionID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    let decoded = try BrokerCommand.decode(
+        command: "remember",
+        arguments: [
+            "content": .string("working task state"),
+            "session_id": .string(sessionID.uuidString),
+            "scope": .string("session"),
+            "memory_type": .string("task_state"),
+            "durability": .string("ephemeral"),
+        ]
+    )
+    guard case .remember(let remember) = decoded else {
+        Issue.record("expected remember")
+        return
+    }
+    #expect(remember.destination == .session(sessionID: sessionID, write: .taskState))
+    #expect(remember.sessionID == sessionID)
+    #expect(remember.writeScope == .session)
+    #expect(remember.writeSemantics.type == .taskState)
+    #expect(remember.writeSemantics.durability == .working)
+}


### PR DESCRIPTION
Stacked on T1 (`arch/f876e26c/T1`, #181). After JSON decode, remember/knowledge_capture writes are a closed `RememberDestination` (session vs durable). `task_state` cannot be durable/locked in-process. Harvest skips leftovers that cannot decode as durable. MCP JSON field names and on-disk `wax.*` keys are unchanged; existing validation sentences remain.

**Ticket:** T2 from `spec/spec-architecture-type-system-seams.md` (architecture pipeline run f876e26c)
**Depends on:** T1 / #181
**Reviews:** swift-adversarial-pr-review (fix pass) + final pass — APPROVE
**Gates:** `MemoryWriteDestinationTests` (6), `BrokerCommandDecodeTests` (27), `TaskStateSafetyTests` with `--traits MCPServer` (6)

Does not change public `import Wax` API.