### PR TITLE
fix(mcp): stop unresolved session search leaking foreign durable

### DIFF
--- a/Resources/hermes/wax-memory-plugin/hermes_wax_memory.py
+++ b/Resources/hermes/wax-memory-plugin/hermes_wax_memory.py
@@ -146,11 +146,6 @@ def _yaml_section_scalars(text: str, section: str) -> Dict[str, Any]:
             if indent == 0 and (stripped == f"{section}:" or stripped.startswith(f"{section}:")):
                 in_section = True
                 section_indent = indent
-                inline = stripped.split(":", 1)[1].strip()
-                if inline and not inline.startswith(("{", "[")):
-                    # Ignore `wax_memory: true` style scalars; we want a mapping.
-                    if inline.lower() not in {"true", "false", "yes", "no", "on", "off", "null", "~"}:
-                        pass
             continue
         if indent <= section_indent:
             break

--- a/Resources/hermes/wax-memory-plugin/tests/test_wax_memory_provider.py
+++ b/Resources/hermes/wax-memory-plugin/tests/test_wax_memory_provider.py
@@ -154,6 +154,16 @@ class ConfigResolutionTests(unittest.TestCase):
             provider = plugin.WaxMemoryProvider(config=cfg)
             self.assertFalse(provider.auto_start_enabled())
 
+    def test_yaml_section_ignores_inline_scalar_header(self) -> None:
+        values = plugin._yaml_section_scalars("wax_memory: true\n", "wax_memory")
+        self.assertEqual(values, {})
+        nested = plugin._yaml_section_scalars(
+            "wax_memory: true\n  auto_start: true\n  endpoint: http://127.0.0.1:3000/mcp\n",
+            "wax_memory",
+        )
+        self.assertEqual(nested.get("auto_start"), True)
+        self.assertEqual(nested.get("endpoint"), "http://127.0.0.1:3000/mcp")
+
 
 class AutoStartTests(unittest.TestCase):
     class Process:
@@ -977,6 +987,18 @@ class ToolRoutingTests(unittest.TestCase):
         self.assertIn("project", properties)
         self.assertIn("repo", properties)
         self.assertIn("cwd", properties)
+        self.assertIn(
+            "hard-filters to the resolved project/repo",
+            properties["scope"]["description"],
+        )
+        self.assertIn("session skips durable merge", properties["scope"]["description"])
+        self.assertIn("wax.project", properties["project"]["description"])
+        self.assertIn("wax.repo", properties["repo"]["description"])
+        self.assertIn(
+            "Optional client working directory used to infer project/repo when not explicit",
+            properties["cwd"]["description"],
+        )
+        self.assertIn("host injects", properties["cwd"]["description"])
         description = recall["description"].lower()
         self.assertIn("recent", description)
         self.assertIn("exact", description)

--- a/Resources/hermes/wax-memory-plugin/wax_memory_schemas.py
+++ b/Resources/hermes/wax-memory-plugin/wax_memory_schemas.py
@@ -103,14 +103,20 @@ TOOL_SCHEMAS = {
             "scope": {
                 "type": "string",
                 "enum": ["project", "session", "global"],
-                "description": "Project is the default relevance scope; global searches every project and is not an authorization boundary.",
+                "description": "Recall scope. project (default) hard-filters to the resolved project/repo; session skips durable merge when a session_id is supplied; global searches the complete trusted local store without current-project boost (it is not an authorization boundary).",
             },
-            "project": {"type": "string"},
+            "project": {
+                "type": "string",
+                "description": "Optional project hard-filter. Default scope=project keeps only frames with matching wax.project.",
+            },
             "repo": {
                 "type": "string",
-                "description": "Exact repo filter; when project is also supplied, both must match.",
+                "description": "Optional exact wax.repo hard-filter. When project is also set, both filters must match.",
             },
-            "cwd": {"type": "string"},
+            "cwd": {
+                "type": "string",
+                "description": "Optional client working directory used to infer project/repo when not explicit; omit and the host injects it.",
+            },
             "search_top_k": {"type": "integer", "minimum": 1, "maximum": 200},
         },
         ["query"],

--- a/Resources/npm/waxmcp/plugins/hermes/hermes_wax_memory.py
+++ b/Resources/npm/waxmcp/plugins/hermes/hermes_wax_memory.py
@@ -146,11 +146,6 @@ def _yaml_section_scalars(text: str, section: str) -> Dict[str, Any]:
             if indent == 0 and (stripped == f"{section}:" or stripped.startswith(f"{section}:")):
                 in_section = True
                 section_indent = indent
-                inline = stripped.split(":", 1)[1].strip()
-                if inline and not inline.startswith(("{", "[")):
-                    # Ignore `wax_memory: true` style scalars; we want a mapping.
-                    if inline.lower() not in {"true", "false", "yes", "no", "on", "off", "null", "~"}:
-                        pass
             continue
         if indent <= section_indent:
             break

--- a/Resources/npm/waxmcp/plugins/hermes/wax_memory_schemas.py
+++ b/Resources/npm/waxmcp/plugins/hermes/wax_memory_schemas.py
@@ -103,14 +103,20 @@ TOOL_SCHEMAS = {
             "scope": {
                 "type": "string",
                 "enum": ["project", "session", "global"],
-                "description": "Project is the default relevance scope; global searches every project and is not an authorization boundary.",
+                "description": "Recall scope. project (default) hard-filters to the resolved project/repo; session skips durable merge when a session_id is supplied; global searches the complete trusted local store without current-project boost (it is not an authorization boundary).",
             },
-            "project": {"type": "string"},
+            "project": {
+                "type": "string",
+                "description": "Optional project hard-filter. Default scope=project keeps only frames with matching wax.project.",
+            },
             "repo": {
                 "type": "string",
-                "description": "Exact repo filter; when project is also supplied, both must match.",
+                "description": "Optional exact wax.repo hard-filter. When project is also set, both filters must match.",
             },
-            "cwd": {"type": "string"},
+            "cwd": {
+                "type": "string",
+                "description": "Optional client working directory used to infer project/repo when not explicit; omit and the host injects it.",
+            },
             "search_top_k": {"type": "integer", "minimum": 1, "maximum": 200},
         },
         ["query"],

--- a/Resources/scripts/quality/production_readiness_gates.sh
+++ b/Resources/scripts/quality/production_readiness_gates.sh
@@ -130,8 +130,9 @@ assert_full_pass_rate() {
   runnable=$((executed - skipped))
   if [[ $runnable -le 0 ]]; then
     # Swift Testing emits an XCTest wrapper of "Executed 0 tests" when the
-    # selected filter has no XCTest cases. A passing swift-testing run is enough.
-    if grep -E "Test run with [0-9]+ tests passed" "$log_file" >/dev/null; then
+    # selected filter has no XCTest cases. Require a positive swift-testing
+    # count so an empty --filter cannot green as 100%.
+    if grep -E "Test run with [1-9][0-9]* tests passed" "$log_file" >/dev/null; then
       echo "PASS_RATE: 100.00% (swift-testing; XCTest wrapper executed 0)"
       return 0
     fi
@@ -177,10 +178,37 @@ assert_mcp_trait_tests_listed() {
     echo "FAIL: MCPServer trait test list is missing wax_mcpTests.toolsListContainsExpectedTools()." >&2
     return 1
   fi
+  if ! grep -E "^WaxCLITests\.WaxCLIMemoryTests/mcpDoctorIsHostAgnosticAndValidatesDailyToolSurface\(\)" "$log_file" >/dev/null; then
+    echo "FAIL: MCPServer trait test list is missing WaxCLITests.WaxCLIMemoryTests/mcpDoctorIsHostAgnosticAndValidatesDailyToolSurface()." >&2
+    return 1
+  fi
+  if ! grep -E "^WaxCLITests\.WaxCLIMemoryTests/mcpDoctorSmokeChecksIsolatedStoreWhenTargetStoreIsHeld\(\)" "$log_file" >/dev/null; then
+    echo "FAIL: MCPServer trait test list is missing WaxCLITests.WaxCLIMemoryTests/mcpDoctorSmokeChecksIsolatedStoreWhenTargetStoreIsHeld()." >&2
+    return 1
+  fi
 
   local count
   count="$(grep -Ec "^wax_mcpTests\." "$log_file")"
   echo "MCP_TRAIT_TESTS: listed=$count"
+}
+
+assert_mcp_cli_doctor_smokes_ran() {
+  local log_file="$1"
+  local id
+  for id in \
+    mcpDoctorIsHostAgnosticAndValidatesDailyToolSurface \
+    mcpDoctorSmokeChecksIsolatedStoreWhenTargetStoreIsHeld
+  do
+    if grep -E "Test ${id}\(\) skipped:" "$log_file" >/dev/null; then
+      echo "FAIL: MCPServer WaxCLI doctor smoke ${id} was skipped." >&2
+      return 1
+    fi
+    if ! grep -F "$id" "$log_file" >/dev/null; then
+      echo "FAIL: MCPServer WaxCLI run log is missing doctor smoke ${id}." >&2
+      return 1
+    fi
+  done
+  echo "MCP_CLI_DOCTOR_SMOKES: executed"
 }
 
 assert_mcp_trait_test_inventory() {
@@ -199,6 +227,7 @@ assert_mcp_trait_test_inventory() {
 run_full() {
   local log_file="/tmp/wax-gate-full.log"
   local mcp_unit_log="/tmp/wax-gate-full-mcp-unit.log"
+  local mcp_cli_log="/tmp/wax-gate-full-mcp-cli.log"
   local mcp_process_log="/tmp/wax-gate-full-mcp-process.log"
   local skip_regex
   skip_regex="$(full_gate_skip_regex)"
@@ -219,6 +248,14 @@ run_full() {
     swift test --parallel --traits MCPServer --filter wax_mcpTests --skip "${skip_regex}|WaxMCPProcessTests"
   assert_no_skips "$mcp_unit_log"
   assert_full_pass_rate "$mcp_unit_log"
+
+  # Doctor smokes live in WaxCLIMemoryTests, not wax_mcpTests. Keep this
+  # slice filtered; do not restore an unfiltered MCPServer package run.
+  run_and_capture "$mcp_cli_log" \
+    swift test --parallel --traits MCPServer --filter WaxCLIMemoryTests
+  assert_no_skips "$mcp_cli_log"
+  assert_full_pass_rate "$mcp_cli_log"
+  assert_mcp_cli_doctor_smokes_ran "$mcp_cli_log"
 
   run_and_capture "$mcp_process_log" \
     swift test --no-parallel --traits MCPServer --filter WaxMCPProcessTests

--- a/Resources/scripts/quality/production_readiness_gates_tests.sh
+++ b/Resources/scripts/quality/production_readiness_gates_tests.sh
@@ -68,6 +68,10 @@ assert_accepts_summary \
   $'Test Suite \'Selected tests\' passed at 2026-09-08 15:17:03.816.\n\t Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.007) seconds\n􁁛  Test run with 28 tests passed after 9.859 seconds.'
 
 assert_rejects_summary \
+  "swift-testing-zero-tests-passed" \
+  $'Test Suite \'Selected tests\' passed at 2026-09-08 15:17:03.816.\n\t Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.007) seconds\n􁁛  Test run with 0 tests passed after 0.007 seconds.'
+
+assert_rejects_summary \
   "xctest-wrapper-zero-without-swift-testing" \
   $'Test Suite \'Selected tests\' passed at 2026-09-08 15:17:03.816.\n\t Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.007) seconds'
 
@@ -143,14 +147,54 @@ EOF
 
 assert_default_mcp_trait_tests_omitted "$DEFAULT_TEST_LIST"
 
-MCP_TEST_LIST="$TMP_DIR/mcp-tests.txt"
-cat >"$MCP_TEST_LIST" <<'EOF'
+MCP_TEST_LIST_NO_DOCTOR="$TMP_DIR/mcp-tests-no-doctor.txt"
+cat >"$MCP_TEST_LIST_NO_DOCTOR" <<'EOF'
 waxTests.PackageTraitManifestTests/waxMCPProductEnablesMiniLMCompileDefine()
 wax_mcpTests.WaxMCPProcessTests/brokerAutoStartHandlesConcurrentFirstAccess()
 wax_mcpTests.toolsListContainsExpectedTools()
 EOF
 
+if assert_mcp_trait_tests_listed "$MCP_TEST_LIST_NO_DOCTOR" >/dev/null 2>&1; then
+  echo "FAIL: MCPServer inventory must require WaxCLI doctor smoke test IDs" >&2
+  exit 1
+fi
+
+MCP_TEST_LIST="$TMP_DIR/mcp-tests.txt"
+cat >"$MCP_TEST_LIST" <<'EOF'
+waxTests.PackageTraitManifestTests/waxMCPProductEnablesMiniLMCompileDefine()
+wax_mcpTests.WaxMCPProcessTests/brokerAutoStartHandlesConcurrentFirstAccess()
+wax_mcpTests.toolsListContainsExpectedTools()
+WaxCLITests.WaxCLIMemoryTests/mcpDoctorIsHostAgnosticAndValidatesDailyToolSurface()
+WaxCLITests.WaxCLIMemoryTests/mcpDoctorSmokeChecksIsolatedStoreWhenTargetStoreIsHeld()
+EOF
+
 assert_mcp_trait_tests_listed "$MCP_TEST_LIST"
+
+DOCTOR_RUN_LOG="$TMP_DIR/mcp-cli-doctor-run.log"
+printf '%s\n' \
+  'Test mcpDoctorIsHostAgnosticAndValidatesDailyToolSurface() passed after 1.000 seconds.' \
+  'Test mcpDoctorSmokeChecksIsolatedStoreWhenTargetStoreIsHeld() passed after 1.000 seconds.' \
+  >"$DOCTOR_RUN_LOG"
+assert_mcp_cli_doctor_smokes_ran "$DOCTOR_RUN_LOG" >/dev/null
+
+SKIPPED_DOCTOR_LOG="$TMP_DIR/mcp-cli-doctor-skipped.log"
+printf '%s\n' \
+  'Test mcpDoctorIsHostAgnosticAndValidatesDailyToolSurface() skipped: "Build with --traits default,MCPServer to run wax-mcp smoke tests"' \
+  'Test mcpDoctorSmokeChecksIsolatedStoreWhenTargetStoreIsHeld() passed after 1.000 seconds.' \
+  >"$SKIPPED_DOCTOR_LOG"
+if assert_mcp_cli_doctor_smokes_ran "$SKIPPED_DOCTOR_LOG" >/dev/null 2>&1; then
+  echo "FAIL: expected skipped doctor smoke to fail run-log inventory" >&2
+  exit 1
+fi
+
+MISSING_DOCTOR_LOG="$TMP_DIR/mcp-cli-doctor-missing.log"
+printf '%s\n' \
+  'Test mcpDoctorSmokeChecksIsolatedStoreWhenTargetStoreIsHeld() passed after 1.000 seconds.' \
+  >"$MISSING_DOCTOR_LOG"
+if assert_mcp_cli_doctor_smokes_ran "$MISSING_DOCTOR_LOG" >/dev/null 2>&1; then
+  echo "FAIL: expected missing doctor smoke to fail run-log inventory" >&2
+  exit 1
+fi
 
 if grep -F 'swift test --traits MCPServer --disable-automatic-resolution list' "$SCRIPT" >/dev/null; then
   echo "FAIL: MCP trait inventory must allow first-time trait dependency resolution" >&2
@@ -166,6 +210,18 @@ if grep -F 'swift test --no-parallel --traits MCPServer --skip' "$SCRIPT" >/dev/
 fi
 if ! grep -F 'swift test --parallel --traits MCPServer --filter wax_mcpTests' "$SCRIPT" >/dev/null; then
   echo "FAIL: MCPServer unit tests must run in parallel filtered to wax_mcpTests" >&2
+  exit 1
+fi
+if ! grep -F 'swift test --parallel --traits MCPServer --filter WaxCLIMemoryTests' "$SCRIPT" >/dev/null; then
+  echo "FAIL: MCPServer gate must run WaxCLIMemoryTests doctor smokes under --traits MCPServer" >&2
+  exit 1
+fi
+if ! grep -E 'Test run with \[1-9\]\[0-9\]\* tests passed' "$SCRIPT" >/dev/null; then
+  echo "FAIL: pass-rate helper must require a positive Swift Testing test count" >&2
+  exit 1
+fi
+if grep -E 'Test run with \[0-9\]\+ tests passed' "$SCRIPT" >/dev/null; then
+  echo "FAIL: pass-rate helper must not treat a 0-test Swift Testing run as success" >&2
   exit 1
 fi
 if ! grep -E 'swift test --no-parallel --traits MCPServer --filter .*WaxMCPProcessTests' "$SCRIPT" >/dev/null; then

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -228,17 +228,28 @@ package actor AgentBrokerService {
         return false
     }
 
-    private static func requiresRememberDrain(_ request: AgentBrokerRequest) -> Bool {
+    /// Invalid decode does not take the remember-drain lock.
+    package static func requiresRememberDrain(_ request: AgentBrokerRequest) -> Bool {
         guard let command = try? BrokerCommand.decode(
             command: request.command,
             arguments: request.arguments
         ) else {
             return false
         }
+        return requiresRememberDrain(command)
+    }
+
+    /// New `BrokerCommand` cases must pick true (teardown) or false.
+    package static func requiresRememberDrain(_ command: BrokerCommand) -> Bool {
         switch command {
         case .taskStateMigrate, .sessionEnd, .sessionClose:
             return true
-        default:
+        case .remember, .recall, .search, .memorySearch, .sessionStart, .sessionResume,
+             .handoff, .handoffLatest, .memoryGet, .memoryHealth, .stats, .flush,
+             .markdownSync, .entityUpsert, .entityResolve, .factRetract, .shutdown,
+             .sessionSynthesize, .knowledgeCapture, .sessionOpen, .compactContext,
+             .markdownExport, .factsQuery, .memoryPromote, .promote, .factAssert,
+             .corpusSearch, .memoryMaintain:
             return false
         }
     }
@@ -732,13 +743,22 @@ extension AgentBrokerService {
                 scope: .project,
                 identity: identity
             )
-            let durableExecution = try await longTermMemory.searchExecution(
+            var durableExecution = try await longTermMemory.searchExecution(
                 query: query,
                 mode: mode,
                 topK: topK,
                 frameFilter: durableFilter,
                 timeRange: parsedFilters.timeRange
             )
+            // `frameFilterForScopedRetrieval` no-ops on empty identity; still drop
+            // stamped foreign durable so session-scoped search matches recall.
+            durableExecution.hits = durableExecution.hits.filter {
+                Self.matchesSessionScopedRetrieval(
+                    metadata: $0.metadata,
+                    identity: identity,
+                    isWorking: false
+                )
+            }
             execution = Self.mergeSearchExecutions(
                 working: sessionExecution,
                 durable: durableExecution,
@@ -2562,11 +2582,7 @@ extension AgentBrokerService {
                 project: writeScope.projectName,
                 repo: writeScope.repoName
             )
-            if identity.project != nil || identity.repo != nil {
-                merged = merged.filter {
-                    LayeredRecall.metadataMatchesScopedRetrieval($0.metadata, identity: identity)
-                }
-            }
+            merged = Self.filterCorpusHits(merged, identity: identity)
         }
         let activeSessionsSearched = orderedActiveSessions.count
 
@@ -3090,16 +3106,58 @@ extension AgentBrokerService {
         case none
     }
 
-    /// Keep working-lane hits. When the live session has a project/repo, drop
-    /// durable/episodic hits that would fail `search`'s scoped frame filter.
+    /// Keep working-lane hits. Resolved identity drops durable/episodic that would
+    /// fail `search`'s scoped frame filter. Unresolved identity keeps unstamped
+    /// durable and drops stamped foreign, matching `LayeredRecall.matchesProjectScope`.
     static func filterMemorySearchHits(
         _ hits: [LayeredMemoryHit],
         identity: LayeredRecall.Identity
     ) -> [LayeredMemoryHit] {
-        guard identity.project != nil || identity.repo != nil else { return hits }
+        hits.filter { hit in
+            matchesSessionScopedRetrieval(
+                metadata: hit.metadata,
+                identity: identity,
+                isWorking: hit.horizon == .working
+            )
+        }
+    }
+
+    /// Unresolved session scope: working + unstamped durable; drop stamped foreign.
+    /// Resolved: exact `wax.project` / `wax.repo` (working always kept).
+    static func matchesSessionScopedRetrieval(
+        metadata: [String: String],
+        identity: LayeredRecall.Identity,
+        isWorking: Bool
+    ) -> Bool {
+        if isWorking { return true }
+        if identity.project == nil && identity.repo == nil {
+            return !hasExplicitProjectOrRepoStamp(metadata)
+        }
+        return LayeredRecall.metadataMatchesScopedRetrieval(metadata, identity: identity)
+    }
+
+    static func hasExplicitProjectOrRepoStamp(_ metadata: [String: String]) -> Bool {
+        let project = metadata[MemoryMetadataKeys.project]
+        let repo = metadata[MemoryMetadataKeys.repo]
+        return (project.map { !$0.isEmpty } ?? false) || (repo.map { !$0.isEmpty } ?? false)
+    }
+
+    static func filterCorpusHits(
+        _ hits: [BrokerCorpusMergeHit],
+        identity: LayeredRecall.Identity
+    ) -> [BrokerCorpusMergeHit] {
+        if identity.project != nil || identity.repo != nil {
+            return hits.filter {
+                LayeredRecall.metadataMatchesScopedRetrieval($0.metadata, identity: identity)
+            }
+        }
         return hits.filter { hit in
-            if hit.horizon == .working { return true }
-            return LayeredRecall.metadataMatchesScopedRetrieval(hit.metadata, identity: identity)
+            let isWorking = hit.metadata[BrokerCorpusMetadataKeys.origin] == "active_session"
+            return matchesSessionScopedRetrieval(
+                metadata: hit.metadata,
+                identity: identity,
+                isWorking: isWorking
+            )
         }
     }
 

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -386,7 +386,7 @@ package enum LayeredRecall {
     }
 
     /// Inflates retrieval top-K when a post-rank project hard-filter may discard foreign hits.
-    package static func retrievalTopK(requested: Int, scope: Scope, maxTopK: Int = 200) -> Int {
+    package static func retrievalTopK(requested: Int, maxTopK: Int = 200) -> Int {
         let bounded = max(1, requested)
         return min(max(bounded * 3, 12), maxTopK)
     }
@@ -427,7 +427,7 @@ package enum LayeredRecall {
         sessionHits: [Hit],
         durableHits: [Hit],
         limit: Int,
-        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        nowMs: Int64
     ) -> [Hit] {
         func identity(_ hit: Hit) -> String {
             if let hash = hit.metadata["wax.content.hash"] {
@@ -514,10 +514,10 @@ package enum LayeredRecall {
     /// facts, lessons, decisions, constraints, reviewed frames, and locked frames
     /// keep their semantic score regardless of age.
     package static func freshnessAdjustedScore(_ hit: Hit, nowMs: Int64) -> Float {
-        let type = hit.metadata[MemoryMetadataKeys.type]
-        let isOperational = type == MemoryType.note.rawValue
-            || type == MemoryType.taskState.rawValue
-            || type == MemoryType.handoff.rawValue
+        let isOperational = switch MemoryType(rawValue: hit.metadata[MemoryMetadataKeys.type] ?? "") {
+        case .note, .taskState, .handoff: true
+        case .userPreference, .decision, .lesson, .constraint, .fact, nil: false
+        }
         let isReviewed = hit.metadata[MemoryMetadataKeys.reviewed]?.lowercased() == "true"
         let isLocked = hit.metadata[MemoryMetadataKeys.durability] == MemoryDurability.locked.rawValue
         guard isOperational, !isReviewed, !isLocked, hit.timestampMs > 0, nowMs > hit.timestampMs else {
@@ -664,13 +664,19 @@ package enum LayeredRecall {
     package static func mergeRecallItems(
         sessionItems: [RAGContext.Item],
         durableItems: [RAGContext.Item],
-        limit: Int
+        limit: Int,
+        nowMs: Int64 = 0
     ) -> [RAGContext.Item] {
         let sessionHits = sessionItems.map {
             hit(from: $0, horizon: .working, sessionID: UUID())
         }
         let durableHits = durableItems.map { hit(from: $0) }
-        return mergeHits(sessionHits: sessionHits, durableHits: durableHits, limit: limit).map { hit in
+        return mergeHits(
+            sessionHits: sessionHits,
+            durableHits: durableHits,
+            limit: limit,
+            nowMs: nowMs
+        ).map { hit in
             RAGContext.Item(
                 kind: hit.kind,
                 frameId: hit.frameID,
@@ -824,7 +830,7 @@ package enum LayeredRecall {
         stores: Stores
     ) async throws -> RecallResult {
         var fetchRequest = request
-        fetchRequest.searchTopK = retrievalTopK(requested: request.searchTopK, scope: request.scope)
+        fetchRequest.searchTopK = retrievalTopK(requested: request.searchTopK)
         let lanes = try await fetchLanes(request: fetchRequest, stores: stores)
         let identity = lanes.identity
 

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -2083,6 +2083,7 @@ package actor MemoryOrchestrator {
         isClosed = true
         for waiter in readinessWaiters.values { waiter.resume(throwing: CancellationError()) }
         readinessWaiters.removeAll()
+        readinessFollowInFlight = false
         readinessFollowTask?.cancel()
         readinessFollowTask = nil
         automaticEmbeddingBackfillTask?.cancel()
@@ -2376,7 +2377,7 @@ package actor MemoryOrchestrator {
         readinessFollowTask?.cancel()
         readinessFollowInFlight = true
         readinessFollowTask = Task {
-            defer { Task { markReadinessFollowFinished() } }
+            defer { markReadinessFollowFinished() }
             let result = await session.waitUntilCompileFinished()
             guard !Task.isCancelled else { return }
             switch result {
@@ -2390,6 +2391,7 @@ package actor MemoryOrchestrator {
 
     private func markReadinessFollowFinished() {
         readinessFollowInFlight = false
+        finishReadinessWaiters()
     }
 
     package func attachEmbedder(_ provider: any EmbeddingProvider) async {

--- a/Sources/WaxMCPServer/ToolSchemas.swift
+++ b/Sources/WaxMCPServer/ToolSchemas.swift
@@ -94,7 +94,7 @@ enum ToolSchemas {
         ),
         Tool(
             name: "session_close",
-            description: "Atomic handoff then session_end for one session_id. Idempotent if the session already ended.",
+            description: "Atomic handoff then session_end for the connection session. Idempotent if the session already ended. Supply session_id to explicitly select another session or when no connection session is bound.",
             inputSchema: waxSessionClose
         ),
         Tool(

--- a/Sources/WaxMCPServer/WaxMCPTools.swift
+++ b/Sources/WaxMCPServer/WaxMCPTools.swift
@@ -220,26 +220,6 @@ private extension WaxMCPTools {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    /// Session-horizon writes only. Durable types stay durable if session_id is
-    /// present, but inheriting the connection UUID would still stamp session
-    /// project onto writes that omitted it on purpose.
-    static func rememberShouldInheritSession(_ arguments: [String: Value]) -> Bool {
-        if case .string(let scope)? = arguments["scope"] {
-            let trimmed = scope.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            if trimmed == "session" { return true }
-            if trimmed == "durable" { return false }
-        }
-        if case .string(let type)? = arguments["memory_type"] {
-            switch type.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-            case "task_state", "handoff":
-                return true
-            default:
-                return false
-            }
-        }
-        return false
-    }
-
     static func validateToolAvailability(name: String, structuredMemoryEnabled: Bool) throws {
         guard let entry = AgentBrokerCommandSurface.entry(for: name), entry.exposure == .publicCommand else {
             throw ToolValidationError.invalid("Unknown tool '\(name)'.")

--- a/Tests/WaxIntegrationTests/EmbeddingReadinessMemoryTests.swift
+++ b/Tests/WaxIntegrationTests/EmbeddingReadinessMemoryTests.swift
@@ -498,6 +498,72 @@ func waitUntilReadyForRememberThrowsWhenCompileFails() async throws {
 }
 
 @Test
+func waitUntilReadyForRememberThrowsAfterCompileAlreadyMarkedUnavailable() async throws {
+    try await TempFiles.withTempFile { url in
+        let readiness = EmbeddingReadiness()
+        var config = OrchestratorConfig.default
+        config.requireOnDeviceProviders = false
+        let orchestrator = try await EmbeddingReadinessBinding.openOrchestrator(
+            at: url,
+            config: config,
+            request: .automatic(.miniLM, .default),
+            readiness: readiness
+        ) {
+            throw TestReadinessError.boom
+        }
+
+        let settleDeadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < settleDeadline {
+            if case .unavailable = await orchestrator.runtimeStats().embeddingStatus {
+                break
+            }
+            await Task.yield()
+        }
+        guard case .unavailable = await orchestrator.runtimeStats().embeddingStatus else {
+            Issue.record("expected unavailable after compile failure before waiting to remember")
+            try await orchestrator.close()
+            return
+        }
+        await Task.yield()
+
+        let waitTask = Task {
+            try await orchestrator.waitUntilReadyForRemember()
+        }
+        let outcome = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                _ = await waitTask.result
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: .milliseconds(400))
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        guard outcome else {
+            waitTask.cancel()
+            Issue.record("waitUntilReadyForRemember stalled after compile failure already marked unavailable")
+            try await orchestrator.close()
+            return
+        }
+
+        do {
+            try await waitTask.value
+            Issue.record("waitUntilReadyForRemember must throw when compile already failed")
+        } catch let error as WaxError {
+            guard case .io = error else {
+                Issue.record("expected WaxError.io from compile failure, got \(error)")
+                try await orchestrator.close()
+                return
+            }
+        }
+        try await orchestrator.close()
+    }
+}
+
+@Test
 func framesWithoutVectorsCountsUnembeddedSourceFramesNotChunks() async throws {
     try await TempFiles.withTempFile { url in
         let provider = DeterministicTextEmbedder()

--- a/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
+++ b/Tests/WaxMCPServerTests/BrokerSessionModelRegressionTests.swift
@@ -1278,6 +1278,138 @@ func corpusSearchWithLiveSessionIDDoesNotReturnForeignProjectDurable() async thr
 }
 
 @Test
+func filterMemorySearchHitsUnresolvedIdentityDropsStampedForeignDurable() {
+    let sessionID = UUID()
+    let working = LayeredRecall.Hit(
+        id: .working(sessionID: sessionID, frameID: 1),
+        score: 1,
+        text: "live working note",
+        preview: "live working note",
+        metadata: [MemoryMetadataKeys.project: "ForeignLab"],
+        explanations: [],
+        timestampMs: 0
+    )
+    let unstamped = LayeredRecall.Hit(
+        id: .durable(frameID: 2),
+        score: 1,
+        text: "unstamped durable token",
+        preview: "unstamped durable token",
+        metadata: [:],
+        explanations: [],
+        timestampMs: 0
+    )
+    let foreign = LayeredRecall.Hit(
+        id: .durable(frameID: 3),
+        score: 1,
+        text: "ForeignLab durable token",
+        preview: "ForeignLab durable token",
+        metadata: [
+            MemoryMetadataKeys.project: "ForeignLab",
+            MemoryMetadataKeys.repo: "ForeignLab",
+        ],
+        explanations: [],
+        timestampMs: 0
+    )
+    let filtered = AgentBrokerService.filterMemorySearchHits(
+        [working, unstamped, foreign],
+        identity: LayeredRecall.Identity()
+    )
+    #expect(filtered.map(\.text) == ["live working note", "unstamped durable token"])
+}
+
+@Test
+func filterCorpusHitsUnresolvedIdentityDropsStampedForeignDurable() {
+    func hit(preview: String, origin: String, project: String?) -> BrokerCorpusMergeHit {
+        var metadata = [BrokerCorpusMetadataKeys.origin: origin]
+        if let project {
+            metadata[MemoryMetadataKeys.project] = project
+            metadata[MemoryMetadataKeys.repo] = project
+        }
+        return BrokerCorpusMergeHit(
+            frameId: 1,
+            score: 1,
+            sources: ["text"],
+            preview: preview,
+            metadata: metadata,
+            dedupeKey: preview
+        )
+    }
+    let filtered = AgentBrokerService.filterCorpusHits(
+        [
+            hit(preview: "live working", origin: "active_session", project: "ForeignLab"),
+            hit(preview: "unstamped durable", origin: "long_term", project: nil),
+            hit(preview: "ForeignLab durable", origin: "long_term", project: "ForeignLab"),
+        ],
+        identity: LayeredRecall.Identity()
+    )
+    #expect(filtered.map(\.preview) == ["live working", "unstamped durable"])
+}
+
+@Test
+func unresolvedSessionScopedSearchDoesNotReturnForeignLabDurable() async throws {
+    try await withIsolatedBroker { service, _ in
+        let started = await service.handle(.init(
+            command: "session_start",
+            arguments: [
+                "agent_id": .string("unresolved-fence-agent"),
+                "run_id": .string("unresolved-fence-run"),
+            ]
+        ))
+        #expect(started.ok == true, "session_start failed: \(started.error ?? "nil")")
+        let sessionID = try requireString(try requireObject(started.payload), "session_id")
+        let foreignToken = "zxqunF\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(10))"
+
+        #expect((await service.handle(.init(
+            command: "remember",
+            arguments: [
+                "content": .string("ForeignLab durable lesson \(foreignToken) must stay out of unresolved session search."),
+                "memory_type": .string("lesson"),
+                "project": .string("ForeignLab"),
+                "repo": .string("ForeignLab"),
+            ]
+        ))).ok == true)
+
+        for command in ["search", "memory_search", "corpus_search"] {
+            let searched = await service.handle(.init(
+                command: command,
+                arguments: [
+                    "query": .string(foreignToken),
+                    "mode": .string("text"),
+                    "topK": .int(10),
+                    "session_id": .string(sessionID),
+                ]
+            ))
+            #expect(searched.ok == true, "\(command) failed: \(searched.error ?? "nil")")
+            let texts = resultTexts(try requireObject(searched.payload))
+            #expect(
+                texts.contains { $0.contains(foreignToken) } == false,
+                "unresolved \(command)+session_id must not leak ForeignLab durable; got \(texts)"
+            )
+            #expect(
+                texts.contains { $0.contains("ForeignLab") } == false,
+                "unresolved \(command)+session_id must not leak ForeignLab text; got \(texts)"
+            )
+        }
+
+        let global = await service.handle(.init(
+            command: "recall",
+            arguments: [
+                "query": .string(foreignToken),
+                "mode": .string("text"),
+                "scope": .string("global"),
+                "limit": .int(10),
+            ]
+        ))
+        #expect(global.ok == true, "global recall failed: \(global.error ?? "nil")")
+        let globalTexts = resultTexts(try requireObject(global.payload))
+        #expect(
+            globalTexts.contains { $0.contains(foreignToken) },
+            "scope=global recall must still find ForeignLab durable; got \(globalTexts)"
+        )
+    }
+}
+
+@Test
 func endedSessionIDIsRejectedOnLaterScopedBrokerCalls() async throws {
     try await withIsolatedBroker { service, _ in
         let started = await service.handle(.init(

--- a/Tests/WaxMCPServerTests/WaxMCPHTTPAgentDXTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPHTTPAgentDXTests.swift
@@ -7,43 +7,6 @@ import Testing
 struct WaxMCPHTTPAgentDXTests {
     @Test
     func loopbackHTTPRejectsDNSRebindingHostAndForeignOrigin() async throws {
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "127.0.0.1:3000",
-            originHeader: "http://localhost:3000"
-        ))
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "[::1]:3000",
-            originHeader: nil
-        ))
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "localhost:3000",
-            originHeader: "http://127.0.0.1:3000"
-        ))
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "attacker.example:3000",
-            originHeader: nil
-        ) == false)
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "127.0.0.1.attacker.example:3000",
-            originHeader: nil
-        ) == false)
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "127.0.0.1:3000",
-            originHeader: "https://attacker.example"
-        ) == false)
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "127.0.0.1:3000",
-            originHeader: "http://127.0.0.1.attacker.example"
-        ) == false)
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "127.0.0.1:3000",
-            originHeader: "null"
-        ) == false)
-        #expect(HTTPAuthPolicy.isSafeLoopbackRequest(
-            hostHeader: "127.0.0.1:3000",
-            originHeader: "http://evil.com@127.0.0.1"
-        ) == false)
-
         let initializeBody = try JSONSerialization.data(withJSONObject: [
             "jsonrpc": "2.0",
             "id": 1,
@@ -170,20 +133,6 @@ struct WaxMCPHTTPAgentDXTests {
             path: "/mcp"
         ))
         #expect(closed.statusCode == 200)
-    }
-
-    @Test
-    func dailyToolProfileMatchesDoctorCanonicalVerbs() {
-        #expect(MCPToolProfile.dailyNames == [
-            "session_open",
-            "remember",
-            "recall",
-            "session_close",
-            "stats",
-            "memory_get",
-            "compact_context",
-            "session_resume",
-        ])
     }
 }
 #endif

--- a/Tests/WaxTests/BrokerCommandDecodeTests.swift
+++ b/Tests/WaxTests/BrokerCommandDecodeTests.swift
@@ -671,4 +671,39 @@ struct BrokerCommandDecodeTests {
             )
         }
     }
+
+    @Test
+    func requiresRememberDrainIsTrueForTeardownCommands() throws {
+        let sessionEnd = try BrokerCommand.decode(command: "session_end", arguments: [:])
+        let sessionClose = try BrokerCommand.decode(
+            command: "session_close",
+            arguments: [
+                "session_id": .string("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"),
+                "content": .string("closing"),
+            ]
+        )
+        let migrate = try BrokerCommand.decode(
+            command: "task_state_migrate",
+            arguments: ["destination_path": .string("/tmp/wax-migrate")]
+        )
+        #expect(AgentBrokerService.requiresRememberDrain(sessionEnd))
+        #expect(AgentBrokerService.requiresRememberDrain(sessionClose))
+        #expect(AgentBrokerService.requiresRememberDrain(migrate))
+    }
+
+    @Test
+    func requiresRememberDrainIsFalseForReadsAndDecodeFailure() throws {
+        let search = try BrokerCommand.decode(
+            command: "search",
+            arguments: ["query": .string("hello")]
+        )
+        let remember = try BrokerCommand.decode(
+            command: "remember",
+            arguments: ["content": .string("note")]
+        )
+        #expect(!AgentBrokerService.requiresRememberDrain(search))
+        #expect(!AgentBrokerService.requiresRememberDrain(remember))
+        #expect(!AgentBrokerService.requiresRememberDrain(.init(command: "not_a_real_command")))
+        #expect(!AgentBrokerService.requiresRememberDrain(.init(command: "session_close")))
+    }
 }

--- a/Tests/WaxTests/CompactAssemblyTests.swift
+++ b/Tests/WaxTests/CompactAssemblyTests.swift
@@ -151,7 +151,7 @@ func compactAssemblyFetchSearchTopKStaysUninflated() {
     #expect(CompactAssembly.fetchSearchTopK(maxItems: 8) == 4)
     #expect(CompactAssembly.fetchSearchTopK(maxItems: 1) == 1)
     #expect(CompactAssembly.fetchSearchTopK(maxItems: 4) == 4)
-    #expect(LayeredRecall.retrievalTopK(requested: 4, scope: .project) == 12)
+    #expect(LayeredRecall.retrievalTopK(requested: 4) == 12)
 }
 
 private func compactHit(

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -12,7 +12,12 @@ struct LayeredRecallTests {
         let session = [
             layeredHit(frameID: 99, score: 0.05, text: "session reserved note", horizon: .working)
         ]
-        let merged = LayeredRecall.mergeHits(sessionHits: session, durableHits: durable, limit: 5)
+        let merged = LayeredRecall.mergeHits(
+            sessionHits: session,
+            durableHits: durable,
+            limit: 5,
+            nowMs: 0
+        )
         #expect(merged.count == 5)
         #expect(merged.contains { $0.text.contains("session reserved note") })
         #expect(merged.contains { $0.explanations.contains("current session") })
@@ -41,7 +46,12 @@ struct LayeredRecallTests {
                 sources: [.vector]
             )
         ]
-        let merged = LayeredRecall.mergeHits(sessionHits: session, durableHits: durable, limit: 2)
+        let merged = LayeredRecall.mergeHits(
+            sessionHits: session,
+            durableHits: durable,
+            limit: 2,
+            nowMs: 0
+        )
         #expect(merged.first?.text.contains("brake pads") == true)
         #expect(merged.first?.score == 0.91)
     }
@@ -66,7 +76,12 @@ struct LayeredRecallTests {
                 sources: [.vector]
             )
         ]
-        let merged = LayeredRecall.mergeHits(sessionHits: session, durableHits: durable, limit: 2)
+        let merged = LayeredRecall.mergeHits(
+            sessionHits: session,
+            durableHits: durable,
+            limit: 2,
+            nowMs: 0
+        )
         #expect(merged.first?.text.contains("Just wrote") == true)
         #expect(merged.first?.score == 1.02)
     }
@@ -79,7 +94,12 @@ struct LayeredRecallTests {
         let durable = [
             layeredHit(frameID: 99, score: 0.05, text: "durable reserved note", horizon: .durable)
         ]
-        let merged = LayeredRecall.mergeHits(sessionHits: session, durableHits: durable, limit: 5)
+        let merged = LayeredRecall.mergeHits(
+            sessionHits: session,
+            durableHits: durable,
+            limit: 5,
+            nowMs: 0
+        )
         #expect(merged.count == 5)
         #expect(merged.contains { $0.text.contains("durable reserved note") })
         #expect(merged.contains { $0.explanations.contains("current session") })
@@ -256,6 +276,51 @@ struct LayeredRecallTests {
             timestampMs: 0
         )
         #expect(LayeredRecall.freshnessAdjustedScore(unknown, nowMs: nowMs) == 0.92)
+    }
+
+    @Test
+    func layeredRecallMergeHitsZeroNowMsLeavesOperationalScoreUnchanged() {
+        let hit = layeredHit(
+            frameID: 1,
+            score: 0.92,
+            text: "operational note",
+            horizon: .durable,
+            metadata: [MemoryMetadataKeys.type: MemoryType.note.rawValue],
+            timestampMs: 1_000
+        )
+        let merged = LayeredRecall.mergeHits(
+            sessionHits: [],
+            durableHits: [hit],
+            limit: 1,
+            nowMs: 0
+        )
+        #expect(merged.first?.score == 0.92)
+        #expect(merged.first?.explanations.contains("freshness adjusted operational memory") == false)
+    }
+
+    @Test
+    func layeredRecallMergeRecallItemsThreadsNowMsIntoFreshness() throws {
+        let nowMs: Int64 = 2_000_000_000_000
+        let stale = RAGContext.Item(
+            kind: .snippet,
+            frameId: 1,
+            score: 0.92,
+            sources: [.text],
+            text: "stale operational note",
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.taskState.rawValue,
+                MemoryMetadataKeys.createdAtMs: String(nowMs - 30 * 86_400_000),
+            ]
+        )
+        let merged = LayeredRecall.mergeRecallItems(
+            sessionItems: [],
+            durableItems: [stale],
+            limit: 1,
+            nowMs: nowMs
+        )
+        let item = try #require(merged.first)
+        #expect(abs(item.score - 0.74) < 0.0001)
+        #expect(item.explanations.contains("freshness adjusted operational memory"))
     }
 
     @Test
@@ -610,10 +675,8 @@ struct LayeredRecallTests {
 
     @Test
     func layeredRecallRetrievalTopKOverfetchesForProjectScope() {
-        #expect(LayeredRecall.retrievalTopK(requested: 5, scope: .project) == 15)
-        #expect(LayeredRecall.retrievalTopK(requested: 5, scope: .session) == 15)
-        #expect(LayeredRecall.retrievalTopK(requested: 5, scope: .global) == 15)
-        #expect(LayeredRecall.retrievalTopK(requested: 100, scope: .project, maxTopK: 200) == 200)
+        #expect(LayeredRecall.retrievalTopK(requested: 5) == 15)
+        #expect(LayeredRecall.retrievalTopK(requested: 100, maxTopK: 200) == 200)
     }
 
     @Test
@@ -651,7 +714,12 @@ struct LayeredRecallTests {
             horizon: .durable,
             timestampMs: 200
         )
-        let merged = LayeredRecall.mergeHits(sessionHits: [], durableHits: [older, newer], limit: 2)
+        let merged = LayeredRecall.mergeHits(
+            sessionHits: [],
+            durableHits: [older, newer],
+            limit: 2,
+            nowMs: 0
+        )
         #expect(merged.map(\.text) == ["newer correction", "older contract"])
     }
 


### PR DESCRIPTION
## Why
Leftover #195 review fixes that missed the squash. Current `main` still lets session-scoped `search` / `memory_search` / `corpus_search` return another project's durable memories when the live session has no project/repo, and `waitUntilReadyForRemember` can hang after MiniLM compile already failed.

## What
- Unresolved identity: keep working + unstamped durable; drop stamped foreign durable (matches recall)
- Wake embedder waiters when compile already marked unavailable
- Delete dead `rememberShouldInheritSession` (inherit policy lives in `injectClientSessionIfNeeded`)
- Hermes recall schema text matches the MCP tool; YAML scalar header still ignored
- Production gate: run WaxCLI doctor smokes under MCPServer; reject a 0-test Swift Testing run

Ported onto current `main` (after #193/#194). Original `codex/wax-mcp-dx-10` dirty checkout was left untouched.

## Proof
- `swift test --filter LayeredRecallTests --filter CompactAssemblyTests --filter BrokerCommandDecodeTests` — 71 passed
- `swift test --filter waitUntilReadyForRememberThrowsAfterCompileAlreadyMarkedUnavailable` — passed
- `swift test --traits MCPServer --filter BrokerSessionModelRegressionTests --filter WaxMCPHTTPAgentDXTests` — 42 passed (includes `unresolvedSessionScopedSearchDoesNotReturnForeignLabDurable`)
- `bash Resources/scripts/quality/hermes_plugin_tests.sh` — ok
- `bash Resources/scripts/quality/production_readiness_gates_tests.sh` — ok
- `bash Resources/scripts/quality/public_repo_hygiene.sh` — ok