### PR TITLE
refactor(broker): extract EndedSessionStore from AgentBrokerService

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -20,6 +20,7 @@ package actor AgentBrokerService {
     let factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)?
     let brokerInstanceID = UUID().uuidString
     let virtualSessions: VirtualSessionStore
+    let endedSessions: DiskEndedSessionStore
     private let commandMutex = AsyncMutex()
     // A remember may wait for deferred embedding readiness. Keep that wait
     // from blocking unrelated reads while still serializing concurrent writes.
@@ -84,6 +85,16 @@ package actor AgentBrokerService {
         self.embeddingRequest = request
         self.readiness = readiness
         self.factoryOverride = factoryOverride
+        self.endedSessions = DiskEndedSessionStore(
+            sessionRootURL: sessionRootURL,
+            noEmbedder: noEmbedder,
+            embedderChoice: embedderChoice,
+            enableAccessStatsScoring: enableAccessStatsScoring,
+            scopeContext: scopeContext,
+            embedderTuning: embedderTuning,
+            readiness: readiness,
+            factoryOverride: factoryOverride
+        )
         let capturedAccessStats = enableAccessStatsScoring
         let capturedScope = scopeContext
         let capturedRequest = request
@@ -572,49 +583,6 @@ extension AgentBrokerService {
             payload["scope_miss_message"] = .string(scopeMissMessage)
         }
         return .object(payload)
-    }
-
-    package static func filterRecallItemsByProject(
-        _ items: [RAGContext.Item],
-        project: String?,
-        repo: String?
-    ) -> [RAGContext.Item] {
-        LayeredRecall.filterRecallItemsByProject(items, project: project, repo: repo)
-    }
-
-    /// Returns items whose `wax.project` or `wax.repo` metadata matches the given identity.
-    package static func recallItems(
-        _ items: [RAGContext.Item],
-        matchingProject project: String?,
-        repo: String?
-    ) -> [RAGContext.Item] {
-        filterRecallItemsByProject(items, project: project, repo: repo)
-    }
-
-    /// Merges project/repo hard-filter into an existing frame filter so unified search
-    /// over-fetches and excludes foreign frames before top-K is finalized.
-    package static func frameFilterByAddingProjectScope(
-        _ base: FrameFilter?,
-        project: String?,
-        repo: String?
-    ) -> FrameFilter? {
-        LayeredRecall.frameFilterForScopedRetrieval(
-            base: base,
-            scope: .project,
-            identity: LayeredRecall.Identity(project: project, repo: repo)
-        )
-    }
-
-    package static func mergeRecallItems(
-        sessionItems: [RAGContext.Item],
-        durableItems: [RAGContext.Item],
-        limit: Int
-    ) -> [RAGContext.Item] {
-        LayeredRecall.mergeRecallItems(
-            sessionItems: sessionItems,
-            durableItems: durableItems,
-            limit: limit
-        )
     }
 
     func search(_ command: BrokerCommand.Search) async throws -> AgentBrokerValue {
@@ -1589,20 +1557,20 @@ extension AgentBrokerService {
         let report: SessionHarvest.Report
         if FileManager.default.fileExists(atPath: storeURL.path) {
             do {
-                report = try await openAdhocMemory(
-                    at: storeURL,
-                    structuredMemoryEnabled: false,
-                    noEmbedder: noEmbedder
-                ) { memory in
+                let longTerm = longTermMemory
+                let scope = scopeContext
+                let settings = promotionSettings
+                let now = Self.nowMs()
+                report = try await endedSessions.withMemory(at: storeURL) { memory in
                     await SessionHarvest.run(
                         sessionMemory: memory,
-                        longTermMemory: self.longTermMemory,
+                        longTermMemory: longTerm,
                         sessionID: sessionID,
                         manifest: manifest,
                         events: events,
-                        scope: self.scopeContext,
-                        settings: self.promotionSettings,
-                        nowMs: Self.nowMs()
+                        scope: scope,
+                        settings: settings,
+                        nowMs: now
                     )
                 }
             } catch {
@@ -2049,9 +2017,8 @@ extension AgentBrokerService {
         } else {
             buildSummary = nil
         }
-        let execution = try await openAdhocMemory(
+        let execution = try await endedSessions.withMemory(
             at: corpusStoreURL,
-            structuredMemoryEnabled: false,
             noEmbedder: corpusNoEmbedder
         ) { memory in
             try await memory.searchExecution(
@@ -2329,8 +2296,6 @@ extension AgentBrokerService {
 
     func layeredRecallStores() -> LayeredRecall.Stores {
         let sessionsSnapshot = activeSessions
-        let noEmbedderFlag = noEmbedder
-        let sessionRoot = sessionRootURL
 
         return LayeredRecall.Stores(
             longTermMemory: longTermMemory,
@@ -2368,95 +2333,7 @@ extension AgentBrokerService {
             canonicalFrameID: { frameID, memory in
                 await self.bestEffortCanonicalDocumentFrameID(for: frameID, memory: memory)
             },
-            endedManifests: {
-                try BrokerSessionPersistence.listManifests(rootURL: sessionRoot)
-            },
-            searchEndedSession: { manifest, query, mode, topK in
-                let sessionURL = URL(fileURLWithPath: manifest.storePath)
-                guard FileManager.default.fileExists(atPath: sessionURL.path) else { return [] }
-                let eventLogURL = URL(fileURLWithPath: manifest.eventLogPath)
-                let execution = try await self.openAdhocMemory(
-                    at: sessionURL,
-                    structuredMemoryEnabled: false,
-                    noEmbedder: noEmbedderFlag
-                ) { memory in
-                    try await memory.searchExecution(
-                        query: query,
-                        mode: mode,
-                        topK: topK,
-                        frameFilter: nil,
-                        timeRange: nil
-                    )
-                }
-                let signals = BrokerSessionPersistence.recallSignals(
-                    from: try BrokerSessionPersistence.loadEvents(from: eventLogURL)
-                )
-                var laneHits: [LayeredRecall.EpisodicLaneHit] = []
-                for hit in execution.hits {
-                    let canonicalFrameID = try await self.openAdhocMemory(
-                        at: sessionURL,
-                        structuredMemoryEnabled: false,
-                        noEmbedder: noEmbedderFlag,
-                        body: { memory in
-                            await self.bestEffortCanonicalDocumentFrameID(for: hit.frameId, memory: memory)
-                        }
-                    )
-                    let signal = canonicalFrameID.flatMap { signals[$0] } ?? signals[hit.frameId]
-                    laneHits.append(
-                        LayeredRecall.EpisodicLaneHit(
-                            frameID: hit.frameId,
-                            score: hit.score,
-                            previewText: hit.previewText,
-                            metadata: hit.metadata,
-                            explanations: hit.explanations,
-                            canonicalFrameID: canonicalFrameID,
-                            recallCount: signal.map(\.recallCount),
-                            uniqueQueryCount: signal.map(\.uniqueQueryCount)
-                        )
-                    )
-                }
-                return laneHits
-            },
-            recallEndedSession: { manifest, query, mode, topK, frameFilter in
-                let sessionURL = URL(fileURLWithPath: manifest.storePath)
-                return try await self.openAdhocMemory(
-                    at: sessionURL,
-                    structuredMemoryEnabled: false,
-                    noEmbedder: noEmbedderFlag
-                ) { memory in
-                    let items = try await memory.recallExecution(
-                        query: query,
-                        mode: mode,
-                        frameFilter: frameFilter,
-                        timeRange: nil,
-                        topK: topK
-                    ).context.items
-                    var hits: [LayeredRecall.Hit] = []
-                    hits.reserveCapacity(items.count)
-                    for item in items {
-                        let canonicalFrameID = await self.bestEffortCanonicalDocumentFrameID(
-                            for: item.frameId,
-                            memory: memory
-                        ) ?? item.frameId
-                        hits.append(
-                            LayeredRecall.Hit(
-                                id: .episodic(sessionID: manifest.sessionID, frameID: canonicalFrameID),
-                                agentID: manifest.agentID,
-                                runID: manifest.runID,
-                                score: item.score,
-                                text: item.text,
-                                preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
-                                metadata: item.metadata,
-                                explanations: ["recent session episode"] + item.explanations,
-                                timestampMs: manifest.updatedAtMs,
-                                kind: item.kind,
-                                sources: item.sources
-                            )
-                        )
-                    }
-                    return hits
-                }
-            },
+            endedSessions: endedSessions,
             nowMs: { Self.nowMs() }
         )
     }
@@ -2476,14 +2353,13 @@ extension AgentBrokerService {
                 timestampMs: document.timestampMs
             )
         case .working(let sessionID, let frameID), .episodic(let sessionID, let frameID):
-            let manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)
-            let loader: (MemoryOrchestrator) async throws -> LayeredMemoryHit = { memory in
-                let document = try await self.requireDocument(frameID: frameID, memory: memory)
-                await memory.recordAccess(frameId: document.frameId)
+            if let state = activeSessions[sessionID] {
+                let document = try await requireDocument(frameID: frameID, memory: state.memory)
+                await state.memory.recordAccess(frameId: document.frameId)
                 return LayeredMemoryHit(
                     id: MemoryID.make(horizon: reference.horizon, sessionID: sessionID, frameID: frameID),
-                    agentID: manifest.agentID,
-                    runID: manifest.runID,
+                    agentID: state.manifest.agentID,
+                    runID: state.manifest.runID,
                     score: 0,
                     text: document.text,
                     preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
@@ -2492,14 +2368,19 @@ extension AgentBrokerService {
                     timestampMs: document.timestampMs
                 )
             }
-            if let state = activeSessions[sessionID] {
-                return try await loader(state.memory)
-            }
-            return try await openAdhocMemory(
-                at: URL(fileURLWithPath: manifest.storePath),
-                structuredMemoryEnabled: false,
-                noEmbedder: noEmbedder,
-                body: loader
+            let document = try await endedSessions.document(
+                EndedSessionDocumentQuery(sessionID: sessionID, frameID: frameID)
+            )
+            return LayeredMemoryHit(
+                id: MemoryID.make(horizon: reference.horizon, sessionID: sessionID, frameID: frameID),
+                agentID: document.agentID,
+                runID: document.runID,
+                score: 0,
+                text: document.text,
+                preview: MemorySemantics.summarizeCandidate(document.text, maxLength: 180),
+                metadata: document.metadata,
+                explanations: [reference.horizon == .working ? "current session" : "recent session episode"],
+                timestampMs: document.timestampMs
             )
         }
     }
@@ -2705,40 +2586,6 @@ extension AgentBrokerService {
 
     func openSessionMemory(at url: URL) async throws -> MemoryOrchestrator {
         try await virtualSessions.openExistingSessionMemory(at: url)
-    }
-
-    func openAdhocMemory<T: Sendable>(
-        at url: URL,
-        structuredMemoryEnabled: Bool,
-        noEmbedder: Bool,
-        body: (MemoryOrchestrator) async throws -> T
-    ) async throws -> T {
-        var config = OrchestratorConfig.default
-        config.enableStructuredMemory = structuredMemoryEnabled
-        config.enableAccessStatsScoring = enableAccessStatsScoring
-        config.defaultScopeContext = scopeContext
-        let request = try HostEmbeddingReadiness.request(
-            noEmbedder: noEmbedder,
-            requireVector: false,
-            embedderChoice: embedderChoice,
-            options: BuiltInEmbeddingProviderOptions(tuning: embedderTuning)
-        )
-        let memory = try await EmbeddingReadinessBinding.openOrchestrator(
-            at: url,
-            config: config,
-            request: request,
-            waxOptions: CommandLineEmbedderFactory.waxOptions(),
-            readiness: readiness,
-            factoryOverride: noEmbedder ? nil : factoryOverride
-        )
-        do {
-            let result = try await body(memory)
-            try await memory.close()
-            return result
-        } catch {
-            try? await memory.close()
-            throw error
-        }
     }
 
     func writeScope(for sessionID: UUID?, clientCWD: String? = nil) -> MemoryScopeContext {

--- a/Sources/Wax/Broker/EndedSessionStore.swift
+++ b/Sources/Wax/Broker/EndedSessionStore.swift
@@ -1,0 +1,341 @@
+import Foundation
+import WaxCore
+import WaxVectorSearch
+
+package struct EndedSessionSearchQuery: Sendable {
+    package var manifest: BrokerSessionManifest
+    package var query: String
+    package var mode: Memory.RetrievalMode
+    package var topK: Int
+
+    package init(
+        manifest: BrokerSessionManifest,
+        query: String,
+        mode: Memory.RetrievalMode,
+        topK: Int
+    ) {
+        self.manifest = manifest
+        self.query = query
+        self.mode = mode
+        self.topK = topK
+    }
+}
+
+package struct EndedSessionRecallQuery: Sendable {
+    package var manifest: BrokerSessionManifest
+    package var query: String
+    package var mode: Memory.RetrievalMode
+    package var topK: Int
+    package var frameFilter: FrameFilter?
+
+    package init(
+        manifest: BrokerSessionManifest,
+        query: String,
+        mode: Memory.RetrievalMode,
+        topK: Int,
+        frameFilter: FrameFilter?
+    ) {
+        self.manifest = manifest
+        self.query = query
+        self.mode = mode
+        self.topK = topK
+        self.frameFilter = frameFilter
+    }
+}
+
+package struct EndedSessionDocumentQuery: Sendable {
+    package var sessionID: UUID
+    package var frameID: UInt64
+
+    package init(sessionID: UUID, frameID: UInt64) {
+        self.sessionID = sessionID
+        self.frameID = frameID
+    }
+}
+
+package struct EndedSessionDocument: Sendable, Equatable {
+    package var sessionID: UUID
+    package var frameID: UInt64
+    package var text: String
+    package var metadata: [String: String]
+    package var timestampMs: Int64
+    package var agentID: String?
+    package var runID: String?
+
+    package init(
+        sessionID: UUID,
+        frameID: UInt64,
+        text: String,
+        metadata: [String: String],
+        timestampMs: Int64,
+        agentID: String? = nil,
+        runID: String? = nil
+    ) {
+        self.sessionID = sessionID
+        self.frameID = frameID
+        self.text = text
+        self.metadata = metadata
+        self.timestampMs = timestampMs
+        self.agentID = agentID
+        self.runID = runID
+    }
+}
+
+/// Ended virtual-session I/O: list manifests, search, recall, get-by-id.
+/// Working-lane and durable `MemoryOrchestrator` stay outside this module.
+package protocol EndedSessionStore: Sendable {
+    func listManifests() throws -> [BrokerSessionManifest]
+    func search(_ query: EndedSessionSearchQuery) async throws -> [LayeredRecall.EpisodicLaneHit]
+    func recall(_ query: EndedSessionRecallQuery) async throws -> [LayeredRecall.Hit]
+    func document(_ query: EndedSessionDocumentQuery) async throws -> EndedSessionDocument
+}
+
+package struct InMemoryEndedSessionStore: EndedSessionStore {
+    package var manifests: [BrokerSessionManifest]
+    package var searchHits: [UUID: [LayeredRecall.EpisodicLaneHit]]
+    package var recallHits: [UUID: [LayeredRecall.Hit]]
+    package var documents: [EndedSessionDocument]
+
+    package init(
+        manifests: [BrokerSessionManifest] = [],
+        searchHits: [UUID: [LayeredRecall.EpisodicLaneHit]] = [:],
+        recallHits: [UUID: [LayeredRecall.Hit]] = [:],
+        documents: [EndedSessionDocument] = []
+    ) {
+        self.manifests = manifests
+        self.searchHits = searchHits
+        self.recallHits = recallHits
+        self.documents = documents
+    }
+
+    package func listManifests() throws -> [BrokerSessionManifest] {
+        manifests
+    }
+
+    package func search(_ query: EndedSessionSearchQuery) async throws -> [LayeredRecall.EpisodicLaneHit] {
+        searchHits[query.manifest.sessionID] ?? []
+    }
+
+    package func recall(_ query: EndedSessionRecallQuery) async throws -> [LayeredRecall.Hit] {
+        recallHits[query.manifest.sessionID] ?? []
+    }
+
+    package func document(_ query: EndedSessionDocumentQuery) async throws -> EndedSessionDocument {
+        guard let document = documents.first(where: {
+            $0.sessionID == query.sessionID && $0.frameID == query.frameID
+        }) else {
+            throw BrokerValidationError.invalid("No memory document found for frame_id \(query.frameID)")
+        }
+        return document
+    }
+}
+
+package struct DiskEndedSessionStore: EndedSessionStore {
+    package let sessionRootURL: URL
+    private let enableAccessStatsScoring: Bool
+    private let scopeContext: MemoryScopeContext
+    private let defaultNoEmbedder: Bool
+    private let embedderChoice: String
+    private let embedderTuning: CommandLineEmbedderRuntimeTuning
+    private let readiness: EmbeddingReadiness
+    private let factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)?
+
+    package init(
+        sessionRootURL: URL,
+        noEmbedder: Bool,
+        embedderChoice: String = "auto",
+        enableAccessStatsScoring: Bool = true,
+        scopeContext: MemoryScopeContext = MemoryScopeContext(),
+        embedderTuning: CommandLineEmbedderRuntimeTuning = .fromEnvironment(),
+        readiness: EmbeddingReadiness = .shared,
+        factoryOverride: (@Sendable () async throws -> any EmbeddingProvider)? = nil
+    ) {
+        self.sessionRootURL = sessionRootURL
+        self.enableAccessStatsScoring = enableAccessStatsScoring
+        self.scopeContext = scopeContext
+        self.defaultNoEmbedder = noEmbedder
+        self.embedderChoice = embedderChoice
+        self.embedderTuning = embedderTuning
+        self.readiness = readiness
+        self.factoryOverride = factoryOverride
+    }
+
+    package func listManifests() throws -> [BrokerSessionManifest] {
+        guard FileManager.default.fileExists(atPath: sessionRootURL.path) else { return [] }
+        return try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
+    }
+
+    package func loadManifest(sessionID: UUID) throws -> BrokerSessionManifest {
+        try BrokerSessionPersistence.loadManifest(rootURL: sessionRootURL, sessionID: sessionID)
+    }
+
+    package func search(_ query: EndedSessionSearchQuery) async throws -> [LayeredRecall.EpisodicLaneHit] {
+        guard let sessionURL = Self.resolvedStoreFileURL(
+            path: query.manifest.storePath,
+            reclaimedAtMs: query.manifest.reclaimedAtMs
+        ) else { return [] }
+        return try await withMemory(at: sessionURL) { memory in
+            let execution = try await memory.searchExecution(
+                query: query.query,
+                mode: query.mode,
+                topK: query.topK,
+                frameFilter: nil,
+                timeRange: nil
+            )
+            let signals = BrokerSessionPersistence.recallSignals(
+                from: try BrokerSessionPersistence.loadEvents(
+                    from: URL(fileURLWithPath: query.manifest.eventLogPath)
+                )
+            )
+            var laneHits: [LayeredRecall.EpisodicLaneHit] = []
+            laneHits.reserveCapacity(execution.hits.count)
+            for hit in execution.hits {
+                let canonicalFrameID = await canonicalFrameID(for: hit.frameId, memory: memory)
+                let signal = canonicalFrameID.flatMap { signals[$0] } ?? signals[hit.frameId]
+                laneHits.append(
+                    LayeredRecall.EpisodicLaneHit(
+                        frameID: hit.frameId,
+                        score: hit.score,
+                        previewText: hit.previewText,
+                        metadata: hit.metadata,
+                        explanations: hit.explanations,
+                        canonicalFrameID: canonicalFrameID,
+                        recallCount: signal.map(\.recallCount),
+                        uniqueQueryCount: signal.map(\.uniqueQueryCount)
+                    )
+                )
+            }
+            return laneHits
+        }
+    }
+
+    package func recall(_ query: EndedSessionRecallQuery) async throws -> [LayeredRecall.Hit] {
+        guard let sessionURL = Self.resolvedStoreFileURL(
+            path: query.manifest.storePath,
+            reclaimedAtMs: query.manifest.reclaimedAtMs
+        ) else { return [] }
+        return try await withMemory(at: sessionURL) { memory in
+            let items = try await memory.recallExecution(
+                query: query.query,
+                mode: query.mode,
+                frameFilter: query.frameFilter,
+                timeRange: nil,
+                topK: query.topK
+            ).context.items
+            var hits: [LayeredRecall.Hit] = []
+            hits.reserveCapacity(items.count)
+            for item in items {
+                let canonicalFrameID = await canonicalFrameID(for: item.frameId, memory: memory)
+                    ?? item.frameId
+                hits.append(
+                    LayeredRecall.Hit(
+                        id: .episodic(sessionID: query.manifest.sessionID, frameID: canonicalFrameID),
+                        agentID: query.manifest.agentID,
+                        runID: query.manifest.runID,
+                        score: item.score,
+                        text: item.text,
+                        preview: MemorySemantics.summarizeCandidate(item.text, maxLength: 180),
+                        metadata: item.metadata,
+                        explanations: ["recent session episode"] + item.explanations,
+                        timestampMs: query.manifest.updatedAtMs,
+                        kind: item.kind,
+                        sources: item.sources
+                    )
+                )
+            }
+            return hits
+        }
+    }
+
+    package func document(_ query: EndedSessionDocumentQuery) async throws -> EndedSessionDocument {
+        let manifest = try loadManifest(sessionID: query.sessionID)
+        guard let sessionURL = Self.resolvedStoreFileURL(
+            path: manifest.storePath,
+            reclaimedAtMs: manifest.reclaimedAtMs
+        ) else {
+            throw BrokerValidationError.invalid(
+                "No ended-session store for session_id \(query.sessionID.uuidString)"
+            )
+        }
+        return try await withMemory(at: sessionURL) { memory in
+            guard let document = try await memory.corpusSourceDocuments()
+                .first(where: { $0.frameId == query.frameID })
+            else {
+                throw BrokerValidationError.invalid("No memory document found for frame_id \(query.frameID)")
+            }
+            await memory.recordAccess(frameId: document.frameId)
+            return EndedSessionDocument(
+                sessionID: query.sessionID,
+                frameID: document.frameId,
+                text: document.text,
+                metadata: document.metadata,
+                timestampMs: document.timestampMs,
+                agentID: manifest.agentID,
+                runID: manifest.runID
+            )
+        }
+    }
+
+    package func withMemory<T: Sendable>(
+        at url: URL,
+        noEmbedder: Bool? = nil,
+        _ body: @Sendable (MemoryOrchestrator) async throws -> T
+    ) async throws -> T {
+        guard let fileURL = Self.resolvedStoreFileURL(path: url.path, reclaimedAtMs: nil) else {
+            throw BrokerValidationError.invalid(
+                "Ended-session store path is missing or not a file: \(url.path)"
+            )
+        }
+        var config = OrchestratorConfig.default
+        config.enableStructuredMemory = false
+        config.enableAccessStatsScoring = enableAccessStatsScoring
+        config.defaultScopeContext = scopeContext
+        let request = try HostEmbeddingReadiness.request(
+            noEmbedder: noEmbedder ?? defaultNoEmbedder,
+            requireVector: false,
+            embedderChoice: embedderChoice,
+            options: BuiltInEmbeddingProviderOptions(tuning: embedderTuning)
+        )
+        let memory = try await EmbeddingReadinessBinding.openOrchestrator(
+            at: fileURL,
+            config: config,
+            request: request,
+            waxOptions: CommandLineEmbedderFactory.waxOptions(),
+            readiness: readiness,
+            factoryOverride: factoryOverride
+        )
+        do {
+            let result = try await body(memory)
+            try await memory.close()
+            return result
+        } catch {
+            try? await memory.close()
+            throw error
+        }
+    }
+
+    /// Reclaim tombstones set `storePath` to `""`. `URL(fileURLWithPath: "")` is CWD.
+    private static func resolvedStoreFileURL(path: String, reclaimedAtMs: Int64?) -> URL? {
+        guard reclaimedAtMs == nil else { return nil }
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: trimmed, isDirectory: &isDirectory),
+              isDirectory.boolValue == false
+        else { return nil }
+        return URL(fileURLWithPath: trimmed)
+    }
+
+    private func canonicalFrameID(for frameID: UInt64, memory: MemoryOrchestrator) async -> UInt64? {
+        do {
+            return try await memory.canonicalDocumentFrameID(for: frameID)
+        } catch {
+            WaxDiagnostics.logSwallowed(
+                error,
+                context: "ended-session canonical frame lookup",
+                fallback: "skip stale search hit"
+            )
+            return nil
+        }
+    }
+}

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -217,20 +217,7 @@ package enum LayeredRecall {
         package var inferWriteScope: @Sendable (_ sessionID: UUID?, _ clientCWD: String?) -> Identity
         package var preview: @Sendable (String?) -> String
         package var canonicalFrameID: @Sendable (UInt64, MemoryOrchestrator) async -> UInt64?
-        package var endedManifests: @Sendable () throws -> [BrokerSessionManifest]
-        package var searchEndedSession: @Sendable (
-            _ manifest: BrokerSessionManifest,
-            _ query: String,
-            _ mode: Memory.RetrievalMode,
-            _ topK: Int
-        ) async throws -> [EpisodicLaneHit]
-        package var recallEndedSession: @Sendable (
-            _ manifest: BrokerSessionManifest,
-            _ query: String,
-            _ mode: Memory.RetrievalMode,
-            _ topK: Int,
-            _ frameFilter: FrameFilter?
-        ) async throws -> [Hit]
+        package var endedSessions: any EndedSessionStore
         package var nowMs: @Sendable () -> Int64
 
         package init(
@@ -239,20 +226,7 @@ package enum LayeredRecall {
             inferWriteScope: @escaping @Sendable (UUID?, String?) -> Identity,
             preview: @escaping @Sendable (String?) -> String,
             canonicalFrameID: @escaping @Sendable (UInt64, MemoryOrchestrator) async -> UInt64?,
-            endedManifests: @escaping @Sendable () throws -> [BrokerSessionManifest],
-            searchEndedSession: @escaping @Sendable (
-                BrokerSessionManifest,
-                String,
-                Memory.RetrievalMode,
-                Int
-            ) async throws -> [EpisodicLaneHit],
-            recallEndedSession: @escaping @Sendable (
-                BrokerSessionManifest,
-                String,
-                Memory.RetrievalMode,
-                Int,
-                FrameFilter?
-            ) async throws -> [Hit],
+            endedSessions: any EndedSessionStore,
             nowMs: @escaping @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
         ) {
             self.longTermMemory = longTermMemory
@@ -260,9 +234,7 @@ package enum LayeredRecall {
             self.inferWriteScope = inferWriteScope
             self.preview = preview
             self.canonicalFrameID = canonicalFrameID
-            self.endedManifests = endedManifests
-            self.searchEndedSession = searchEndedSession
-            self.recallEndedSession = recallEndedSession
+            self.endedSessions = endedSessions
             self.nowMs = nowMs
         }
     }
@@ -336,7 +308,8 @@ package enum LayeredRecall {
 
     /// Ended virtual session stores eligible for the episodic lane.
     /// Agent filtering applies only when a current session is in scope.
-    /// Reclaimed tombstones are excluded; callers still skip missing store files.
+    /// Reclaimed tombstones are excluded. Missing store files are skipped by the
+    /// ended-session adapter, not here.
     package static func episodicManifests(
         from manifests: [BrokerSessionManifest],
         currentSessionID: UUID?,
@@ -655,20 +628,20 @@ package enum LayeredRecall {
 
         var episodicHits: [Hit] = []
         if horizons.contains(.episodic) {
-            let selected = onDiskEpisodicManifests(
-                episodicManifests(
-                    from: try stores.endedManifests(),
-                    currentSessionID: request.sessionID,
-                    currentAgentID: working?.agentID
-                )
+            let selected = episodicManifests(
+                from: try stores.endedSessions.listManifests(),
+                currentSessionID: request.sessionID,
+                currentAgentID: working?.agentID
             )
             for manifest in selected {
-                let hits = try await stores.recallEndedSession(
-                    manifest,
-                    request.query,
-                    request.mode ?? .hybrid(),
-                    max(1, episodicTopK),
-                    scopedFrameFilter
+                let hits = try await stores.endedSessions.recall(
+                    EndedSessionRecallQuery(
+                        manifest: manifest,
+                        query: request.query,
+                        mode: request.mode ?? .hybrid(),
+                        topK: max(1, episodicTopK),
+                        frameFilter: scopedFrameFilter
+                    )
                 )
                 episodicHits.append(contentsOf: hits)
             }
@@ -812,21 +785,21 @@ package enum LayeredRecall {
 
         if request.horizons.contains(.episodic) {
             let currentAgentID = request.sessionID.flatMap { stores.workingLane($0)?.agentID }
-            let scopedManifests = onDiskEpisodicManifests(
-                episodicManifests(
-                    from: try stores.endedManifests(),
-                    currentSessionID: request.sessionID,
-                    currentAgentID: currentAgentID
-                )
+            let scopedManifests = episodicManifests(
+                from: try stores.endedSessions.listManifests(),
+                currentSessionID: request.sessionID,
+                currentAgentID: currentAgentID
             )
             .prefix(6)
 
             for manifest in scopedManifests {
-                let laneHits = try await stores.searchEndedSession(
-                    manifest,
-                    request.query,
-                    request.mode,
-                    max(1, min(3, request.topK))
+                let laneHits = try await stores.endedSessions.search(
+                    EndedSessionSearchQuery(
+                        manifest: manifest,
+                        query: request.query,
+                        mode: request.mode,
+                        topK: max(1, min(3, request.topK))
+                    )
                 )
                 let ageMs: Int64 = max(0, stores.nowMs() - manifest.updatedAtMs)
                 let recencyBoost: Float = ageMs < Int64(7 * 24 * 60 * 60 * 1000) ? 0.15 : 0.05
@@ -866,12 +839,6 @@ package enum LayeredRecall {
                 return lhs.reference < rhs.reference
             }.prefix(request.topK)
         )
-    }
-
-    private static func onDiskEpisodicManifests(
-        _ manifests: [BrokerSessionManifest]
-    ) -> [BrokerSessionManifest] {
-        manifests.filter { FileManager.default.fileExists(atPath: $0.storePath) }
     }
 
     private static func canonicalizeHits(

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -585,20 +585,20 @@ func filterBeforeMergeKeepsProjectHitWhenForeignRanksFillLimit() {
     )
 
     // Wrong order (filter after merge/limit): home frame is starved out.
-    let starved = AgentBrokerService.recallItems(
-        AgentBrokerService.mergeRecallItems(sessionItems: [], durableItems: foreign + [home], limit: 3),
-        matchingProject: "HomeLand",
+    let starved = LayeredRecall.filterRecallItemsByProject(
+        LayeredRecall.mergeRecallItems(sessionItems: [], durableItems: foreign + [home], limit: 3),
+        project: "HomeLand",
         repo: nil
     )
     #expect(starved.isEmpty)
 
     // Correct order (filter before merge/limit): home frame survives.
-    let filtered = AgentBrokerService.recallItems(
+    let filtered = LayeredRecall.filterRecallItemsByProject(
         foreign + [home],
-        matchingProject: "HomeLand",
+        project: "HomeLand",
         repo: nil
     )
-    let kept = AgentBrokerService.mergeRecallItems(
+    let kept = LayeredRecall.mergeRecallItems(
         sessionItems: [],
         durableItems: filtered,
         limit: 3
@@ -612,10 +612,10 @@ func frameFilterByAddingProjectScopeMergesMetadataEntries() {
     let base = FrameFilter(
         metadataFilter: MetadataFilter(requiredEntries: ["topic": "keep"])
     )
-    let scoped = AgentBrokerService.frameFilterByAddingProjectScope(
-        base,
-        project: "HomeLand",
-        repo: nil
+    let scoped = LayeredRecall.frameFilterForScopedRetrieval(
+        base: base,
+        scope: .project,
+        identity: LayeredRecall.Identity(project: "HomeLand", repo: nil)
     )
     #expect(scoped?.metadataFilter?.requiredEntries[MemoryMetadataKeys.project] == "HomeLand")
     #expect(scoped?.metadataFilter?.requiredEntries["topic"] == "keep")

--- a/Tests/WaxMCPServerTests/WaxMCPReliabilityPlanContractsTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPReliabilityPlanContractsTests.swift
@@ -761,10 +761,10 @@ func frameFilterByAddingProjectScopeInjectsWaxProject() {
         includeDeleted: true,
         metadataFilter: MetadataFilter(requiredEntries: ["custom": "1"], requiredLabels: ["keep"])
     )
-    let merged = AgentBrokerService.frameFilterByAddingProjectScope(
-        base,
-        project: "AlphaLand",
-        repo: "IgnoredWhenProjectSet"
+    let merged = LayeredRecall.frameFilterForScopedRetrieval(
+        base: base,
+        scope: .project,
+        identity: LayeredRecall.Identity(project: "AlphaLand", repo: "IgnoredWhenProjectSet")
     )
     #expect(merged?.includeDeleted == true)
     #expect(merged?.metadataFilter?.requiredLabels == ["keep"])
@@ -772,12 +772,18 @@ func frameFilterByAddingProjectScopeInjectsWaxProject() {
     #expect(merged?.metadataFilter?.requiredEntries[MemoryMetadataKeys.project] == "AlphaLand")
     #expect(merged?.metadataFilter?.requiredEntries[MemoryMetadataKeys.repo] == nil)
 
-    let repoOnly = AgentBrokerService.frameFilterByAddingProjectScope(
-        nil,
-        project: nil,
-        repo: "RepoOnly"
+    let repoOnly = LayeredRecall.frameFilterForScopedRetrieval(
+        base: nil,
+        scope: .project,
+        identity: LayeredRecall.Identity(project: nil, repo: "RepoOnly")
     )
     #expect(repoOnly?.metadataFilter?.requiredEntries[MemoryMetadataKeys.repo] == "RepoOnly")
-    #expect(AgentBrokerService.frameFilterByAddingProjectScope(base, project: nil, repo: nil) == base)
+    #expect(
+        LayeredRecall.frameFilterForScopedRetrieval(
+            base: base,
+            scope: .project,
+            identity: LayeredRecall.Identity(project: nil, repo: nil)
+        ) == base
+    )
 }
 #endif

--- a/Tests/WaxTests/EndedSessionStoreTests.swift
+++ b/Tests/WaxTests/EndedSessionStoreTests.swift
@@ -1,0 +1,359 @@
+import Foundation
+import Testing
+@testable import Wax
+
+struct EndedSessionStoreTests {
+    @Test
+    func diskStoreListsEndedManifestAndSearchesRememberedText() async throws {
+        try await withEndedSessionDisk { store, manifest, token in
+            let manifests = try store.listManifests()
+            #expect(manifests.map(\.sessionID) == [manifest.sessionID])
+
+            let hits = try await store.search(
+                EndedSessionSearchQuery(
+                    manifest: manifest,
+                    query: token,
+                    mode: .textOnly,
+                    topK: 5
+                )
+            )
+            #expect(hits.contains { hit in
+                (hit.previewText ?? "").contains(token) && hit.canonicalFrameID != nil
+            })
+        }
+    }
+
+    @Test
+    func diskStoreSearchAndRecallReturnEmptyWhenStoreFileIsMissing() async throws {
+        try await withEndedSessionDisk { store, manifest, token in
+            try FileManager.default.removeItem(atPath: manifest.storePath)
+            let searchHits = try await store.search(
+                EndedSessionSearchQuery(
+                    manifest: manifest,
+                    query: token,
+                    mode: .textOnly,
+                    topK: 5
+                )
+            )
+            #expect(searchHits.isEmpty)
+            let recallHits = try await store.recall(
+                EndedSessionRecallQuery(
+                    manifest: manifest,
+                    query: token,
+                    mode: .textOnly,
+                    topK: 5,
+                    frameFilter: nil
+                )
+            )
+            #expect(recallHits.isEmpty)
+            await #expect(throws: BrokerValidationError.self) {
+                try await store.document(
+                    EndedSessionDocumentQuery(sessionID: manifest.sessionID, frameID: 1)
+                )
+            }
+        }
+    }
+
+    @Test
+    func diskStoreSkipsReclaimTombstoneWithEmptyStorePath() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-ended-tombstone-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sessionID = UUID()
+        let nowMs: Int64 = 1
+        let tombstone = BrokerSessionManifest(
+            sessionID: sessionID,
+            agentID: "ended-agent",
+            runID: "ended-run",
+            project: "Wax",
+            repo: "Wax",
+            storePath: "",
+            eventLogPath: "",
+            status: .ended,
+            brokerLeaseOwnerID: nil,
+            leaseExpiresAtMs: nil,
+            createdAtMs: nowMs,
+            updatedAtMs: nowMs,
+            endedAtMs: nowMs,
+            reclaimedAtMs: nowMs
+        )
+        try BrokerSessionPersistence.saveManifest(
+            tombstone,
+            to: BrokerSessionPersistence.manifestURL(rootURL: root, sessionID: sessionID)
+        )
+        let store = DiskEndedSessionStore(
+            sessionRootURL: root,
+            noEmbedder: true,
+            enableAccessStatsScoring: false,
+            readiness: EmbeddingReadiness()
+        )
+        let searchHits = try await store.search(
+            EndedSessionSearchQuery(manifest: tombstone, query: "anything", mode: .textOnly, topK: 5)
+        )
+        #expect(searchHits.isEmpty)
+        let recallHits = try await store.recall(
+            EndedSessionRecallQuery(
+                manifest: tombstone,
+                query: "anything",
+                mode: .textOnly,
+                topK: 5,
+                frameFilter: nil
+            )
+        )
+        #expect(recallHits.isEmpty)
+        await #expect(throws: BrokerValidationError.self) {
+            try await store.document(
+                EndedSessionDocumentQuery(sessionID: sessionID, frameID: 1)
+            )
+        }
+        await #expect(throws: BrokerValidationError.self) {
+            try await store.withMemory(at: URL(fileURLWithPath: "")) { _ in 0 }
+        }
+    }
+
+    @Test
+    func diskStoreRecallsRememberedText() async throws {
+        try await withEndedSessionDisk { store, manifest, token in
+            let hits = try await store.recall(
+                EndedSessionRecallQuery(
+                    manifest: manifest,
+                    query: token,
+                    mode: .textOnly,
+                    topK: 5,
+                    frameFilter: nil
+                )
+            )
+            #expect(hits.contains { $0.text.contains(token) })
+            #expect(hits.contains { $0.explanations.contains("recent session episode") })
+            #expect(hits.contains { $0.id.horizon == .episodic })
+        }
+    }
+
+    @Test
+    func diskStoreLoadsDocumentByFrameID() async throws {
+        try await withEndedSessionDisk { store, manifest, token in
+            let hits = try await store.search(
+                EndedSessionSearchQuery(
+                    manifest: manifest,
+                    query: token,
+                    mode: .textOnly,
+                    topK: 1
+                )
+            )
+            let frameID = try #require(hits.first?.canonicalFrameID ?? hits.first?.frameID)
+            let document = try await store.document(
+                EndedSessionDocumentQuery(sessionID: manifest.sessionID, frameID: frameID)
+            )
+            #expect(document.text.contains(token))
+            #expect(document.sessionID == manifest.sessionID)
+            #expect(document.frameID == frameID)
+        }
+    }
+
+    @Test
+    func diskStoreWithMemoryClosesSoALaterSearchCanReopen() async throws {
+        try await withEndedSessionDisk { store, manifest, token in
+            let counted: Int = try await store.withMemory(at: URL(fileURLWithPath: manifest.storePath)) { memory in
+                let docs = try await memory.corpusSourceDocuments()
+                return docs.count
+            }
+            #expect(counted >= 1)
+
+            let hits = try await store.search(
+                EndedSessionSearchQuery(
+                    manifest: manifest,
+                    query: token,
+                    mode: .textOnly,
+                    topK: 5
+                )
+            )
+            #expect(hits.isEmpty == false)
+        }
+    }
+
+    @Test
+    func inMemoryStoreServesCannedSearchAndRecallHits() async throws {
+        let sessionID = UUID()
+        let manifest = endedTestManifest(sessionID: sessionID, storePath: "/tmp/ended-session-missing.wax")
+        let cannedSearch = LayeredRecall.EpisodicLaneHit(
+            frameID: 11,
+            score: 0.8,
+            previewText: "canned search hit",
+            metadata: [:],
+            explanations: ["fixture"],
+            canonicalFrameID: 11
+        )
+        let cannedRecall = LayeredRecall.Hit(
+            id: .episodic(sessionID: sessionID, frameID: 11),
+            score: 0.8,
+            text: "canned recall hit",
+            preview: "canned recall hit",
+            metadata: [:],
+            explanations: ["recent session episode"],
+            timestampMs: 1
+        )
+        let store = InMemoryEndedSessionStore(
+            manifests: [manifest],
+            searchHits: [sessionID: [cannedSearch]],
+            recallHits: [sessionID: [cannedRecall]],
+            documents: [
+                EndedSessionDocument(
+                    sessionID: sessionID,
+                    frameID: 11,
+                    text: "canned document",
+                    metadata: [:],
+                    timestampMs: 1,
+                    agentID: manifest.agentID,
+                    runID: manifest.runID
+                )
+            ]
+        )
+
+        #expect(try store.listManifests().map(\.sessionID) == [sessionID])
+        let searchHits = try await store.search(
+            EndedSessionSearchQuery(manifest: manifest, query: "q", mode: .textOnly, topK: 3)
+        )
+        #expect(searchHits.map(\.frameID) == [11])
+        let recallHits = try await store.recall(
+            EndedSessionRecallQuery(manifest: manifest, query: "q", mode: .textOnly, topK: 3, frameFilter: nil)
+        )
+        #expect(recallHits.map(\.text) == ["canned recall hit"])
+        let document = try await store.document(
+            EndedSessionDocumentQuery(sessionID: sessionID, frameID: 11)
+        )
+        #expect(document.text == "canned document")
+    }
+
+    @Test
+    func layeredRecallSearchUsesEndedSessionStoreForEpisodicLane() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wax-ended-layered-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = false
+        config.enableStructuredMemory = false
+        let longTerm = try await MemoryOrchestrator(
+            at: root.appendingPathComponent("durable.wax"),
+            config: config
+        )
+        do {
+            let sessionID = UUID()
+            let manifest = endedTestManifest(
+                sessionID: sessionID,
+                storePath: "/tmp/ended-session-not-on-disk.wax"
+            )
+            let ended = InMemoryEndedSessionStore(
+                manifests: [manifest],
+                searchHits: [
+                    sessionID: [
+                        LayeredRecall.EpisodicLaneHit(
+                            frameID: 42,
+                            score: 0.91,
+                            previewText: "in-memory episode note",
+                            metadata: [:],
+                            explanations: [],
+                            canonicalFrameID: 42
+                        )
+                    ]
+                ]
+            )
+            let stores = LayeredRecall.Stores(
+                longTermMemory: longTerm,
+                workingLane: { _ in nil },
+                inferWriteScope: { _, _ in LayeredRecall.Identity() },
+                preview: { $0 ?? "" },
+                canonicalFrameID: { frameID, _ in frameID },
+                endedSessions: ended,
+                nowMs: { 0 }
+            )
+
+            let hits = try await LayeredRecall.search(
+                request: LayeredRecall.SearchRequest(
+                    query: "episode",
+                    mode: .textOnly,
+                    topK: 5,
+                    horizons: .episodic
+                ),
+                stores: stores
+            )
+            #expect(hits.contains { $0.text.contains("in-memory episode note") })
+            #expect(hits.contains { $0.id == .episodic(sessionID: sessionID, frameID: 42) })
+            try await longTerm.close()
+        } catch {
+            try? await longTerm.close()
+            throw error
+        }
+    }
+}
+
+private func withEndedSessionDisk(
+    _ body: (DiskEndedSessionStore, BrokerSessionManifest, String) async throws -> Void
+) async throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-ended-session-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let sessionID = UUID()
+    let storeURL = root.appendingPathComponent("\(sessionID.uuidString).wax")
+    let token = "ENDED-SESSION-\(UUID().uuidString.prefix(8))"
+
+    var config = OrchestratorConfig.default
+    config.enableVectorSearch = false
+    config.enableStructuredMemory = false
+    let writer = try await MemoryOrchestrator(at: storeURL, config: config)
+    _ = try await writer.remember(token)
+    try await writer.flush()
+    try await writer.close()
+
+    let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+    let manifest = BrokerSessionManifest(
+        sessionID: sessionID,
+        agentID: "ended-agent",
+        runID: "ended-run",
+        project: "Wax",
+        repo: "Wax",
+        storePath: storeURL.path,
+        eventLogPath: BrokerSessionPersistence.eventLogURL(rootURL: root, sessionID: sessionID).path,
+        status: .ended,
+        brokerLeaseOwnerID: nil,
+        leaseExpiresAtMs: nil,
+        createdAtMs: nowMs,
+        updatedAtMs: nowMs,
+        endedAtMs: nowMs
+    )
+    try BrokerSessionPersistence.saveManifest(
+        manifest,
+        to: BrokerSessionPersistence.manifestURL(rootURL: root, sessionID: sessionID)
+    )
+
+    let store = DiskEndedSessionStore(
+        sessionRootURL: root,
+        noEmbedder: true,
+        enableAccessStatsScoring: false,
+        readiness: EmbeddingReadiness()
+    )
+    try await body(store, manifest, token)
+}
+
+private func endedTestManifest(sessionID: UUID, storePath: String) -> BrokerSessionManifest {
+    BrokerSessionManifest(
+        sessionID: sessionID,
+        agentID: "ended-agent",
+        runID: "ended-run",
+        project: "Wax",
+        repo: "Wax",
+        storePath: storePath,
+        eventLogPath: "/tmp/ended-session-missing.events.jsonl",
+        status: .ended,
+        brokerLeaseOwnerID: nil,
+        leaseExpiresAtMs: nil,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        endedAtMs: 1
+    )
+}


### PR DESCRIPTION
## Summary

Ended-session I/O (list, search, recall, get-by-id, open/close) now lives in `EndedSessionStore` instead of closures on `AgentBrokerService`.

- Production adapter: `DiskEndedSessionStore` (`BrokerSessionPersistence` + `MemoryOrchestrator`)
- Test adapter: `InMemoryEndedSessionStore`
- Harvest, `corpus_search`, and ended `memory_get` call this module instead of `openAdhocMemory`
- Layered recall takes the store; working lane and durable `MemoryOrchestrator` stay outside
- Reclaim tombstones with empty `storePath` no longer open the current directory

## Test plan

- [x] `swift test --filter EndedSessionStoreTests` (8 passed: disk search/recall/get, missing file, tombstone, in-memory, Layered recall wiring)
- [x] `swift test --filter LayeredRecallTests`
- [x] `swift test --filter CompactAssemblyTests`
- [x] `swift test --filter sessionCloseHarvestsAlwaysPromotableNeedleIntoDurableRecall`
- [x] `swift test --traits MCPServer --filter corpusSearchIncludesDurableLongTermFrames`
- [x] `swift test --traits MCPServer --filter frameFilterByAddingProjectScope`
- [ ] Full `production_readiness_gates.sh` not run

`recallAppliesFrameFilterToDurableHitsWhenSessionIDIsSet` still fails on default `scope=project` with a session that has no project. That path is unchanged here.