### PR TITLE
docs: drop disabled GitHub Discussions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,8 +632,7 @@ A: Hybrid and vector search require a local embedding model. In Swift, `Memory(a
 
 ## Community & Support
 
-- 💬 **Discussions & Q&A:** [GitHub Discussions](https://github.com/christopherkarani/Wax/discussions)
-- 🐛 **Bug reports:** [GitHub Issues](https://github.com/christopherkarani/Wax/issues)
+- 💬 **Questions & bug reports:** [GitHub Issues](https://github.com/christopherkarani/Wax/issues)
 - ⭐ **Star the repo** to follow releases
 - 📖 **Full documentation:** [iOS developer docs](https://christopherkarani.github.io/Wax/) · [DocC sources](Sources/Wax/Wax.docc)
 


### PR DESCRIPTION
Closes #178.

The Community section pointed at GitHub Discussions, which is disabled on this repo. Q&A and bug reports now both go to Issues. No other docs files had that URL.