### PR TITLE
refactor(rag): use injected nowMs for FastRAG and orchestrator writes

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1752,7 +1752,7 @@ package actor MemoryOrchestrator {
         metadata.entries["kind"] = "handoff"
         metadata.entries[MemoryMetadataKeys.type] = MemoryType.handoff.rawValue
         metadata.entries[MemoryMetadataKeys.durability] = MemoryDurability.ephemeral.rawValue
-        metadata.entries[MemoryMetadataKeys.createdAtMs] = String(Int64(Date().timeIntervalSince1970 * 1000))
+        metadata.entries[MemoryMetadataKeys.createdAtMs] = String(nowProvider())
         if let normalizedProject, !normalizedProject.isEmpty {
             metadata.entries["project"] = normalizedProject
             metadata.entries[MemoryMetadataKeys.project] = normalizedProject
@@ -1817,7 +1817,7 @@ package actor MemoryOrchestrator {
         commit: Bool = true
     ) async throws -> EntityRowID {
         try ensureStructuredMemoryEnabled()
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let nowMs = nowProvider()
         let entityID = try await session.upsertEntity(key: key, kind: kind, aliases: aliases, nowMs: nowMs)
         if commit {
             try await session.commit()
@@ -1864,7 +1864,7 @@ package actor MemoryOrchestrator {
     }
 
     private func nextStructuredSystemMs() throws -> Int64 {
-        let wallNow = Int64(Date().timeIntervalSince1970 * 1000)
+        let wallNow = nowProvider()
         guard wallNow < Int64.max else {
             throw WaxError.encodingError(reason: "structured system timestamp must be less than Int64.max")
         }

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -28,6 +28,12 @@ package struct FastRAGContextBuilder: Sendable {
     ) async throws -> RAGContext {
         let clamped = clamp(config)
         let counter = try await TokenCounter.shared()
+        // One evaluation clock for this build. Do not invent wall time.
+        // SearchRequest.nowMs is non-optional; 0 is not recency-neutral
+        // (MemorySemantics ageDays uses max(0, now - created), so a missing
+        // clock looks "recent" and does not expire). Ranking callers must set
+        // deterministicNowMs; MemoryOrchestrator.recall always does.
+        let nowMs = clamped.deterministicNowMs
 
         // 1) Run unified search
         // Access-aware ranking needs a little headroom so a stale top result can
@@ -50,7 +56,7 @@ package struct FastRAGContextBuilder: Sendable {
             topK: searchTopK,
             timeRange: timeRange,
             frameFilter: frameFilter,
-            nowMs: clamped.deterministicNowMs ?? Int64(Date().timeIntervalSince1970 * 1000),
+            nowMs: nowMs ?? 0,
             scopeContext: scopeContext,
             rrfK: clamped.rrfK,
             previewMaxBytes: clamped.previewMaxBytes
@@ -62,15 +68,6 @@ package struct FastRAGContextBuilder: Sendable {
         } else {
             try await wax.search(request)
         }
-        let scoringMetadata: [UInt64: FrameMeta] = if accessStatsManager != nil,
-                                                        clamped.deterministicNowMs == nil {
-            await wax.frameMetas(frameIds: response.results.map(\.frameId))
-        } else {
-            [:]
-        }
-        let accessScoringNowMs = clamped.deterministicNowMs
-            ?? scoringMetadata.values.map(\.timestamp).max()
-            ?? 0
         let accessStatsMap: [UInt64: FrameAccessStats] = if let accessStatsManager {
             await AccessFrequencyRanker.statsForRanking(
                 frameIds: response.results.map(\.frameId),
@@ -80,15 +77,19 @@ package struct FastRAGContextBuilder: Sendable {
         } else {
             [:]
         }
-        let accessRankedResults = accessStatsManager == nil
-            ? response.results
-            : AccessFrequencyRanker.rerank(
+        let accessRankedResults: [SearchResponse.Result] = if accessStatsManager == nil {
+            response.results
+        } else if let nowMs {
+            AccessFrequencyRanker.rerank(
                 results: response.results,
                 query: query,
                 accessStats: accessStatsMap,
-                nowMs: accessScoringNowMs,
+                nowMs: nowMs,
                 maxWindow: searchTopK
             )
+        } else {
+            response.results
+        }
         let queryAnalyzer = QueryAnalyzer()
         let rankedResults = clamped.enableAnswerFocusedRanking
             ? Self.orderCandidatesForAnswer(
@@ -122,19 +123,6 @@ package struct FastRAGContextBuilder: Sendable {
         let sourceFrameMetasTask: [UInt64: FrameMeta] = shouldPrefetchSurrogates
             ? await wax.frameMetas(frameIds: sourceFrameIds)
             : [:]
-
-        // nowMs resolution order:
-        // 1. deterministicNowMs if explicitly set (always the case when called via MemoryOrchestrator.recall)
-        // 2. max frame timestamp — provides a stable, deterministic "now" for direct callers
-        //    that have not set deterministicNowMs (e.g., tests). Note: this may understate
-        //    recency for stores where all frames are old relative to wall clock.
-        // Both values derive from store state, so tier selection and access-recency
-        // explanations stay deterministic. When neither source exists, nowMs stays nil:
-        // unknown-now produces no access-recency signal (access-reason enrichment is
-        // skipped) instead of a maximal "recently used" signal from a zero sentinel,
-        // and surrogate tiers keep full fidelity rather than a fabricated zero age.
-        let nowMs = clamped.deterministicNowMs
-            ?? sourceFrameMetasTask.values.map(\.timestamp).max()
 
         var expansionTextByFrame: [UInt64: String] = [:]
         var expandedSourceFrameId: UInt64?

--- a/Tests/WaxTests/EvaluationClockTests.swift
+++ b/Tests/WaxTests/EvaluationClockTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+@testable import Wax
+import WaxCore
+
+private let evaluationClockNowMs: Int64 = 1_700_000_000_000
+private let evaluationClockDayMs: Int64 = 24 * 60 * 60 * 1000
+
+struct EvaluationClockTests {
+
+    @Test
+    func handoffCreatedAtMsUsesInjectedNow() async throws {
+        try await withOrchestrator(structuredMemory: false) { orchestrator in
+            let frameId = try await orchestrator.rememberHandoff(
+                content: "Evaluation-clock handoff for waxfile ranking."
+            )
+            let hits = try await orchestrator.search(
+                query: "Evaluation-clock handoff",
+                mode: .textOnly,
+                topK: 5
+            )
+            let hit = try #require(hits.first { $0.frameId == frameId })
+            #expect(hit.metadata[MemoryMetadataKeys.createdAtMs] == String(evaluationClockNowMs))
+        }
+    }
+
+    @Test
+    func upsertEntityUsesInjectedNow() async throws {
+        try await withOrchestrator(structuredMemory: true) { orchestrator in
+            let key = EntityKey("person:evaluation-clock")
+            _ = try await orchestrator.upsertEntity(
+                key: key,
+                kind: "person",
+                aliases: ["Evaluation Clock"]
+            )
+            let match = try #require(try await orchestrator.entity(forKey: key))
+            #expect(match.key == key)
+            #expect(match.kind == "person")
+
+            let source = try orchestratorSource()
+            let upsertBody = try #require(functionBody(named: "upsertEntity", in: source))
+            #expect(upsertBody.contains("nowProvider()"))
+            #expect(upsertBody.contains("Date()") == false)
+        }
+    }
+
+    @Test
+    func assertFactSystemTimeUsesInjectedNow() async throws {
+        try await withOrchestrator(structuredMemory: true) { orchestrator in
+            let subject = EntityKey("service:evaluation-clock")
+            _ = try await orchestrator.assertFact(
+                subject: subject,
+                predicate: PredicateKey("status"),
+                object: .string("active")
+            )
+            let facts = try await orchestrator.facts(about: subject, limit: 10)
+            let hit = try #require(facts.hits.first)
+            #expect(hit.system.fromMs == evaluationClockNowMs)
+            #expect(hit.valid.fromMs == evaluationClockNowMs)
+        }
+    }
+
+    @Test
+    func assertFactMonotonicBumpWhenProviderRepeats() async throws {
+        try await withOrchestrator(structuredMemory: true) { orchestrator in
+            let subject = EntityKey("service:evaluation-clock-mono")
+            _ = try await orchestrator.assertFact(
+                subject: subject,
+                predicate: PredicateKey("status"),
+                object: .string("active")
+            )
+            _ = try await orchestrator.assertFact(
+                subject: subject,
+                predicate: PredicateKey("region"),
+                object: .string("us-west")
+            )
+            let facts = try await orchestrator.facts(about: subject, limit: 10)
+            let times = facts.hits.map(\.system.fromMs).sorted()
+            #expect(times == [evaluationClockNowMs, evaluationClockNowMs + 1])
+        }
+    }
+
+    @Test
+    func fastRAGBuildUsesSingleDeterministicNowMs() async throws {
+        try await withOrchestrator(structuredMemory: false) { orchestrator in
+            _ = try await orchestrator.rememberHandoff(
+                content: "Waxfile ranking-clock pin for recency explanations."
+            )
+            let recall = try await orchestrator.recall(query: "Waxfile ranking-clock")
+            let item = try #require(recall.items.first)
+            #expect(item.explanations.contains("recent handoff"))
+            #expect(item.explanations.contains("stale handoff") == false)
+        }
+    }
+
+    @Test
+    func fastRAGContextBuilderSourceHasNoDateAndOneNowMs() throws {
+        let source = try fastRAGSource()
+        #expect(source.contains("Date()") == false)
+        #expect(source.contains("let nowMs = clamped.deterministicNowMs"))
+        #expect(source.contains("nowMs: nowMs ?? 0"))
+        #expect(source.contains("nowMs: nowMs"))
+        #expect(source.contains("AccessFrequencyRanker.rerank"))
+        #expect(source.contains("RecallAssembly.pack"))
+        #expect(source.contains("accessScoringNowMs") == false)
+    }
+
+    @Test
+    func remainingOrchestratorDateIsOnlyNowMsProviderDefault() throws {
+        let source = try orchestratorSource()
+        let dateCallCount = source.components(separatedBy: "Date()").count - 1
+        #expect(dateCallCount == 1)
+        #expect(source.contains(
+            "nowMsProvider: @escaping @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }"
+        ))
+        let handoffBody = try #require(functionBody(named: "rememberHandoffSerialized", in: source))
+        #expect(handoffBody.contains("nowProvider()"))
+        #expect(handoffBody.contains("Date()") == false)
+        let nextBody = try #require(functionBody(named: "nextStructuredSystemMs", in: source))
+        #expect(nextBody.contains("nowProvider()"))
+        #expect(nextBody.contains("Date()") == false)
+    }
+
+    @Test
+    func zeroNowMsBoostsRecencyAndSkipsExpiry() {
+        let createdAtMs = evaluationClockNowMs
+        let expiresAtMs = createdAtMs + evaluationClockDayMs
+        let metadata = [
+            MemoryMetadataKeys.type: MemoryType.handoff.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.ephemeral.rawValue,
+            MemoryMetadataKeys.createdAtMs: String(createdAtMs),
+            MemoryMetadataKeys.expiresAtMs: String(expiresAtMs),
+        ]
+        let atZero = MemorySemantics.parse(metadata: metadata, nowMs: 0)
+        #expect(atZero.isExpired == false)
+        let zeroReasons = MemorySemantics.rankingReasons(
+            metadata: metadata,
+            scope: nil,
+            nowMs: 0
+        )
+        #expect(zeroReasons.reasons.contains("recent handoff"))
+
+        let expired = MemorySemantics.parse(metadata: metadata, nowMs: expiresAtMs)
+        #expect(expired.isExpired)
+        let atCreated = MemorySemantics.rankingReasons(
+            metadata: metadata,
+            scope: nil,
+            nowMs: createdAtMs
+        )
+        #expect(atCreated.reasons.contains("recent handoff"))
+    }
+}
+
+private func withOrchestrator(
+    structuredMemory: Bool,
+    _ body: (MemoryOrchestrator) async throws -> Void
+) async throws {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-eval-clock-" + UUID().uuidString)
+        .appendingPathExtension("wax")
+    var config = OrchestratorConfig.default
+    config.enableTextSearch = true
+    config.enableVectorSearch = false
+    config.enableStructuredMemory = structuredMemory
+    config.enableAccessStatsScoring = false
+    config.rag.searchMode = .textOnly
+    config.rag.deterministicNowMs = evaluationClockNowMs
+
+    let orchestrator = try await MemoryOrchestrator(
+        at: url,
+        config: config,
+        nowMsProvider: { evaluationClockNowMs }
+    )
+    do {
+        try await body(orchestrator)
+        try await orchestrator.close()
+        try? FileManager.default.removeItem(at: url)
+    } catch {
+        try? await orchestrator.close()
+        try? FileManager.default.removeItem(at: url)
+        throw error
+    }
+}
+
+private func repoRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+private func fastRAGSource() throws -> String {
+    try String(
+        contentsOf: repoRoot().appendingPathComponent("Sources/Wax/RAG/FastRAGContextBuilder.swift"),
+        encoding: .utf8
+    )
+}
+
+private func orchestratorSource() throws -> String {
+    try String(
+        contentsOf: repoRoot().appendingPathComponent("Sources/Wax/Orchestrator/MemoryOrchestrator.swift"),
+        encoding: .utf8
+    )
+}
+
+private func functionBody(named name: String, in source: String) -> String? {
+    guard let nameRange = source.range(of: "func \(name)(") else { return nil }
+    let fromName = source[nameRange.lowerBound...]
+    guard let openBrace = fromName.firstIndex(of: "{") else { return nil }
+    var depth = 0
+    var index = openBrace
+    while index < fromName.endIndex {
+        let character = fromName[index]
+        if character == "{" {
+            depth += 1
+        } else if character == "}" {
+            depth -= 1
+            if depth == 0 {
+                return String(fromName[openBrace...index])
+            }
+        }
+        index = fromName.index(after: index)
+    }
+    return nil
+}

--- a/Tests/WaxTests/EvaluationClockTests.swift
+++ b/Tests/WaxTests/EvaluationClockTests.swift
@@ -4,7 +4,8 @@ import Testing
 import WaxCore
 
 private let evaluationClockNowMs: Int64 = 1_700_000_000_000
-private let evaluationClockDayMs: Int64 = 24 * 60 * 60 * 1000
+private let evaluationClockHourMs: Int64 = 60 * 60 * 1000
+private let evaluationClockDayMs: Int64 = 24 * evaluationClockHourMs
 
 struct EvaluationClockTests {
 
@@ -25,22 +26,23 @@ struct EvaluationClockTests {
     }
 
     @Test
-    func upsertEntityUsesInjectedNow() async throws {
-        try await withOrchestrator(structuredMemory: true) { orchestrator in
+    func upsertEntityInvokesInjectedNow() async throws {
+        let clock = RecordingNowMs(value: evaluationClockNowMs)
+        try await withOrchestrator(
+            structuredMemory: true,
+            nowMsProvider: { clock.now() }
+        ) { orchestrator in
+            let before = clock.calls
             let key = EntityKey("person:evaluation-clock")
             _ = try await orchestrator.upsertEntity(
                 key: key,
                 kind: "person",
                 aliases: ["Evaluation Clock"]
             )
+            #expect(clock.calls > before)
             let match = try #require(try await orchestrator.entity(forKey: key))
             #expect(match.key == key)
             #expect(match.kind == "person")
-
-            let source = try orchestratorSource()
-            let upsertBody = try #require(functionBody(named: "upsertEntity", in: source))
-            #expect(upsertBody.contains("nowProvider()"))
-            #expect(upsertBody.contains("Date()") == false)
         }
     }
 
@@ -81,7 +83,7 @@ struct EvaluationClockTests {
     }
 
     @Test
-    func fastRAGBuildUsesSingleDeterministicNowMs() async throws {
+    func fastRAGBuildUsesDeterministicNowMsNotWallClock() async throws {
         try await withOrchestrator(structuredMemory: false) { orchestrator in
             _ = try await orchestrator.rememberHandoff(
                 content: "Waxfile ranking-clock pin for recency explanations."
@@ -94,31 +96,85 @@ struct EvaluationClockTests {
     }
 
     @Test
-    func fastRAGContextBuilderSourceHasNoDateAndOneNowMs() throws {
-        let source = try fastRAGSource()
-        #expect(source.contains("Date()") == false)
-        #expect(source.contains("let nowMs = clamped.deterministicNowMs"))
-        #expect(source.contains("nowMs: nowMs ?? 0"))
-        #expect(source.contains("nowMs: nowMs"))
-        #expect(source.contains("AccessFrequencyRanker.rerank"))
-        #expect(source.contains("RecallAssembly.pack"))
-        #expect(source.contains("accessScoringNowMs") == false)
+    func fastRAGBuildUsesDeterministicNowMsNotZeroSentinel() async throws {
+        let agedNowMs = evaluationClockNowMs + 20 * evaluationClockDayMs
+        try await withOrchestrator(
+            structuredMemory: false,
+            deterministicNowMs: agedNowMs
+        ) { orchestrator in
+            _ = try await orchestrator.rememberHandoff(
+                content: "Waxfile ranking-clock pin for recency explanations."
+            )
+            let recall = try await orchestrator.recall(query: "Waxfile ranking-clock")
+            let item = try #require(recall.items.first)
+            #expect(item.explanations.contains("stale handoff"))
+            #expect(item.explanations.contains("recent handoff") == false)
+        }
     }
 
     @Test
-    func remainingOrchestratorDateIsOnlyNowMsProviderDefault() throws {
-        let source = try orchestratorSource()
-        let dateCallCount = source.components(separatedBy: "Date()").count - 1
-        #expect(dateCallCount == 1)
-        #expect(source.contains(
-            "nowMsProvider: @escaping @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }"
-        ))
-        let handoffBody = try #require(functionBody(named: "rememberHandoffSerialized", in: source))
-        #expect(handoffBody.contains("nowProvider()"))
-        #expect(handoffBody.contains("Date()") == false)
-        let nextBody = try #require(functionBody(named: "nextStructuredSystemMs", in: source))
-        #expect(nextBody.contains("nowProvider()"))
-        #expect(nextBody.contains("Date()") == false)
+    func fastRAGAccessRerankAndPackUseInjectedNowMs() async throws {
+        try await withOrchestrator(
+            structuredMemory: false,
+            enableAccessStatsScoring: true
+        ) { orchestrator in
+            let frameId = try await orchestrator.rememberHandoff(
+                content: "Waxfile access-clock pin for recently used explanations."
+            )
+            await orchestrator.seedAccessStats(
+                frameId: frameId,
+                from: FrameAccessStats(
+                    frameId: frameId,
+                    nowMs: evaluationClockNowMs - evaluationClockHourMs
+                )
+            )
+            let recall = try await orchestrator.recall(query: "Waxfile access-clock")
+            let item = try #require(recall.items.first { $0.frameId == frameId })
+            #expect(item.explanations.contains("recently used"))
+        }
+
+        let staleAccessNowMs = evaluationClockNowMs + 48 * evaluationClockHourMs
+        try await withOrchestrator(
+            structuredMemory: false,
+            enableAccessStatsScoring: true,
+            deterministicNowMs: staleAccessNowMs
+        ) { orchestrator in
+            let frameId = try await orchestrator.rememberHandoff(
+                content: "Waxfile access-clock pin for recently used explanations."
+            )
+            await orchestrator.seedAccessStats(
+                frameId: frameId,
+                from: FrameAccessStats(
+                    frameId: frameId,
+                    nowMs: evaluationClockNowMs - evaluationClockHourMs
+                )
+            )
+            let recall = try await orchestrator.recall(query: "Waxfile access-clock")
+            let item = try #require(recall.items.first { $0.frameId == frameId })
+            #expect(item.explanations.contains("recently used") == false)
+        }
+    }
+
+    @Test
+    func fastRAGNilDeterministicNowMsDoesNotUseWallClock() async throws {
+        try await withOrchestrator(structuredMemory: false) { orchestrator in
+            _ = try await orchestrator.rememberHandoff(
+                content: "Waxfile ranking-clock pin for recency explanations."
+            )
+            let config = FastRAGConfig(searchMode: .textOnly)
+            #expect(config.deterministicNowMs == nil)
+            let context = try await FastRAGContextBuilder().build(
+                query: "Waxfile ranking-clock",
+                wax: orchestrator.wax,
+                session: orchestrator.session,
+                config: config
+            )
+            let item = try #require(context.items.first)
+            // Wall clock (~2026) would mark a 2023 handoff stale. SearchRequest.nowMs
+            // is non-optional, so the nil-clock path passes 0, which looks recent.
+            #expect(item.explanations.contains("recent handoff"))
+            #expect(item.explanations.contains("stale handoff") == false)
+        }
     }
 
     @Test
@@ -148,11 +204,50 @@ struct EvaluationClockTests {
             nowMs: createdAtMs
         )
         #expect(atCreated.reasons.contains("recent handoff"))
+
+        let unexpired = [
+            MemoryMetadataKeys.type: MemoryType.handoff.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.ephemeral.rawValue,
+            MemoryMetadataKeys.createdAtMs: String(createdAtMs),
+        ]
+        let aged = MemorySemantics.rankingReasons(
+            metadata: unexpired,
+            scope: nil,
+            nowMs: createdAtMs + 20 * evaluationClockDayMs
+        )
+        #expect(aged.reasons.contains("stale handoff"))
+        #expect(aged.reasons.contains("recent handoff") == false)
+    }
+}
+
+private final class RecordingNowMs: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls = 0
+    let value: Int64
+
+    init(value: Int64) {
+        self.value = value
+    }
+
+    var calls: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _calls
+    }
+
+    func now() -> Int64 {
+        lock.lock()
+        _calls += 1
+        lock.unlock()
+        return value
     }
 }
 
 private func withOrchestrator(
     structuredMemory: Bool,
+    enableAccessStatsScoring: Bool = false,
+    deterministicNowMs: Int64 = evaluationClockNowMs,
+    nowMsProvider: (@Sendable () -> Int64)? = nil,
     _ body: (MemoryOrchestrator) async throws -> Void
 ) async throws {
     let url = FileManager.default.temporaryDirectory
@@ -162,14 +257,15 @@ private func withOrchestrator(
     config.enableTextSearch = true
     config.enableVectorSearch = false
     config.enableStructuredMemory = structuredMemory
-    config.enableAccessStatsScoring = false
+    config.enableAccessStatsScoring = enableAccessStatsScoring
     config.rag.searchMode = .textOnly
-    config.rag.deterministicNowMs = evaluationClockNowMs
+    config.rag.deterministicNowMs = deterministicNowMs
+    let provider = nowMsProvider ?? { evaluationClockNowMs }
 
     let orchestrator = try await MemoryOrchestrator(
         at: url,
         config: config,
-        nowMsProvider: { evaluationClockNowMs }
+        nowMsProvider: provider
     )
     do {
         try await body(orchestrator)
@@ -180,46 +276,4 @@ private func withOrchestrator(
         try? FileManager.default.removeItem(at: url)
         throw error
     }
-}
-
-private func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-}
-
-private func fastRAGSource() throws -> String {
-    try String(
-        contentsOf: repoRoot().appendingPathComponent("Sources/Wax/RAG/FastRAGContextBuilder.swift"),
-        encoding: .utf8
-    )
-}
-
-private func orchestratorSource() throws -> String {
-    try String(
-        contentsOf: repoRoot().appendingPathComponent("Sources/Wax/Orchestrator/MemoryOrchestrator.swift"),
-        encoding: .utf8
-    )
-}
-
-private func functionBody(named name: String, in source: String) -> String? {
-    guard let nameRange = source.range(of: "func \(name)(") else { return nil }
-    let fromName = source[nameRange.lowerBound...]
-    guard let openBrace = fromName.firstIndex(of: "{") else { return nil }
-    var depth = 0
-    var index = openBrace
-    while index < fromName.endIndex {
-        let character = fromName[index]
-        if character == "{" {
-            depth += 1
-        } else if character == "}" {
-            depth -= 1
-            if depth == 0 {
-                return String(fromName[openBrace...index])
-            }
-        }
-        index = fromName.index(after: index)
-    }
-    return nil
 }


### PR DESCRIPTION
## Ticket
T1 of functional-evolution spec (run `c8b30767`). Independent of T2.

Discovery: evaluation-clock seam after PRs #140 / #153.

## What
`FastRAGContextBuilder.build` uses one `deterministicNowMs` for SearchRequest ranking, access rerank, and pack. No `Date()` in the builder. `MemoryOrchestrator` handoff `createdAtMs`, `upsertEntity`, and structured system time go through `nowProvider()`.

Public `Memory` / `SearchMode` unchanged. `SearchRequest.nowMs` default is unchanged (out of ticket scope).

## Why
Recall was already documented as `(store, query, nowMs)` but writes and FastRAG still mixed wall clock with the injected clock.

## Tests
- `swift test --filter EvaluationClockTests`
- `bash Resources/scripts/quality/public_repo_hygiene.sh`

## Review
- Step 6: `swift-adversarial-pr-review` (fix allowed)
- Step 7: `swift-adversarial-pr-review` final pass

## Residual
Direct `FastRAGContextBuilder.build` with `deterministicNowMs == nil` still passes `SearchRequest.nowMs = 0` (non-optional field). Orchestrator recall always injects now.