### PR TITLE
refactor(search): extract SearchPlan and package-visible RRF fusion

### DIFF
--- a/Sources/Wax/UnifiedSearch/HybridSearch.swift
+++ b/Sources/Wax/UnifiedSearch/HybridSearch.swift
@@ -1,5 +1,126 @@
 /// Hybrid search fusion helpers used by UnifiedSearch ranking.
 package enum HybridSearch {
+    /// One fused candidate after Reciprocal Rank Fusion.
+    package struct FusionResult: Sendable, Equatable {
+        package var frameId: UInt64
+        package var score: Float
+        package var sources: [SearchResponse.Source]
+        package var diagnostics: SearchResponse.RankingDiagnostics?
+    }
+
+    /// Reciprocal Rank Fusion across weighted lane id lists.
+    /// Sort: fused score desc, best lane rank asc, frameId asc.
+    package static func rrfFusionResults(
+        lists: [(source: SearchResponse.Source, weight: Float, frameIds: [UInt64])],
+        k: Int,
+        includeDiagnostics: Bool,
+        diagnosticsTopK: Int
+    ) -> [FusionResult] {
+        let kConstant = max(0, k)
+        struct Accumulator {
+            var score: Float = 0
+            var bestRank: Int = .max
+            var sources: [SearchResponse.Source] = []
+            var laneContributions: [SearchResponse.RankingLaneContribution] = []
+        }
+        let estimatedFrameCount = lists.reduce(into: 0) { partial, list in
+            partial += list.frameIds.count
+        }
+        var byFrame: [UInt64: Accumulator] = [:]
+        byFrame.reserveCapacity(estimatedFrameCount)
+
+        for list in lists {
+            guard list.weight > 0 else { continue }
+            for (rankZeroBased, frameId) in list.frameIds.enumerated() {
+                let rank = rankZeroBased + 1
+                let contribution = list.weight / Float(kConstant + rank)
+                var acc = byFrame[frameId] ?? Accumulator()
+                acc.score += contribution
+                acc.bestRank = min(acc.bestRank, rank)
+                if !acc.sources.contains(list.source) {
+                    acc.sources.append(list.source)
+                }
+                if includeDiagnostics {
+                    acc.laneContributions.append(
+                        .init(
+                            source: list.source,
+                            weight: list.weight,
+                            rank: rank,
+                            rrfScore: contribution
+                        )
+                    )
+                }
+                byFrame[frameId] = acc
+            }
+        }
+
+        var ranked: [RRFFusedCandidate] = []
+        ranked.reserveCapacity(byFrame.count)
+        for (frameId, acc) in byFrame {
+            let contributions = includeDiagnostics
+                ? acc.laneContributions.sorted { lhs, rhs in
+                    if lhs.rrfScore != rhs.rrfScore { return lhs.rrfScore > rhs.rrfScore }
+                    return lhs.source.rawValue < rhs.source.rawValue
+                }
+                : []
+            ranked.append(
+                RRFFusedCandidate(
+                    frameId: frameId,
+                    score: acc.score,
+                    bestRank: acc.bestRank,
+                    sources: acc.sources.sorted { $0.rawValue < $1.rawValue },
+                    laneContributions: contributions
+                )
+            )
+        }
+
+        ranked.sort { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            if lhs.bestRank != rhs.bestRank { return lhs.bestRank < rhs.bestRank }
+            return lhs.frameId < rhs.frameId
+        }
+
+        let topDiagLimit = max(1, diagnosticsTopK)
+        var fused: [FusionResult] = []
+        fused.reserveCapacity(ranked.count)
+        for index in ranked.indices {
+            let candidate = ranked[index]
+            let diagnostics: SearchResponse.RankingDiagnostics?
+            if includeDiagnostics, index < topDiagLimit {
+                let reason: SearchResponse.RankingTieBreakReason
+                if index == 0 {
+                    reason = .topResult
+                } else {
+                    let previous = ranked[index - 1]
+                    if previous.score != candidate.score {
+                        reason = .fusedScore
+                    } else if previous.bestRank != candidate.bestRank {
+                        reason = .bestLaneRank
+                    } else {
+                        reason = .frameID
+                    }
+                }
+                diagnostics = .init(
+                    bestLaneRank: candidate.bestRank == .max ? nil : candidate.bestRank,
+                    laneContributions: candidate.laneContributions,
+                    tieBreakReason: reason
+                )
+            } else {
+                diagnostics = nil
+            }
+
+            fused.append(
+                FusionResult(
+                    frameId: candidate.frameId,
+                    score: candidate.score,
+                    sources: candidate.sources,
+                    diagnostics: diagnostics
+                )
+            )
+        }
+        return fused
+    }
+
     /// Maps raw RRF (`weight / (k + rank)`) onto `0...1` without changing order.
     /// `totalWeight` is the sum of lane weights that contributed to fusion.
     package static func publishNormalizedRRFScores(
@@ -57,5 +178,12 @@ package enum HybridSearch {
         else { return nil }
         return (textIndex, vectorIndex)
     }
-}
 
+    private struct RRFFusedCandidate {
+        let frameId: UInt64
+        let score: Float
+        let bestRank: Int
+        let sources: [SearchResponse.Source]
+        let laneContributions: [SearchResponse.RankingLaneContribution]
+    }
+}

--- a/Sources/Wax/UnifiedSearch/SearchPlan.swift
+++ b/Sources/Wax/UnifiedSearch/SearchPlan.swift
@@ -1,0 +1,100 @@
+/// Pure pre-I/O description of which lanes and windows a `SearchRequest` will use.
+package struct SearchPlan: Sendable, Equatable {
+    package var trimmedQuery: String?
+    package var queryType: QueryType
+    package var weights: FusionWeights
+    package var includeText: Bool
+    package var includeVector: Bool
+    package var exactIntentWindow: Int?
+    package var candidateLimit: Int
+    package var matchPlan: MatchPlan?
+}
+
+package extension SearchPlan {
+    package static func make(_ request: SearchRequest) -> SearchPlan {
+        let trimmedQuery = request.query?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let queryType: QueryType
+        if let trimmedQuery, !trimmedQuery.isEmpty {
+            queryType = RuleBasedQueryClassifier.classify(trimmedQuery)
+        } else {
+            queryType = .exploratory
+        }
+
+        let includeText: Bool
+        let includeVector: Bool
+        switch request.mode {
+        case .textOnly:
+            includeText = true
+            includeVector = false
+        case .vectorOnly:
+            includeText = false
+            includeVector = true
+        case .hybrid:
+            includeText = true
+            includeVector = true
+        }
+
+        let requestedTopK = max(0, request.topK)
+        // Exact-intent overfetch + rerank are text-lane only. vectorOnly must not
+        // widen the pending window or promote a buried lexical frame.
+        let exactIntentWindow: Int? = (
+            includeText && (trimmedQuery.map(RuleBasedQueryClassifier.isExactIntentQuery) ?? false)
+        ) ? min(max(boundedMultiply(requestedTopK, by: 3), 12), 48) : nil
+
+        let matchPlan: MatchPlan?
+        if let trimmedQuery, !trimmedQuery.isEmpty {
+            matchPlan = MatchPlan.plan(query: trimmedQuery)
+        } else {
+            matchPlan = nil
+        }
+
+        return SearchPlan(
+            trimmedQuery: trimmedQuery,
+            queryType: queryType,
+            weights: AdaptiveFusionConfig.default.weights(for: queryType),
+            includeText: includeText,
+            includeVector: includeVector,
+            exactIntentWindow: exactIntentWindow,
+            candidateLimit: candidateLimit(
+                for: requestedTopK,
+                filter: request.frameFilter ?? FrameFilter()
+            ),
+            matchPlan: matchPlan
+        )
+    }
+
+    private static func candidateLimit(for topK: Int) -> Int {
+        guard topK > 0 else { return 0 }
+        let expanded = boundedMultiply(topK, by: 3)
+        let capped = min(expanded, 1000)
+        // Keep the public request's topK from becoming an unbounded SQLite or
+        // vector-engine limit. FTS independently caps at 10,000; matching the
+        // same ceiling here also makes Int.max requests safe.
+        return min(max(topK, capped), 10_000)
+    }
+
+    private static func candidateLimit(for topK: Int, filter: FrameFilter) -> Int {
+        let baseLimit = candidateLimit(for: topK)
+        guard needsCallerFilterOverfetch(filter) else { return baseLimit }
+
+        let multiplied = boundedMultiply(topK, by: 5)
+        let withSlack = topK > Int.max - 200 ? Int.max : topK + 200
+        let overfetchLimit = min(1000, max(multiplied, withSlack))
+        return max(baseLimit, overfetchLimit)
+    }
+
+    private static func boundedMultiply(_ value: Int, by multiplier: Int) -> Int {
+        guard value > 0, multiplier > 0 else { return 0 }
+        guard value <= Int.max / multiplier else { return Int.max }
+        return value * multiplier
+    }
+
+    private static func needsCallerFilterOverfetch(_ filter: FrameFilter) -> Bool {
+        if filter.frameIds != nil { return true }
+        guard let metadataFilter = filter.metadataFilter else { return false }
+        return !metadataFilter.requiredEntries.isEmpty
+            || !metadataFilter.requiredTags.isEmpty
+            || !metadataFilter.requiredLabels.isEmpty
+    }
+}

--- a/Sources/Wax/UnifiedSearch/SearchPlan.swift
+++ b/Sources/Wax/UnifiedSearch/SearchPlan.swift
@@ -11,7 +11,7 @@ package struct SearchPlan: Sendable, Equatable {
 }
 
 package extension SearchPlan {
-    package static func make(_ request: SearchRequest) -> SearchPlan {
+    static func make(_ request: SearchRequest) -> SearchPlan {
         let trimmedQuery = request.query?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let queryType: QueryType
@@ -64,6 +64,13 @@ package extension SearchPlan {
         )
     }
 
+    /// Overflow-safe `value * multiplier` used for overfetch and rerank windows.
+    static func boundedMultiply(_ value: Int, by multiplier: Int) -> Int {
+        guard value > 0, multiplier > 0 else { return 0 }
+        guard value <= Int.max / multiplier else { return Int.max }
+        return value * multiplier
+    }
+
     private static func candidateLimit(for topK: Int) -> Int {
         guard topK > 0 else { return 0 }
         let expanded = boundedMultiply(topK, by: 3)
@@ -82,12 +89,6 @@ package extension SearchPlan {
         let withSlack = topK > Int.max - 200 ? Int.max : topK + 200
         let overfetchLimit = min(1000, max(multiplied, withSlack))
         return max(baseLimit, overfetchLimit)
-    }
-
-    private static func boundedMultiply(_ value: Int, by multiplier: Int) -> Int {
-        guard value > 0, multiplier > 0 else { return 0 }
-        guard value <= Int.max / multiplier else { return Int.max }
-        return value * multiplier
     }
 
     private static func needsCallerFilterOverfetch(_ filter: FrameFilter) -> Bool {

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -31,43 +31,22 @@ extension Wax {
         // agree within one search. asOfMs is a structured-fact cutoff, not ranking-now.
         let semanticNowMs = request.nowMs
 
-        let trimmedQuery = request.query?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let queryType: QueryType
-        if let trimmedQuery, !trimmedQuery.isEmpty {
-            queryType = RuleBasedQueryClassifier.classify(trimmedQuery)
-        } else {
-            queryType = .exploratory
-        }
-
-        let weights = AdaptiveFusionConfig.default.weights(for: queryType)
+        let plan = SearchPlan.make(request)
+        let trimmedQuery = plan.trimmedQuery
+        let queryType = plan.queryType
+        let weights = plan.weights
+        let includeText = plan.includeText
+        let includeVector = plan.includeVector
+        let exactIntentWindow = plan.exactIntentWindow
+        let candidateLimit = plan.candidateLimit
         let filter = request.frameFilter ?? FrameFilter()
 
-        let includeText: Bool
-        let includeVector: Bool
-        switch request.mode {
-        case .textOnly:
-            includeText = true
-            includeVector = false
-        case .vectorOnly:
+        if case .vectorOnly = request.mode {
             let hasEmbedding = !(request.embedding?.isEmpty ?? true)
             guard hasEmbedding else {
                 throw WaxError.io("vectorOnly search requires a non-empty query embedding")
             }
-            includeText = false
-            includeVector = true
-        case .hybrid:
-            includeText = true
-            includeVector = true
         }
-
-        // Exact-intent overfetch + rerank are text-lane only. vectorOnly must not
-        // widen the pending window or promote a buried lexical frame.
-        let exactIntentWindow: Int? = (
-            includeText && (trimmedQuery.map(RuleBasedQueryClassifier.isExactIntentQuery) ?? false)
-        ) ? min(max(Self.boundedMultiply(requestedTopK, by: 3), 12), 48) : nil
-
-        let candidateLimit = Self.candidateLimit(for: requestedTopK, filter: filter)
         let cache = UnifiedSearchEngineCache.shared
         let textEngine: FTS5SearchEngine? = if includeText {
             if let override = engineOverrides?.textEngine {
@@ -131,12 +110,12 @@ extension Wax {
             }
             // Empty MATCH plans (stopwords / operators only) must not fall back to
             // the raw user string — FTS5 would interpret AND/OR/NOT/NEAR as syntax.
-            guard let plan = MatchPlan.plan(query: trimmedQuery) else {
+            guard let matchPlan = plan.matchPlan else {
                 return ([], false)
             }
-            let primaryQuery = plan.primaryMatch
-            let fallbackQuery = plan.fallbackMatch
-            let queryTokenCount = plan.tokenCount
+            let primaryQuery = matchPlan.primaryMatch
+            let fallbackQuery = matchPlan.fallbackMatch
+            let queryTokenCount = matchPlan.tokenCount
 
             func merged(
                 base: [TextSearchResult],
@@ -319,7 +298,7 @@ extension Wax {
                 }
             } else {
                 let (textIds, textSet) = Self.frameIDsAndSet(from: textResults.lazy.map(\.frameId))
-                let fused = Self.rrfFusionResults(
+                let fused = HybridSearch.rrfFusionResults(
                     lists: [
                         (source: .text, weight: weights.bm25, frameIds: textIds),
                         (source: .structured, weight: structuredWeight, frameIds: structuredIds),
@@ -370,7 +349,7 @@ extension Wax {
                 }
             } else {
                 let (vectorIds, vectorSet) = Self.frameIDsAndSet(from: vectorResults.lazy.map(\.frameId))
-                let fused = Self.rrfFusionResults(
+                let fused = HybridSearch.rrfFusionResults(
                     lists: [
                         (source: .vector, weight: weights.vector, frameIds: vectorIds),
                         (source: .structured, weight: structuredWeight, frameIds: structuredIds),
@@ -438,7 +417,7 @@ extension Wax {
                 break
             }
 
-            var fused = Self.rrfFusionResults(
+            var fused = HybridSearch.rrfFusionResults(
                 lists: lists,
                 k: request.rrfK,
                 includeDiagnostics: diagnosticsEnabled,
@@ -802,125 +781,6 @@ extension Wax {
         return results.map { scoredAsORFallbackOnly($0, tokenCount: tokenCount) }
     }
 
-    private struct RRFFusedCandidate {
-        let frameId: UInt64
-        let score: Float
-        let bestRank: Int
-        let sources: [SearchResponse.Source]
-        let laneContributions: [SearchResponse.RankingLaneContribution]
-    }
-
-    private static func rrfFusionResults(
-        lists: [(source: SearchResponse.Source, weight: Float, frameIds: [UInt64])],
-        k: Int,
-        includeDiagnostics: Bool,
-        diagnosticsTopK: Int
-    ) -> [(frameId: UInt64, score: Float, sources: [SearchResponse.Source], diagnostics: SearchResponse.RankingDiagnostics?)] {
-        let kConstant = max(0, k)
-        struct Accumulator {
-            var score: Float = 0
-            var bestRank: Int = .max
-            var sources: [SearchResponse.Source] = []
-            var laneContributions: [SearchResponse.RankingLaneContribution] = []
-        }
-        let estimatedFrameCount = lists.reduce(into: 0) { partial, list in
-            partial += list.frameIds.count
-        }
-        var byFrame: [UInt64: Accumulator] = [:]
-        byFrame.reserveCapacity(estimatedFrameCount)
-
-        for list in lists {
-            guard list.weight > 0 else { continue }
-            for (rankZeroBased, frameId) in list.frameIds.enumerated() {
-                let rank = rankZeroBased + 1
-                let contribution = list.weight / Float(kConstant + rank)
-                var acc = byFrame[frameId] ?? Accumulator()
-                acc.score += contribution
-                acc.bestRank = min(acc.bestRank, rank)
-                if !acc.sources.contains(list.source) {
-                    acc.sources.append(list.source)
-                }
-                if includeDiagnostics {
-                    acc.laneContributions.append(
-                        .init(
-                            source: list.source,
-                            weight: list.weight,
-                            rank: rank,
-                            rrfScore: contribution
-                        )
-                    )
-                }
-                byFrame[frameId] = acc
-            }
-        }
-
-        var ranked: [RRFFusedCandidate] = []
-        ranked.reserveCapacity(byFrame.count)
-        for (frameId, acc) in byFrame {
-            let contributions = includeDiagnostics
-                ? acc.laneContributions.sorted { lhs, rhs in
-                    if lhs.rrfScore != rhs.rrfScore { return lhs.rrfScore > rhs.rrfScore }
-                    return lhs.source.rawValue < rhs.source.rawValue
-                }
-                : []
-            ranked.append(
-                RRFFusedCandidate(
-                    frameId: frameId,
-                    score: acc.score,
-                    bestRank: acc.bestRank,
-                    sources: acc.sources.sorted { $0.rawValue < $1.rawValue },
-                    laneContributions: contributions
-                )
-            )
-        }
-
-        ranked.sort { lhs, rhs in
-            if lhs.score != rhs.score { return lhs.score > rhs.score }
-            if lhs.bestRank != rhs.bestRank { return lhs.bestRank < rhs.bestRank }
-            return lhs.frameId < rhs.frameId
-        }
-
-        let topDiagLimit = max(1, diagnosticsTopK)
-        var fused: [(frameId: UInt64, score: Float, sources: [SearchResponse.Source], diagnostics: SearchResponse.RankingDiagnostics?)] = []
-        fused.reserveCapacity(ranked.count)
-        for index in ranked.indices {
-            let candidate = ranked[index]
-            let diagnostics: SearchResponse.RankingDiagnostics?
-            if includeDiagnostics, index < topDiagLimit {
-                let reason: SearchResponse.RankingTieBreakReason
-                if index == 0 {
-                    reason = .topResult
-                } else {
-                    let previous = ranked[index - 1]
-                    if previous.score != candidate.score {
-                        reason = .fusedScore
-                    } else if previous.bestRank != candidate.bestRank {
-                        reason = .bestLaneRank
-                    } else {
-                        reason = .frameID
-                    }
-                }
-                diagnostics = .init(
-                    bestLaneRank: candidate.bestRank == .max ? nil : candidate.bestRank,
-                    laneContributions: candidate.laneContributions,
-                    tieBreakReason: reason
-                )
-            } else {
-                diagnostics = nil
-            }
-
-            fused.append(
-                (
-                    frameId: candidate.frameId,
-                    score: candidate.score,
-                    sources: candidate.sources,
-                    diagnostics: diagnostics
-                )
-            )
-        }
-        return fused
-    }
-
     package static func dehighlightedPreviewText(_ text: String) -> String {
         UnifiedRanking.dehighlightedPreviewText(text)
     }
@@ -983,38 +843,10 @@ extension Wax {
         return sorted.prefix(capped).map { EntityKey($0.key) }
     }
 
-    private static func candidateLimit(for topK: Int) -> Int {
-        guard topK > 0 else { return 0 }
-        let expanded = boundedMultiply(topK, by: 3)
-        let capped = min(expanded, 1000)
-        // Keep the public request's topK from becoming an unbounded SQLite or
-        // vector-engine limit. FTS independently caps at 10,000; matching the
-        // same ceiling here also makes Int.max requests safe.
-        return min(max(topK, capped), 10_000)
-    }
-
-    private static func candidateLimit(for topK: Int, filter: FrameFilter) -> Int {
-        let baseLimit = candidateLimit(for: topK)
-        guard needsCallerFilterOverfetch(filter) else { return baseLimit }
-
-        let multiplied = boundedMultiply(topK, by: 5)
-        let withSlack = topK > Int.max - 200 ? Int.max : topK + 200
-        let overfetchLimit = min(1000, max(multiplied, withSlack))
-        return max(baseLimit, overfetchLimit)
-    }
-
     private static func boundedMultiply(_ value: Int, by multiplier: Int) -> Int {
         guard value > 0, multiplier > 0 else { return 0 }
         guard value <= Int.max / multiplier else { return Int.max }
         return value * multiplier
-    }
-
-    private static func needsCallerFilterOverfetch(_ filter: FrameFilter) -> Bool {
-        if filter.frameIds != nil { return true }
-        guard let metadataFilter = filter.metadataFilter else { return false }
-        return !metadataFilter.requiredEntries.isEmpty
-            || !metadataFilter.requiredTags.isEmpty
-            || !metadataFilter.requiredLabels.isEmpty
     }
 
     private static func frameIDsAndSet<S: Sequence>(from frameIDs: S) -> ([UInt64], Set<UInt64>)

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -620,14 +620,14 @@ extension Wax {
             filtered = UnifiedRanking.intentAwareRerank(
                 results: filtered,
                 query: trimmedQuery,
-                maxWindow: min(max(Self.boundedMultiply(request.topK, by: 2), 10), 32)
+                maxWindow: min(max(SearchPlan.boundedMultiply(request.topK, by: 2), 10), 32)
             )
         }
         filtered = UnifiedRanking.semanticMemoryRerank(
             results: filtered,
             scopeContext: request.scopeContext,
             nowMs: semanticNowMs,
-            maxWindow: min(max(Self.boundedMultiply(request.topK, by: 3), 12), 48)
+            maxWindow: min(max(SearchPlan.boundedMultiply(request.topK, by: 3), 12), 48)
         )
         if let exactIntentWindow, let trimmedQuery {
             filtered = UnifiedRanking.identifierExactMatchRerank(
@@ -841,12 +841,6 @@ extension Wax {
         }
 
         return sorted.prefix(capped).map { EntityKey($0.key) }
-    }
-
-    private static func boundedMultiply(_ value: Int, by multiplier: Int) -> Int {
-        guard value > 0, multiplier > 0 else { return 0 }
-        guard value <= Int.max / multiplier else { return Int.max }
-        return value * multiplier
     }
 
     private static func frameIDsAndSet<S: Sequence>(from frameIDs: S) -> ([UInt64], Set<UInt64>)

--- a/Tests/WaxTests/HybridFusionTests.swift
+++ b/Tests/WaxTests/HybridFusionTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 struct HybridFusionTests {
     @Test
-    func singleLaneOrdersByRankAndPinsTopKDiagnostics() {
+    func singleLaneOrdersByRankAndPinsTopKDiagnostics() throws {
         let fused = HybridSearch.rrfFusionResults(
             lists: [
                 (source: .text, weight: 0.7, frameIds: [2, 1]),
@@ -13,6 +13,7 @@ struct HybridFusionTests {
             diagnosticsTopK: 10
         )
 
+        try #require(fused.count == 2)
         #expect(fused.map(\.frameId) == [2, 1])
         #expect(fused[0].score == Float(0.7) / 61)
         #expect(fused[1].score == Float(0.7) / 62)
@@ -22,10 +23,16 @@ struct HybridFusionTests {
         #expect(fused[0].diagnostics?.bestLaneRank == 1)
         #expect(fused[1].diagnostics?.tieBreakReason == .fusedScore)
         #expect(fused[1].diagnostics?.bestLaneRank == 2)
+        let topContributions = try #require(fused[0].diagnostics?.laneContributions)
+        try #require(topContributions.count == 1)
+        #expect(topContributions[0].source == .text)
+        #expect(topContributions[0].weight == 0.7)
+        #expect(topContributions[0].rank == 1)
+        #expect(topContributions[0].rrfScore == Float(0.7) / 61)
     }
 
     @Test
-    func twoExclusiveLanesFuseByReciprocalRank() {
+    func twoExclusiveLanesFuseByReciprocalRank() throws {
         let fused = HybridSearch.rrfFusionResults(
             lists: [
                 (source: .text, weight: 0.7, frameIds: [2, 1]),
@@ -36,6 +43,7 @@ struct HybridFusionTests {
             diagnosticsTopK: 10
         )
 
+        try #require(fused.count == 3)
         #expect(fused.map(\.frameId) == [1, 2, 3])
         #expect(fused[0].score == (Float(0.7) / 62) + (Float(0.3) / 61))
         #expect(fused[1].score == Float(0.7) / 61)
@@ -49,10 +57,18 @@ struct HybridFusionTests {
         #expect(fused[0].diagnostics?.bestLaneRank == 1)
         #expect(fused[1].diagnostics?.bestLaneRank == 1)
         #expect(fused[2].diagnostics?.bestLaneRank == 2)
+
+        let overlap = try #require(fused[0].diagnostics?.laneContributions)
+        try #require(overlap.count == 2)
+        #expect(overlap.map(\.source) == [.text, .vector])
+        #expect(overlap[0].rank == 2)
+        #expect(overlap[0].rrfScore == Float(0.7) / 62)
+        #expect(overlap[1].rank == 1)
+        #expect(overlap[1].rrfScore == Float(0.3) / 61)
     }
 
     @Test
-    func equalFusedScoreBreaksTiesByBestLaneRank() {
+    func equalFusedScoreBreaksTiesByBestLaneRank() throws {
         let fused = HybridSearch.rrfFusionResults(
             lists: [
                 (source: .text, weight: 2, frameIds: [100, 10]),
@@ -63,7 +79,11 @@ struct HybridFusionTests {
             diagnosticsTopK: 10
         )
 
+        try #require(fused.count == 3)
         #expect(fused.map(\.frameId) == [100, 20, 10])
+        #expect(fused[0].score == 2)
+        #expect(fused[1].score == 1)
+        #expect(fused[2].score == 1)
         #expect(fused[1].score == fused[2].score)
         #expect(fused[1].diagnostics?.bestLaneRank == 1)
         #expect(fused[2].diagnostics?.bestLaneRank == 2)
@@ -73,27 +93,32 @@ struct HybridFusionTests {
     }
 
     @Test
-    func remainingTieBreaksByFrameId() {
+    func remainingTieBreaksByFrameId() throws {
         let fused = HybridSearch.rrfFusionResults(
             lists: [
-                (source: .text, weight: 1, frameIds: [5]),
-                (source: .vector, weight: 1, frameIds: [3]),
+                (source: .text, weight: 1, frameIds: [9]),
+                (source: .vector, weight: 1, frameIds: [4]),
+                (source: .structured, weight: 1, frameIds: [7]),
             ],
             k: 60,
             includeDiagnostics: true,
             diagnosticsTopK: 10
         )
 
-        #expect(fused.map(\.frameId) == [3, 5])
+        try #require(fused.count == 3)
+        #expect(fused.map(\.frameId) == [4, 7, 9])
         #expect(fused[0].score == fused[1].score)
+        #expect(fused[1].score == fused[2].score)
         #expect(fused[0].diagnostics?.bestLaneRank == 1)
         #expect(fused[1].diagnostics?.bestLaneRank == 1)
+        #expect(fused[2].diagnostics?.bestLaneRank == 1)
         #expect(fused[0].diagnostics?.tieBreakReason == .topResult)
         #expect(fused[1].diagnostics?.tieBreakReason == .frameID)
+        #expect(fused[2].diagnostics?.tieBreakReason == .frameID)
     }
 
     @Test
-    func diagnosticsAttachOnlyToTopK() {
+    func diagnosticsAttachOnlyToTopK() throws {
         let fused = HybridSearch.rrfFusionResults(
             lists: [
                 (source: .text, weight: 0.7, frameIds: [2, 1]),
@@ -104,9 +129,28 @@ struct HybridFusionTests {
             diagnosticsTopK: 1
         )
 
-        #expect(fused.count == 3)
+        try #require(fused.count == 3)
         #expect(fused[0].diagnostics?.tieBreakReason == .topResult)
         #expect(fused[1].diagnostics == nil)
         #expect(fused[2].diagnostics == nil)
+    }
+
+    @Test
+    func zeroWeightLaneIsIgnoredAndDiagnosticsCanBeOmitted() throws {
+        let fused = HybridSearch.rrfFusionResults(
+            lists: [
+                (source: .text, weight: 0, frameIds: [2, 1]),
+                (source: .vector, weight: 0.3, frameIds: [3]),
+            ],
+            k: 60,
+            includeDiagnostics: false,
+            diagnosticsTopK: 10
+        )
+
+        try #require(fused.count == 1)
+        #expect(fused[0].frameId == 3)
+        #expect(fused[0].score == Float(0.3) / 61)
+        #expect(fused[0].sources == [.vector])
+        #expect(fused[0].diagnostics == nil)
     }
 }

--- a/Tests/WaxTests/HybridFusionTests.swift
+++ b/Tests/WaxTests/HybridFusionTests.swift
@@ -1,0 +1,112 @@
+import Testing
+@testable import Wax
+
+struct HybridFusionTests {
+    @Test
+    func singleLaneOrdersByRankAndPinsTopKDiagnostics() {
+        let fused = HybridSearch.rrfFusionResults(
+            lists: [
+                (source: .text, weight: 0.7, frameIds: [2, 1]),
+            ],
+            k: 60,
+            includeDiagnostics: true,
+            diagnosticsTopK: 10
+        )
+
+        #expect(fused.map(\.frameId) == [2, 1])
+        #expect(fused[0].score == Float(0.7) / 61)
+        #expect(fused[1].score == Float(0.7) / 62)
+        #expect(fused[0].sources == [.text])
+        #expect(fused[1].sources == [.text])
+        #expect(fused[0].diagnostics?.tieBreakReason == .topResult)
+        #expect(fused[0].diagnostics?.bestLaneRank == 1)
+        #expect(fused[1].diagnostics?.tieBreakReason == .fusedScore)
+        #expect(fused[1].diagnostics?.bestLaneRank == 2)
+    }
+
+    @Test
+    func twoExclusiveLanesFuseByReciprocalRank() {
+        let fused = HybridSearch.rrfFusionResults(
+            lists: [
+                (source: .text, weight: 0.7, frameIds: [2, 1]),
+                (source: .vector, weight: 0.3, frameIds: [1, 3]),
+            ],
+            k: 60,
+            includeDiagnostics: true,
+            diagnosticsTopK: 10
+        )
+
+        #expect(fused.map(\.frameId) == [1, 2, 3])
+        #expect(fused[0].score == (Float(0.7) / 62) + (Float(0.3) / 61))
+        #expect(fused[1].score == Float(0.7) / 61)
+        #expect(fused[2].score == Float(0.3) / 62)
+        #expect(fused[0].sources == [.text, .vector])
+        #expect(fused[1].sources == [.text])
+        #expect(fused[2].sources == [.vector])
+        #expect(fused[0].diagnostics?.tieBreakReason == .topResult)
+        #expect(fused[1].diagnostics?.tieBreakReason == .fusedScore)
+        #expect(fused[2].diagnostics?.tieBreakReason == .fusedScore)
+        #expect(fused[0].diagnostics?.bestLaneRank == 1)
+        #expect(fused[1].diagnostics?.bestLaneRank == 1)
+        #expect(fused[2].diagnostics?.bestLaneRank == 2)
+    }
+
+    @Test
+    func equalFusedScoreBreaksTiesByBestLaneRank() {
+        let fused = HybridSearch.rrfFusionResults(
+            lists: [
+                (source: .text, weight: 2, frameIds: [100, 10]),
+                (source: .vector, weight: 1, frameIds: [20]),
+            ],
+            k: 0,
+            includeDiagnostics: true,
+            diagnosticsTopK: 10
+        )
+
+        #expect(fused.map(\.frameId) == [100, 20, 10])
+        #expect(fused[1].score == fused[2].score)
+        #expect(fused[1].diagnostics?.bestLaneRank == 1)
+        #expect(fused[2].diagnostics?.bestLaneRank == 2)
+        #expect(fused[0].diagnostics?.tieBreakReason == .topResult)
+        #expect(fused[1].diagnostics?.tieBreakReason == .fusedScore)
+        #expect(fused[2].diagnostics?.tieBreakReason == .bestLaneRank)
+    }
+
+    @Test
+    func remainingTieBreaksByFrameId() {
+        let fused = HybridSearch.rrfFusionResults(
+            lists: [
+                (source: .text, weight: 1, frameIds: [5]),
+                (source: .vector, weight: 1, frameIds: [3]),
+            ],
+            k: 60,
+            includeDiagnostics: true,
+            diagnosticsTopK: 10
+        )
+
+        #expect(fused.map(\.frameId) == [3, 5])
+        #expect(fused[0].score == fused[1].score)
+        #expect(fused[0].diagnostics?.bestLaneRank == 1)
+        #expect(fused[1].diagnostics?.bestLaneRank == 1)
+        #expect(fused[0].diagnostics?.tieBreakReason == .topResult)
+        #expect(fused[1].diagnostics?.tieBreakReason == .frameID)
+    }
+
+    @Test
+    func diagnosticsAttachOnlyToTopK() {
+        let fused = HybridSearch.rrfFusionResults(
+            lists: [
+                (source: .text, weight: 0.7, frameIds: [2, 1]),
+                (source: .vector, weight: 0.3, frameIds: [1, 3]),
+            ],
+            k: 60,
+            includeDiagnostics: true,
+            diagnosticsTopK: 1
+        )
+
+        #expect(fused.count == 3)
+        #expect(fused[0].diagnostics?.tieBreakReason == .topResult)
+        #expect(fused[1].diagnostics == nil)
+        #expect(fused[2].diagnostics == nil)
+    }
+}

--- a/Tests/WaxTests/SearchPlanTests.swift
+++ b/Tests/WaxTests/SearchPlanTests.swift
@@ -51,4 +51,60 @@ struct SearchPlanTests {
         #expect(empty.includeVector)
         #expect(empty.exactIntentWindow == nil)
     }
+
+    @Test
+    func hybridIncludesBothLanesWithoutExactIntentWindow() {
+        let plan = SearchPlan.make(
+            SearchRequest(query: "hello world", mode: .hybrid(), nowMs: 0)
+        )
+        #expect(plan.includeText)
+        #expect(plan.includeVector)
+        #expect(plan.queryType == .exploratory)
+        #expect(plan.exactIntentWindow == nil)
+        #expect(plan.candidateLimit == 30)
+        #expect(plan.matchPlan != nil)
+    }
+
+    @Test(arguments: [(1, 12), (10, 30), (20, 48)])
+    func exactIntentWindowClampsToTwelveAndFortyEight(topK: Int, window: Int) {
+        let plan = SearchPlan.make(SearchRequest(query: "7f3a91", topK: topK, nowMs: 0))
+        #expect(plan.exactIntentWindow == window)
+        #expect(plan.includeText)
+        #expect(plan.includeVector == false)
+    }
+
+    @Test
+    func callerFilterOverfetchesCandidateLimit() {
+        let allowlist = SearchPlan.make(
+            SearchRequest(
+                query: "hello world",
+                topK: 10,
+                frameFilter: FrameFilter(frameIds: [1]),
+                nowMs: 0
+            )
+        )
+        #expect(allowlist.candidateLimit == 210)
+
+        let metadata = SearchPlan.make(
+            SearchRequest(
+                query: "hello world",
+                topK: 10,
+                frameFilter: FrameFilter(
+                    metadataFilter: MetadataFilter(requiredEntries: ["k": "v"])
+                ),
+                nowMs: 0
+            )
+        )
+        #expect(metadata.candidateLimit == 210)
+
+        let emptyMetadata = SearchPlan.make(
+            SearchRequest(
+                query: "hello world",
+                topK: 10,
+                frameFilter: FrameFilter(metadataFilter: MetadataFilter()),
+                nowMs: 0
+            )
+        )
+        #expect(emptyMetadata.candidateLimit == 30)
+    }
 }

--- a/Tests/WaxTests/SearchPlanTests.swift
+++ b/Tests/WaxTests/SearchPlanTests.swift
@@ -1,0 +1,54 @@
+import Testing
+@testable import Wax
+
+struct SearchPlanTests {
+    @Test
+    func emptyQueryIsExploratoryTextOnly() {
+        let whitespace = SearchPlan.make(SearchRequest(query: "   ", nowMs: 0))
+        #expect(whitespace.trimmedQuery == "")
+        #expect(whitespace.queryType == .exploratory)
+        #expect(whitespace.includeText)
+        #expect(whitespace.includeVector == false)
+        #expect(whitespace.exactIntentWindow == nil)
+        #expect(whitespace.matchPlan == nil)
+        #expect(whitespace.weights == FusionWeights(bm25: 0.4, vector: 0.5, temporal: 0.1))
+
+        let omitted = SearchPlan.make(SearchRequest(query: nil, nowMs: 0))
+        #expect(omitted.trimmedQuery == nil)
+        #expect(omitted.queryType == .exploratory)
+        #expect(omitted.includeText)
+        #expect(omitted.includeVector == false)
+        #expect(omitted.matchPlan == nil)
+    }
+
+    @Test
+    func factualIdentifierPlansLexicalLaneAndExactIntentWindow() {
+        let plan = SearchPlan.make(SearchRequest(query: "7f3a91", topK: 10, nowMs: 0))
+        #expect(plan.trimmedQuery == "7f3a91")
+        #expect(plan.queryType == .factual)
+        #expect(plan.includeText)
+        #expect(plan.includeVector == false)
+        #expect(plan.exactIntentWindow == 30)
+        #expect(plan.candidateLimit == 30)
+        #expect(plan.matchPlan != nil)
+        #expect(plan.weights == FusionWeights(bm25: 0.7, vector: 0.3, temporal: 0.0))
+    }
+
+    @Test
+    func vectorOnlyWithoutEmbeddingSetsIncludeFlagsAndDoesNotThrow() {
+        let missing = SearchPlan.make(
+            SearchRequest(query: "7f3a91", embedding: nil, mode: .vectorOnly, nowMs: 0)
+        )
+        #expect(missing.includeText == false)
+        #expect(missing.includeVector)
+        #expect(missing.exactIntentWindow == nil)
+        #expect(missing.queryType == .factual)
+
+        let empty = SearchPlan.make(
+            SearchRequest(query: "7f3a91", embedding: [], mode: .vectorOnly, nowMs: 0)
+        )
+        #expect(empty.includeText == false)
+        #expect(empty.includeVector)
+        #expect(empty.exactIntentWindow == nil)
+    }
+}


### PR DESCRIPTION
## Ticket
T2 of functional-evolution spec (run `c8b30767`). Independent of T1.

## What
Move Reciprocal Rank Fusion to package `HybridSearch.rrfFusionResults` (`FusionResult`). Add `SearchPlan.make(SearchRequest)` for pre-I/O lane/window decisions. `Wax.search` stays the deep facade; `vectorOnly` empty embedding still throws in the search shell.

Public `SearchMode` / `Memory.search` unchanged. Package-only types are not named in public docs.

## Why
`rrfFusionResults` was private inside a 1k-line effectful method. Fusion tie-breaks and plan flags can now be tested without FTS or MiniLM.

## Tests
- `swift test --filter HybridFusionTests`
- `swift test --filter SearchPlanTests`
- `swift test --filter HybridSearchTests`
- `bash Resources/scripts/quality/public_repo_hygiene.sh`

## Review
- Step 6: `swift-pr-review` (fix allowed)
- Step 7: `swift-pr-review` final pass