### PR TITLE
Extract SessionOpenDecision from broker sessionOpen

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1634,8 +1634,7 @@ extension AgentBrokerService {
             hintedSessionResumable = false
         }
 
-        var conversationResume: (sessionID: UUID, runID: String)?
-        let startPayload: AgentBrokerValue
+        var conversationMatch: SessionOpenDecision.Match?
         if let conversationID {
             if let match = try BrokerSessionPersistence.findActive(
                 conversationID: conversationID,
@@ -1644,70 +1643,73 @@ extension AgentBrokerService {
                 repo: inferredScope.repoName,
                 rootURL: sessionRootURL
             ) {
-                conversationResume = (match.sessionID, match.runID)
-                startPayload = try await sessionResume(
-                    .init(sessionID: match.sessionID, agentID: nil, runID: nil)
-                )
-                if let requestedRunID, match.runID != requestedRunID {
-                    try virtualSessions.updateLive(match.sessionID) { state in
-                        state.manifest.runID = requestedRunID
-                        state.manifest.updatedAtMs = Self.nowMs()
-                    }
-                }
-            } else {
-                // An explicit host conversation is an isolation boundary. Do not
-                // let a connection hint or a same-agent/project session capture it.
-                startPayload = try await sessionStart(
-                    .init(
-                        sessionID: UUID(),
-                        agentID: agentID,
-                        runID: runID,
-                        cwd: cwd,
-                        project: project,
-                        repo: repo,
-                        conversationID: conversationID
-                    )
-                )
+                conversationMatch = .init(sessionID: match.sessionID, runID: match.runID)
             }
-        } else if hintedSessionResumable, let hintedSessionID = command.sessionID {
-            // A broker restart clears the live map without ending persisted
-            // sessions. Restore that session instead of losing its working state.
-            // A different explicit project is a new job, not a rewrite of the
-            // connection's current session identity.
-            startPayload = try await sessionResume(
-                .init(sessionID: hintedSessionID, agentID: nil, runID: nil)
-            )
-        } else {
-            startPayload = try await sessionStart(
-                .init(
-                    sessionID: nil,
-                    agentID: agentID,
-                    runID: runID,
-                    cwd: cwd,
-                    project: project,
-                    repo: repo,
-                    conversationID: conversationID
-                )
-            )
         }
-        let startObject = startPayload.objectValue
-        let sessionID = startObject?["session_id"]?.stringValue
+
+        let openFacts = SessionOpenDecision.Facts(
+            conversationID: conversationID,
+            conversationMatch: conversationMatch,
+            hintedSessionID: command.sessionID,
+            hintedResumable: hintedSessionResumable,
+            priorUnique: priorUnique.map { .init(sessionID: $0.sessionID, runID: $0.runID) },
+            requestedRunID: requestedRunID
+        )
+        let openAction = SessionOpenDecision.evaluate(openFacts)
+
+        let lifecycle: VirtualSessionStore.LifecycleResult
+        switch openAction {
+        case .resume(let resumeSessionID):
+            // Conversation match may also stamp a new run_id; hinted resume restores
+            // a connection session after broker restart without rewriting identity.
+            lifecycle = try await virtualSessions.resume(
+                explicitSessionID: resumeSessionID,
+                agentID: nil,
+                runID: nil
+            )
+            if let conversationMatch,
+               conversationMatch.sessionID == resumeSessionID,
+               let requestedRunID,
+               conversationMatch.runID != requestedRunID
+            {
+                try virtualSessions.updateLive(resumeSessionID) { state in
+                    state.manifest.runID = requestedRunID
+                    state.manifest.updatedAtMs = Self.nowMs()
+                }
+            }
+        case .startNew:
+            // Conversation isolation mints a fresh UUID; otherwise start handles
+            // exact pair / unique agent+project rebind.
+            let explicitSessionID = conversationID == nil ? nil : UUID()
+            lifecycle = try await virtualSessions.start(
+                explicitSessionID: explicitSessionID,
+                agentID: agentID,
+                runID: runID,
+                inferredScope: inferredScope
+            )
+            if let conversationID {
+                try virtualSessions.updateLive(lifecycle.state.id) { state in
+                    state.manifest.conversationID = conversationID
+                }
+            }
+        }
+
+        let sessionUUID = lifecycle.state.id
+        let sessionID = sessionUUID.uuidString
 
         // Explicit project must win over cwd inference for both project and repo.
         // Leaving a cwd-inferred repo would advertise a split identity and stamp
         // foreign wax.repo on later remembers.
-        if let sessionID, let uuid = UUID(uuidString: sessionID) {
-            let trimmedProject = project?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let trimmedRepo = repo?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !trimmedProject.isEmpty || conversationID != nil {
-                try virtualSessions.updateLive(uuid) { state in
-                    if !trimmedProject.isEmpty {
-                        state.manifest.project = trimmedProject
-                        state.manifest.repo = trimmedRepo.isEmpty ? trimmedProject : trimmedRepo
-                    }
-                    if let conversationID {
-                        state.manifest.conversationID = conversationID
-                    }
+        let trimmedProject = project?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let trimmedRepo = repo?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedProject.isEmpty || conversationID != nil {
+            try virtualSessions.updateLive(sessionUUID) { state in
+                if !trimmedProject.isEmpty {
+                    state.manifest.project = trimmedProject
+                    state.manifest.repo = trimmedRepo.isEmpty ? trimmedProject : trimmedRepo
+                }
+                if let conversationID {
+                    state.manifest.conversationID = conversationID
                 }
             }
         }
@@ -1715,7 +1717,7 @@ extension AgentBrokerService {
         let inferred = cwd.map { MemorySemantics.inferScopeContext(currentDirectoryPath: $0) } ?? MemoryScopeContext()
         let resolvedProject: String?
         let resolvedRepo: String?
-        if let sessionID, let uuid = UUID(uuidString: sessionID), let live = activeSessions[uuid] {
+        if let live = activeSessions[sessionUUID] {
             resolvedProject = live.manifest.project ?? BrokerCommand.normalizedOrNil(project) ?? inferred.projectName
             resolvedRepo = live.manifest.repo ?? BrokerCommand.normalizedOrNil(repo) ?? inferred.repoName
         } else {
@@ -1733,10 +1735,8 @@ extension AgentBrokerService {
 
         var recallPayload: AgentBrokerValue?
         if let recallQuery, !recallQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            if let sessionID,
-               let uuid = UUID(uuidString: sessionID),
-               await longTermMemory.isQueryEmbedderReady() {
-                await awaitQueryEmbedderIfNeeded(memory: try await memory(for: uuid))
+            if await longTermMemory.isQueryEmbedderReady() {
+                await awaitQueryEmbedderIfNeeded(memory: try await memory(for: sessionUUID))
             }
             var recallArgs: [String: AgentBrokerValue] = [
                 "query": .string(recallQuery),
@@ -1745,36 +1745,27 @@ extension AgentBrokerService {
             ]
             if let resolvedProject { recallArgs["project"] = .string(resolvedProject) }
             if let resolvedRepo { recallArgs["repo"] = .string(resolvedRepo) }
-            if let sessionID { recallArgs["session_id"] = .string(sessionID) }
+            recallArgs["session_id"] = .string(sessionID)
             if let cwd { recallArgs["cwd"] = .string(cwd) }
             recallPayload = try await recall(try BrokerCommand.Recall.decode(BrokerArguments(recallArgs)))
         }
 
-        let returnedSessionID = sessionID.flatMap { UUID(uuidString: $0) }
         let rebound: Bool
-        if let priorUnique, let returnedSessionID, returnedSessionID == priorUnique.sessionID {
+        if let priorUnique, sessionUUID == priorUnique.sessionID {
             rebound = requestedRunID == nil || requestedRunID != priorUnique.runID
-        } else if let conversationResume, let returnedSessionID,
-                  returnedSessionID == conversationResume.sessionID
-        {
-            rebound = requestedRunID == nil || requestedRunID != conversationResume.runID
+        } else if let conversationMatch, sessionUUID == conversationMatch.sessionID {
+            rebound = requestedRunID == nil || requestedRunID != conversationMatch.runID
         } else {
             rebound = false
         }
-        let sharePrompt: String
-        if let sessionID {
-            sharePrompt =
-                "This MCP connection remembers session_id (\(sessionID)); omit it on subsequent memory calls on this connection. Retain it for reconnects, explicit cross-session calls, and direct broker/CLI use. Host children do not get Wax tools."
-        } else {
-            sharePrompt =
-                "The MCP connection remembers the returned session_id; omit it on subsequent memory calls on this connection. Retain it for reconnects, explicit cross-session calls, and direct broker/CLI use. Host children do not get Wax tools."
-        }
+        let sharePrompt =
+            "This MCP connection remembers session_id (\(sessionID)); omit it on subsequent memory calls on this connection. Retain it for reconnects, explicit cross-session calls, and direct broker/CLI use. Host children do not get Wax tools."
 
         // Keep the bootstrap wire shape deliberately small.  Callers that
         // need project/repo, lease state, or the full handoff can issue the
         // corresponding explicit read after they have the session UUID.
         var payload: [String: AgentBrokerValue] = [
-            "session_id": .from(sessionID),
+            "session_id": .string(sessionID),
             "rebound": .bool(rebound),
             "share_prompt": .string(sharePrompt),
             "handoff": try await Self.compactSessionOpenHandoff(

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1750,14 +1750,7 @@ extension AgentBrokerService {
             recallPayload = try await recall(try BrokerCommand.Recall.decode(BrokerArguments(recallArgs)))
         }
 
-        let rebound: Bool
-        if let priorUnique, sessionUUID == priorUnique.sessionID {
-            rebound = requestedRunID == nil || requestedRunID != priorUnique.runID
-        } else if let conversationMatch, sessionUUID == conversationMatch.sessionID {
-            rebound = requestedRunID == nil || requestedRunID != conversationMatch.runID
-        } else {
-            rebound = false
-        }
+        let rebound = SessionOpenDecision.rebound(returnedSessionID: sessionUUID, facts: openFacts)
         let sharePrompt =
             "This MCP connection remembers session_id (\(sessionID)); omit it on subsequent memory calls on this connection. Retain it for reconnects, explicit cross-session calls, and direct broker/CLI use. Host children do not get Wax tools."
 

--- a/Sources/Wax/Broker/SessionOpenDecision.swift
+++ b/Sources/Wax/Broker/SessionOpenDecision.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Pure open-policy for `session_open`: resume vs start-new from precomputed facts.
+package enum SessionOpenDecision: Sendable {
+    package struct Match: Sendable, Equatable {
+        package var sessionID: UUID
+        package var runID: String
+
+        package init(sessionID: UUID, runID: String) {
+            self.sessionID = sessionID
+            self.runID = runID
+        }
+    }
+
+    package struct Facts: Sendable, Equatable {
+        package var conversationID: String?
+        package var conversationMatch: Match?
+        package var hintedSessionID: UUID?
+        /// Exists, active, and no project conflict — shell already gates exact-pair / unique lease.
+        package var hintedResumable: Bool
+        package var priorUnique: Match?
+        package var requestedRunID: String?
+
+        package init(
+            conversationID: String?,
+            conversationMatch: Match?,
+            hintedSessionID: UUID?,
+            hintedResumable: Bool,
+            priorUnique: Match?,
+            requestedRunID: String?
+        ) {
+            self.conversationID = conversationID
+            self.conversationMatch = conversationMatch
+            self.hintedSessionID = hintedSessionID
+            self.hintedResumable = hintedResumable
+            self.priorUnique = priorUnique
+            self.requestedRunID = requestedRunID
+        }
+    }
+
+    package enum Action: Sendable, Equatable {
+        case resume(sessionID: UUID)
+        case startNew
+    }
+
+    /// Evaluate order matches current `sessionOpen` policy.
+    package static func evaluate(_ facts: Facts) -> Action {
+        if facts.conversationID != nil {
+            if let match = facts.conversationMatch {
+                return .resume(sessionID: match.sessionID)
+            }
+            // Explicit host conversation is an isolation boundary — ignore hints.
+            return .startNew
+        }
+        if facts.hintedResumable, let hintedSessionID = facts.hintedSessionID {
+            return .resume(sessionID: hintedSessionID)
+        }
+        return .startNew
+    }
+}

--- a/Sources/Wax/Broker/SessionOpenDecision.swift
+++ b/Sources/Wax/Broker/SessionOpenDecision.swift
@@ -18,7 +18,9 @@ package enum SessionOpenDecision: Sendable {
         package var hintedSessionID: UUID?
         /// Exists, active, and no project conflict — shell already gates exact-pair / unique lease.
         package var hintedResumable: Bool
+        /// Unique agent+project lease; used by `rebound`, not by `evaluate` (start owns rebind).
         package var priorUnique: Match?
+        /// Requested run_id; used by `rebound`, not by `evaluate`.
         package var requestedRunID: String?
 
         package init(
@@ -44,6 +46,8 @@ package enum SessionOpenDecision: Sendable {
     }
 
     /// Evaluate order matches current `sessionOpen` policy.
+    /// Unique agent+project rebind is intentionally *not* decided here — `startNew`
+    /// lets `virtualSessions.start` stamp/rebind.
     package static func evaluate(_ facts: Facts) -> Action {
         if facts.conversationID != nil {
             if let match = facts.conversationMatch {
@@ -56,5 +60,16 @@ package enum SessionOpenDecision: Sendable {
             return .resume(sessionID: hintedSessionID)
         }
         return .startNew
+    }
+
+    /// Unique agent+project rebind or conversation resume with a different/omitted run_id.
+    package static func rebound(returnedSessionID: UUID, facts: Facts) -> Bool {
+        if let prior = facts.priorUnique, returnedSessionID == prior.sessionID {
+            return facts.requestedRunID == nil || facts.requestedRunID != prior.runID
+        }
+        if let match = facts.conversationMatch, returnedSessionID == match.sessionID {
+            return facts.requestedRunID == nil || facts.requestedRunID != match.runID
+        }
+        return false
     }
 }

--- a/Tests/WaxTests/SessionOpenDecisionTests.swift
+++ b/Tests/WaxTests/SessionOpenDecisionTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+@testable import Wax
+
+struct SessionOpenDecisionTests {
+    private let matchA = SessionOpenDecision.Match(
+        sessionID: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!,
+        runID: "run-a"
+    )
+    private let hintedID = UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!
+
+    @Test
+    func evaluateResumesConversationMatch() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: "conv-1",
+            conversationMatch: matchA,
+            hintedSessionID: hintedID,
+            hintedResumable: true,
+            priorUnique: nil,
+            requestedRunID: "run-b"
+        )
+
+        #expect(SessionOpenDecision.evaluate(facts) == .resume(sessionID: matchA.sessionID))
+    }
+
+    @Test
+    func evaluateStartsNewWhenConversationHasNoMatchEvenIfHintedResumable() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: "conv-1",
+            conversationMatch: nil,
+            hintedSessionID: hintedID,
+            hintedResumable: true,
+            priorUnique: nil,
+            requestedRunID: nil
+        )
+
+        #expect(SessionOpenDecision.evaluate(facts) == .startNew)
+    }
+
+    @Test
+    func evaluateResumesHintedWhenNoConversation() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: hintedID,
+            hintedResumable: true,
+            priorUnique: nil,
+            requestedRunID: nil
+        )
+
+        #expect(SessionOpenDecision.evaluate(facts) == .resume(sessionID: hintedID))
+    }
+
+    @Test
+    func evaluateStartsNewWhenNoConversationAndHintNotResumable() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: hintedID,
+            hintedResumable: false,
+            priorUnique: nil,
+            requestedRunID: nil
+        )
+
+        #expect(SessionOpenDecision.evaluate(facts) == .startNew)
+    }
+
+    @Test
+    func evaluateStartsNewWhenNoConversationAndNoHint() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: nil,
+            hintedResumable: true,
+            priorUnique: nil,
+            requestedRunID: nil
+        )
+
+        #expect(SessionOpenDecision.evaluate(facts) == .startNew)
+    }
+
+    @Test(arguments: [
+        (
+            "conversation match wins over hint",
+            SessionOpenDecision.Facts(
+                conversationID: "c",
+                conversationMatch: SessionOpenDecision.Match(
+                    sessionID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+                    runID: "r1"
+                ),
+                hintedSessionID: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                hintedResumable: true,
+                priorUnique: nil,
+                requestedRunID: nil
+            ),
+            SessionOpenDecision.Action.resume(
+                sessionID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+            )
+        ),
+        (
+            "conversation miss isolates from hint",
+            SessionOpenDecision.Facts(
+                conversationID: "c",
+                conversationMatch: nil,
+                hintedSessionID: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                hintedResumable: true,
+                priorUnique: SessionOpenDecision.Match(
+                    sessionID: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+                    runID: "old"
+                ),
+                requestedRunID: "new"
+            ),
+            SessionOpenDecision.Action.startNew
+        ),
+        (
+            "hint resume",
+            SessionOpenDecision.Facts(
+                conversationID: nil,
+                conversationMatch: nil,
+                hintedSessionID: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                hintedResumable: true,
+                priorUnique: nil,
+                requestedRunID: nil
+            ),
+            SessionOpenDecision.Action.resume(
+                sessionID: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+            )
+        ),
+        (
+            "default start",
+            SessionOpenDecision.Facts(
+                conversationID: nil,
+                conversationMatch: nil,
+                hintedSessionID: nil,
+                hintedResumable: false,
+                priorUnique: nil,
+                requestedRunID: nil
+            ),
+            SessionOpenDecision.Action.startNew
+        ),
+    ])
+    func evaluateTable(
+        _ label: String,
+        facts: SessionOpenDecision.Facts,
+        expected: SessionOpenDecision.Action
+    ) {
+        #expect(SessionOpenDecision.evaluate(facts) == expected, "\(label)")
+    }
+}

--- a/Tests/WaxTests/SessionOpenDecisionTests.swift
+++ b/Tests/WaxTests/SessionOpenDecisionTests.swift
@@ -79,6 +79,21 @@ struct SessionOpenDecisionTests {
         #expect(SessionOpenDecision.evaluate(facts) == .startNew)
     }
 
+    @Test
+    func evaluateStartsNewWhenPriorUniqueAlone() {
+        // Unique rebind is owned by virtualSessions.start, not evaluate.
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: nil,
+            hintedResumable: false,
+            priorUnique: matchA,
+            requestedRunID: "run-b"
+        )
+
+        #expect(SessionOpenDecision.evaluate(facts) == .startNew)
+    }
+
     @Test(arguments: [
         (
             "conversation match wins over hint",
@@ -127,6 +142,21 @@ struct SessionOpenDecisionTests {
             )
         ),
         (
+            "priorUnique alone is startNew",
+            SessionOpenDecision.Facts(
+                conversationID: nil,
+                conversationMatch: nil,
+                hintedSessionID: nil,
+                hintedResumable: false,
+                priorUnique: SessionOpenDecision.Match(
+                    sessionID: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+                    runID: "old"
+                ),
+                requestedRunID: "new"
+            ),
+            SessionOpenDecision.Action.startNew
+        ),
+        (
             "default start",
             SessionOpenDecision.Facts(
                 conversationID: nil,
@@ -145,5 +175,75 @@ struct SessionOpenDecisionTests {
         expected: SessionOpenDecision.Action
     ) {
         #expect(SessionOpenDecision.evaluate(facts) == expected, "\(label)")
+    }
+
+    @Test
+    func reboundTrueForPriorUniqueWithDifferentRunID() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: nil,
+            hintedResumable: false,
+            priorUnique: matchA,
+            requestedRunID: "run-b"
+        )
+
+        #expect(SessionOpenDecision.rebound(returnedSessionID: matchA.sessionID, facts: facts))
+    }
+
+    @Test
+    func reboundTrueForPriorUniqueWithOmittedRunID() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: nil,
+            hintedResumable: false,
+            priorUnique: matchA,
+            requestedRunID: nil
+        )
+
+        #expect(SessionOpenDecision.rebound(returnedSessionID: matchA.sessionID, facts: facts))
+    }
+
+    @Test
+    func reboundFalseForPriorUniqueWithSameRunID() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: nil,
+            hintedResumable: false,
+            priorUnique: matchA,
+            requestedRunID: matchA.runID
+        )
+
+        #expect(!SessionOpenDecision.rebound(returnedSessionID: matchA.sessionID, facts: facts))
+    }
+
+    @Test
+    func reboundTrueForConversationResumeWithDifferentRunID() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: "conv-1",
+            conversationMatch: matchA,
+            hintedSessionID: nil,
+            hintedResumable: false,
+            priorUnique: nil,
+            requestedRunID: "run-b"
+        )
+
+        #expect(SessionOpenDecision.rebound(returnedSessionID: matchA.sessionID, facts: facts))
+    }
+
+    @Test
+    func reboundFalseWhenReturnedSessionDoesNotMatch() {
+        let facts = SessionOpenDecision.Facts(
+            conversationID: nil,
+            conversationMatch: nil,
+            hintedSessionID: hintedID,
+            hintedResumable: true,
+            priorUnique: matchA,
+            requestedRunID: "run-b"
+        )
+
+        #expect(!SessionOpenDecision.rebound(returnedSessionID: hintedID, facts: facts))
     }
 }


### PR DESCRIPTION
## Ticket T1

Functional-evolution Strong candidate: session open as a pure decision.

`sessionOpen` mixed identity rules with store I/O and then parsed `session_id` back out of `AgentBrokerValue`. This extracts `SessionOpenDecision.evaluate` / `rebound`, uses typed `LifecycleResult` from `virtualSessions.start`/`resume`, and keeps the MCP bootstrap wire shape.

Spec (not in this public tree): architecture pipeline run `7eba74a0`, ticket T1.

### Review

- Skill: `swift-adversarial-pr-review` (largest file `AgentBrokerService.swift` ≥ 1500 LOC)
- First pass: fix allowed (`e7e9b0007` rebound helper)
- Final pass: APPROVE

### Tests

- `swift test --filter SessionOpenDecisionTests`
- `swift test --filter WaxMCP0128BrokerFixTests --traits MCPServer`
- conversation / hinted-open MCP filters on final pass

No public Swift API change. Independent of T2.