### PR TITLE
Share access-ranking window; require FastRAG evaluation clock

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1283,12 +1283,13 @@ package actor MemoryOrchestrator {
         // Access-aware ranking needs additional candidates so a stale top hit
         // can be displaced by a close, recently/frequently used result. The
         // candidate window is bounded and applies only when the feature is on.
-        let searchTopK: Int
-        if !config.enableAccessStatsScoring || topK > 16 {
-            searchTopK = topK
-        } else {
-            searchTopK = topK * 3
-        }
+        let accessEnabled = config.enableAccessStatsScoring
+        let searchTopK = AccessRankingWindow.candidateCount(
+            requestedTopK: topK,
+            accessEnabled: accessEnabled,
+            multiplier: 3,
+            applyWhenRequestedTopKAtMost: 16
+        )
         // One ranking-now for this search: UnifiedSearch recency and later
         // access ranking must not tick the wall clock twice.
         let searchNowMs = config.rag.deterministicNowMs ?? nowProvider()
@@ -1307,7 +1308,7 @@ package actor MemoryOrchestrator {
         )
         let response = try await session.search(request)
 
-        let accessStatsMap: [UInt64: FrameAccessStats] = if config.enableAccessStatsScoring {
+        let accessStatsMap: [UInt64: FrameAccessStats] = if accessEnabled {
             await AccessFrequencyRanker.statsForRanking(
                 frameIds: response.results.map(\.frameId),
                 manager: accessStatsManager,
@@ -1316,15 +1317,14 @@ package actor MemoryOrchestrator {
         } else {
             [:]
         }
-        let scoredResults = config.enableAccessStatsScoring
-            ? AccessFrequencyRanker.rerank(
-                results: response.results,
-                query: trimmed,
-                accessStats: accessStatsMap,
-                nowMs: searchNowMs,
-                maxWindow: searchTopK
-            )
-            : response.results
+        let scoredResults = RankedSearch.applyAccessRanking(
+            results: response.results,
+            query: trimmed,
+            accessStats: accessStatsMap,
+            nowMs: searchNowMs,
+            maxWindow: searchTopK,
+            enabled: accessEnabled
+        )
         let hits = scoredResults.prefix(topK).map { result in
             let accessReasons = MemorySemantics.accessReasons(
                 stats: accessStatsMap[result.frameId],

--- a/Sources/Wax/RAG/FastRAGConfig.swift
+++ b/Sources/Wax/RAG/FastRAGConfig.swift
@@ -116,10 +116,9 @@ package struct FastRAGConfig: Sendable, Equatable {
     /// Enable query-aware tier selection (boosts tier for specific queries)
     package var enableQueryAwareTierSelection: Bool = true
     
-    /// Optional fixed "now" timestamp used for deterministic tier selection.
-    /// When nil, the builder resolves "now" as the max candidate frame timestamp;
-    /// if that is also unavailable, "now" is unknown and no access-recency signals
-    /// are produced (never wall clock time).
+    /// Fixed evaluation clock (ms since epoch) for ranking and tier selection.
+    /// Required by `FastRAGContextBuilder.build` — nil throws (no wall clock or zero).
+    /// `MemoryOrchestrator.ragConfigForRecall()` always fills this.
     package var deterministicNowMs: Int64? = nil
 
     package init(

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -28,25 +28,27 @@ package struct FastRAGContextBuilder: Sendable {
     ) async throws -> RAGContext {
         let clamped = clamp(config)
         let counter = try await TokenCounter.shared()
-        // One evaluation clock for this build. Do not invent wall time.
-        // SearchRequest.nowMs is non-optional; 0 is not recency-neutral
-        // (MemorySemantics ageDays uses max(0, now - created), so a missing
-        // clock looks "recent" and does not expire). Ranking callers must set
-        // deterministicNowMs; MemoryOrchestrator.recall always does.
-        let nowMs = clamped.deterministicNowMs
+        // One evaluation clock for this build. Do not invent wall time or
+        // epoch/zero (MemorySemantics ageDays treats 0 as "recent").
+        // MemoryOrchestrator.ragConfigForRecall() always fills this; other
+        // callers must set FastRAGConfig.deterministicNowMs.
+        guard let nowMs = clamped.deterministicNowMs else {
+            throw WaxError.io(
+                "FastRAGContextBuilder.build requires FastRAGConfig.deterministicNowMs"
+            )
+        }
 
         // 1) Run unified search
         // Access-aware ranking needs a little headroom so a stale top result can
         // be displaced by a recently/frequently used candidate just outside the
         // normal context window. The bound keeps enabled-mode work predictable.
-        let searchTopK: Int
-        if accessStatsManager == nil {
-            searchTopK = clamped.searchTopK
-        } else if clamped.searchTopK <= 24 {
-            searchTopK = clamped.searchTopK * 2
-        } else {
-            searchTopK = clamped.searchTopK
-        }
+        let accessEnabled = accessStatsManager != nil
+        let searchTopK = AccessRankingWindow.candidateCount(
+            requestedTopK: clamped.searchTopK,
+            accessEnabled: accessEnabled,
+            multiplier: 2,
+            applyWhenRequestedTopKAtMost: 24
+        )
         let request = SearchRequest(
             query: query,
             embedding: embedding,
@@ -56,7 +58,7 @@ package struct FastRAGContextBuilder: Sendable {
             topK: searchTopK,
             timeRange: timeRange,
             frameFilter: frameFilter,
-            nowMs: nowMs ?? 0,
+            nowMs: nowMs,
             scopeContext: scopeContext,
             rrfK: clamped.rrfK,
             previewMaxBytes: clamped.previewMaxBytes
@@ -77,19 +79,14 @@ package struct FastRAGContextBuilder: Sendable {
         } else {
             [:]
         }
-        let accessRankedResults: [SearchResponse.Result] = if accessStatsManager == nil {
-            response.results
-        } else if let nowMs {
-            AccessFrequencyRanker.rerank(
-                results: response.results,
-                query: query,
-                accessStats: accessStatsMap,
-                nowMs: nowMs,
-                maxWindow: searchTopK
-            )
-        } else {
-            response.results
-        }
+        let accessRankedResults = RankedSearch.applyAccessRanking(
+            results: response.results,
+            query: query,
+            accessStats: accessStatsMap,
+            nowMs: nowMs,
+            maxWindow: searchTopK,
+            enabled: accessEnabled
+        )
         let queryAnalyzer = QueryAnalyzer()
         let rankedResults = clamped.enableAnswerFocusedRanking
             ? Self.orderCandidatesForAnswer(
@@ -219,20 +216,14 @@ package struct FastRAGContextBuilder: Sendable {
                     group.addTask {
                         guard let data = surrogateContents[item.surrogateFrameId] else { return (index, nil) }
 
-                        let selectedTier: SurrogateTier
-                        if let nowMs {
-                            let frameTimestamp = frameMetaMap[item.result.frameId]?.timestamp ?? nowMs
-                            let context = TierSelectionContext(
-                                frameTimestamp: frameTimestamp,
-                                accessStats: accessStatsMap[item.result.frameId],
-                                querySignals: querySignals,
-                                nowMs: nowMs
-                            )
-                            selectedTier = tierSelector.selectTier(context: context)
-                        } else {
-                            // Unknown "now": no age/recency basis for compression.
-                            selectedTier = .full
-                        }
+                        let frameTimestamp = frameMetaMap[item.result.frameId]?.timestamp ?? nowMs
+                        let context = TierSelectionContext(
+                            frameTimestamp: frameTimestamp,
+                            accessStats: accessStatsMap[item.result.frameId],
+                            querySignals: querySignals,
+                            nowMs: nowMs
+                        )
+                        let selectedTier = tierSelector.selectTier(context: context)
                         guard let text = SurrogateTierSelector.extractTier(from: data, tier: selectedTier),
                               !text.isEmpty else { return (index, nil) }
 

--- a/Sources/Wax/UnifiedSearch/AccessRankingWindow.swift
+++ b/Sources/Wax/UnifiedSearch/AccessRankingWindow.swift
@@ -1,0 +1,49 @@
+import Foundation
+import WaxCore
+
+/// Shared overfetch window for access-aware reranking.
+///
+/// Search and FastRAG keep different multipliers/caps; this helper encodes
+/// the shared rule without silently unifying those numbers.
+package enum AccessRankingWindow {
+    /// Candidate count for the retrieval stage when access ranking may run.
+    ///
+    /// - Parameters:
+    ///   - requestedTopK: Caller-facing result count.
+    ///   - accessEnabled: Whether access-stat reranking is on for this call.
+    ///   - multiplier: Overfetch factor (`3` search, `2` FastRAG).
+    ///   - applyWhenRequestedTopKAtMost: Cap at/under which overfetch applies
+    ///     (`16` search, `24` FastRAG). Above the cap, returns `requestedTopK`.
+    package static func candidateCount(
+        requestedTopK: Int,
+        accessEnabled: Bool,
+        multiplier: Int,
+        applyWhenRequestedTopKAtMost: Int
+    ) -> Int {
+        guard accessEnabled, requestedTopK <= applyWhenRequestedTopKAtMost else {
+            return requestedTopK
+        }
+        return SearchPlan.boundedMultiply(requestedTopK, by: multiplier)
+    }
+}
+
+/// Shared access-stat rerank seam for `searchExecution` and FastRAG.
+package enum RankedSearch {
+    package static func applyAccessRanking(
+        results: [SearchResponse.Result],
+        query: String,
+        accessStats: [UInt64: FrameAccessStats],
+        nowMs: Int64,
+        maxWindow: Int,
+        enabled: Bool
+    ) -> [SearchResponse.Result] {
+        guard enabled else { return results }
+        return AccessFrequencyRanker.rerank(
+            results: results,
+            query: query,
+            accessStats: accessStats,
+            nowMs: nowMs,
+            maxWindow: maxWindow
+        )
+    }
+}

--- a/Tests/WaxIntegrationTests/DeterminismPropertyTests.swift
+++ b/Tests/WaxIntegrationTests/DeterminismPropertyTests.swift
@@ -23,7 +23,7 @@ func fastRAGDeterministicAcrossRepeatedBuildsWithMixedCorpus() async throws {
     try await TempFiles.withTempFile { url in
         let wax = try await makeDeterminismWax(at: url)
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(
+        var config = FastRAGConfig(
             maxContextTokens: 140,
             expansionMaxTokens: 56,
             snippetMaxTokens: 24,
@@ -31,6 +31,7 @@ func fastRAGDeterministicAcrossRepeatedBuildsWithMixedCorpus() async throws {
             searchTopK: 24,
             searchMode: .textOnly
         )
+        config.deterministicNowMs = 1_700_000_000_000
 
         let contextA = try await builder.build(query: "Swift concurrency", wax: wax, config: config)
         let contextB = try await builder.build(query: "Swift concurrency", wax: wax, config: config)

--- a/Tests/WaxIntegrationTests/FastRAGIntegrationTests.swift
+++ b/Tests/WaxIntegrationTests/FastRAGIntegrationTests.swift
@@ -3,6 +3,8 @@ import Testing
 import Wax
 import WaxCore
 
+private let fastRAGIntegrationNowMs: Int64 = 1_700_000_000_000
+
 @Test
 func fastRAGIntegrationCreateRecallReopen() async throws {
     try await TempFiles.withTempFile { url in
@@ -15,7 +17,9 @@ func fastRAGIntegrationCreateRecallReopen() async throws {
         try await text.commit()
 
         let builder = FastRAGContextBuilder()
-        let ctx1 = try await builder.build(query: "concurrency", wax: wax)
+        var config = FastRAGConfig()
+        config.deterministicNowMs = fastRAGIntegrationNowMs
+        let ctx1 = try await builder.build(query: "concurrency", wax: wax, config: config)
         #expect(!ctx1.items.isEmpty)
 
         let baseName = url.deletingPathExtension().lastPathComponent
@@ -28,7 +32,7 @@ func fastRAGIntegrationCreateRecallReopen() async throws {
         try await wax.close()
 
         let reopened = try await Wax.open(at: url)
-        let ctx2 = try await builder.build(query: "concurrency", wax: reopened)
+        let ctx2 = try await builder.build(query: "concurrency", wax: reopened, config: config)
         #expect(!ctx2.items.isEmpty)
         try await reopened.close()
     }

--- a/Tests/WaxIntegrationTests/FastRAGTests.swift
+++ b/Tests/WaxIntegrationTests/FastRAGTests.swift
@@ -3,6 +3,8 @@ import Testing
 @testable import Wax
 import WaxCore
 
+private let fastRAGTestNowMs: Int64 = 1_700_000_000_000
+
 @Test
 func fastRAGProducesSnippetsAndSingleExpansionWhenAvailable() async throws {
     try await TempFiles.withTempFile { url in
@@ -17,7 +19,8 @@ func fastRAGProducesSnippetsAndSingleExpansionWhenAvailable() async throws {
         try await text.commit()
 
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(maxContextTokens: 40, expansionMaxTokens: 20, snippetMaxTokens: 10, maxSnippets: 5, searchTopK: 4)
+        var config = FastRAGConfig(maxContextTokens: 40, expansionMaxTokens: 20, snippetMaxTokens: 10, maxSnippets: 5, searchTopK: 4)
+        config.deterministicNowMs = fastRAGTestNowMs
         let ctx = try await builder.build(query: "Swift", wax: wax, config: config)
 
         #expect(!ctx.items.isEmpty)
@@ -49,7 +52,7 @@ func fastRAGIsDeterministicAndEnforcesTokenBudgets() async throws {
         try await text.commit()
 
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(
+        var config = FastRAGConfig(
             maxContextTokens: 40,
             expansionMaxTokens: 15,
             snippetMaxTokens: 8,
@@ -57,6 +60,7 @@ func fastRAGIsDeterministicAndEnforcesTokenBudgets() async throws {
             searchTopK: 10,
             searchMode: .textOnly
         )
+        config.deterministicNowMs = fastRAGTestNowMs
 
         let ctxA = try await builder.build(query: "Swift", wax: wax, config: config)
         let ctxB = try await builder.build(query: "Swift", wax: wax, config: config)
@@ -107,7 +111,7 @@ func fastRAGUsingSessionMatchesWaxSearchDeterministically() async throws {
             searchTopK: 6,
             searchMode: .textOnly
         )
-        config.deterministicNowMs = 1_700_000_000_000
+        config.deterministicNowMs = fastRAGTestNowMs
 
         let session = try await wax.openSession(.readOnly)
         let viaSessionA = try await builder.build(
@@ -153,7 +157,8 @@ func fastRAGSkipsNonUTF8ExpansionCandidates() async throws {
         try await text.commit()
 
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(maxContextTokens: 40, expansionMaxTokens: 20, snippetMaxTokens: 10, maxSnippets: 5, searchTopK: 4, searchMode: .textOnly)
+        var config = FastRAGConfig(maxContextTokens: 40, expansionMaxTokens: 20, snippetMaxTokens: 10, maxSnippets: 5, searchTopK: 4, searchMode: .textOnly)
+        config.deterministicNowMs = fastRAGTestNowMs
         let ctx = try await builder.build(query: "Swift", wax: wax, config: config)
 
         let expanded = ctx.items.filter { $0.kind == .expanded }
@@ -185,6 +190,7 @@ func fastRAGSkipsExpansionWhenBytesExceedCap() async throws {
             searchTopK: 4,
             searchMode: .textOnly
         )
+        config.deterministicNowMs = fastRAGTestNowMs
         config.expansionMaxBytes = 64
 
         let ctx = try await builder.build(query: "Swift", wax: wax, config: config)
@@ -240,7 +246,7 @@ func denseCachedSkipsInvalidSurrogateAndFallsBackToSnippet() async throws {
         try await wax.commit()
 
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(
+        var config = FastRAGConfig(
             mode: .denseCached,
             maxContextTokens: 40,
             expansionMaxTokens: 0,
@@ -251,6 +257,7 @@ func denseCachedSkipsInvalidSurrogateAndFallsBackToSnippet() async throws {
             searchTopK: 5,
             searchMode: .textOnly
         )
+        config.deterministicNowMs = fastRAGTestNowMs
 
         let ctx = try await builder.build(query: "Swift", wax: wax, config: config)
         #expect(ctx.items.contains { $0.kind == .snippet })
@@ -298,7 +305,7 @@ func denseCachedSkipsSurrogateWhenFrameContentThrowsAndStillReturnsSnippets() as
         try handle.close()
 
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(
+        var config = FastRAGConfig(
             mode: .denseCached,
             maxContextTokens: 40,
             expansionMaxTokens: 0,
@@ -309,6 +316,7 @@ func denseCachedSkipsSurrogateWhenFrameContentThrowsAndStillReturnsSnippets() as
             searchTopK: 5,
             searchMode: .textOnly
         )
+        config.deterministicNowMs = fastRAGTestNowMs
 
         let ctx = try await builder.build(query: "Swift", wax: wax, config: config)
         #expect(ctx.items.contains { $0.kind == .snippet })
@@ -356,7 +364,7 @@ func denseCachedEnforcesSurrogateLimitsAndSkipsSourceSnippets() async throws {
         try await wax.commit()
 
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(
+        var config = FastRAGConfig(
             mode: .denseCached,
             maxContextTokens: 30,
             expansionMaxTokens: 0,
@@ -367,6 +375,7 @@ func denseCachedEnforcesSurrogateLimitsAndSkipsSourceSnippets() async throws {
             searchTopK: 10,
             searchMode: .textOnly
         )
+        config.deterministicNowMs = fastRAGTestNowMs
 
         let ctx = try await builder.build(query: "Swift", wax: wax, config: config)
         let surrogates = ctx.items.filter { $0.kind == .surrogate }
@@ -414,6 +423,7 @@ func queryAwareRerankPrefersIntentAlignedPreviewOverHigherBaseScore() {
         ),
     ]
     var config = FastRAGConfig()
+    config.deterministicNowMs = fastRAGTestNowMs
     config.enableAnswerFocusedRanking = true
 
     let ordered = FastRAGContextBuilder.orderCandidatesForAnswer(

--- a/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
+++ b/Tests/WaxIntegrationTests/LongMemoryBenchmarkHarness.swift
@@ -297,7 +297,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
         let judge = TokenF1AnswerJudge()
         let ragBuilder = FastRAGContextBuilder()
         let answerExtractor = DeterministicAnswerExtractor()
-        let ragConfig = FastRAGConfig(
+        var ragConfig = FastRAGConfig(
             maxContextTokens: 180,
             expansionMaxTokens: 120,
             snippetMaxTokens: 45,
@@ -305,6 +305,7 @@ final class LongMemoryBenchmarkHarness: XCTestCase {
             searchTopK: max(config.topK, 12),
             searchMode: config.includeVectors ? .hybrid(alpha: config.searchAlpha) : .textOnly
         )
+        ragConfig.deterministicNowMs = Int64(Date().timeIntervalSince1970 * 1000)
 
         var outcomes: [LongMemoryQueryOutcome] = []
         outcomes.reserveCapacity(fixture.queries.count)

--- a/Tests/WaxIntegrationTests/RAGBenchmarks.swift
+++ b/Tests/WaxIntegrationTests/RAGBenchmarks.swift
@@ -365,7 +365,8 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 snippetMaxTokens: 160,
                 maxSnippets: 20,
                 searchTopK: scale.searchTopK,
-                searchMode: .hybrid(alpha: 0.7)
+                searchMode: .hybrid(alpha: 0.7),
+                deterministicNowMs: 1_700_000_000_000
             )
 
             _ = try await builder.build(
@@ -403,7 +404,8 @@ final class RAGPerformanceBenchmarks: XCTestCase {
                 maxSurrogates: 8,
                 surrogateMaxTokens: 80,
                 searchTopK: scale.searchTopK,
-                searchMode: .hybrid(alpha: 0.7)
+                searchMode: .hybrid(alpha: 0.7),
+                deterministicNowMs: 1_700_000_000_000
             )
 
             _ = try await builder.build(

--- a/Tests/WaxIntegrationTests/RAGConfigClampingTests.swift
+++ b/Tests/WaxIntegrationTests/RAGConfigClampingTests.swift
@@ -4,6 +4,8 @@ import Testing
 @testable import Wax
 import WaxCore
 
+private let ragClampTestNowMs: Int64 = 1_700_000_000_000
+
 private let tinyPNGData = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6Q5+YAAAAASUVORK5CYII=")!
 private let tinyPhotoQueryImage = PhotoQueryImage(data: tinyPNGData, format: .png)
 
@@ -235,6 +237,7 @@ func fastRAGRrfKZeroOrNegativeDoesNotCrash() async throws {
 
         for value in [0, -1, -100] {
             var config = FastRAGConfig(searchMode: .textOnly)
+            config.deterministicNowMs = ragClampTestNowMs
             config.rrfK = value
             let context = try await builder.build(query: "Swift", wax: wax, config: config)
             #expect(!context.items.isEmpty)
@@ -252,6 +255,7 @@ func fastRAGExpansionBudgetIsBoundedByContextBudget() async throws {
         let counter = try await TokenCounter()
 
         var config = FastRAGConfig(searchMode: .textOnly)
+        config.deterministicNowMs = ragClampTestNowMs
         config.maxContextTokens = 32
         config.expansionMaxTokens = 512
 
@@ -272,6 +276,7 @@ func fastRAGMaxSnippetsZeroProducesNoSnippets() async throws {
         let builder = FastRAGContextBuilder()
 
         var config = FastRAGConfig(searchMode: .textOnly)
+        config.deterministicNowMs = ragClampTestNowMs
         config.maxSnippets = 0
         config.expansionMaxTokens = 0
         config.maxContextTokens = 128
@@ -290,6 +295,7 @@ func fastRAGNegativeBudgetsClampToZeroAtBuildTime() async throws {
         let builder = FastRAGContextBuilder()
 
         var config = FastRAGConfig(searchMode: .textOnly)
+        config.deterministicNowMs = ragClampTestNowMs
         config.maxContextTokens = -1
         config.snippetMaxTokens = -100
         config.maxSnippets = -5
@@ -312,6 +318,7 @@ func fastRAGSearchTopKZeroReturnsEmptyResults() async throws {
         let builder = FastRAGContextBuilder()
 
         var config = FastRAGConfig(searchMode: .textOnly)
+        config.deterministicNowMs = ragClampTestNowMs
         config.searchTopK = 0
         let context = try await builder.build(query: "Swift", wax: wax, config: config)
         #expect(context.items.isEmpty)
@@ -328,6 +335,7 @@ func fastRAGPreviewMaxBytesZeroStillBuildsContext() async throws {
         let builder = FastRAGContextBuilder()
 
         var config = FastRAGConfig(searchMode: .textOnly)
+        config.deterministicNowMs = ragClampTestNowMs
         config.previewMaxBytes = 0
         let context = try await builder.build(query: "Swift", wax: wax, config: config)
         #expect(!context.items.isEmpty)

--- a/Tests/WaxIntegrationTests/READMEExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/READMEExamplesTests.swift
@@ -239,10 +239,11 @@ func readmeExampleFastRAG() async throws {
         try await text.commit()
 
         let builder = FastRAGContextBuilder()
-        let config = FastRAGConfig(
+        var config = FastRAGConfig(
             maxContextTokens: 800,
             searchMode: .hybrid(alpha: 0.5)
         )
+        config.deterministicNowMs = 1_700_000_000_000
 
         let context = try await builder.build(query: "swift concurrency", wax: wax, config: config)
         #expect(context.totalTokens >= 0)

--- a/Tests/WaxIntegrationTests/VectorLaneDiagnosticsTests.swift
+++ b/Tests/WaxIntegrationTests/VectorLaneDiagnosticsTests.swift
@@ -58,7 +58,8 @@ struct VectorLaneDiagnosticsTests {
                 let context = try await FastRAGContextBuilder().build(
                     query: "memory reliability", embedding: [1, 0],
                     vectorSearchTimeout: .milliseconds(25), wax: wax,
-                    engineOverrides: .init(vectorEngine: DiagnosticVectorEngine(hang: true))
+                    engineOverrides: .init(vectorEngine: DiagnosticVectorEngine(hang: true)),
+                    config: FastRAGConfig(deterministicNowMs: 1_700_000_000_000)
                 )
                 #expect(context.diagnostics?.effectiveMode == .textOnly)
                 #expect(context.diagnostics?.queryEmbeddingState == .available)

--- a/Tests/WaxTests/AccessRankingWindowTests.swift
+++ b/Tests/WaxTests/AccessRankingWindowTests.swift
@@ -1,0 +1,103 @@
+import Testing
+@testable import Wax
+import WaxCore
+
+struct AccessRankingWindowTests {
+    @Test(arguments: [
+        // search path: multiplier 3, cap 16
+        (requested: 10, enabled: true, multiplier: 3, cap: 16, expected: 30),
+        (requested: 16, enabled: true, multiplier: 3, cap: 16, expected: 48),
+        (requested: 17, enabled: true, multiplier: 3, cap: 16, expected: 17),
+        (requested: 20, enabled: true, multiplier: 3, cap: 16, expected: 20),
+        // FastRAG path: multiplier 2, cap 24
+        (requested: 24, enabled: true, multiplier: 2, cap: 24, expected: 48),
+        (requested: 25, enabled: true, multiplier: 2, cap: 24, expected: 25),
+        (requested: 10, enabled: true, multiplier: 2, cap: 24, expected: 20),
+        // disabled → requestedTopK
+        (requested: 10, enabled: false, multiplier: 3, cap: 16, expected: 10),
+        (requested: 24, enabled: false, multiplier: 2, cap: 24, expected: 24),
+        (requested: 0, enabled: true, multiplier: 3, cap: 16, expected: 0),
+    ])
+    func candidateCountMatchesSearchAndFastRAGPolicies(
+        requested: Int,
+        enabled: Bool,
+        multiplier: Int,
+        cap: Int,
+        expected: Int
+    ) {
+        let count = AccessRankingWindow.candidateCount(
+            requestedTopK: requested,
+            accessEnabled: enabled,
+            multiplier: multiplier,
+            applyWhenRequestedTopKAtMost: cap
+        )
+        #expect(count == expected)
+    }
+
+    @Test
+    func applyAccessRankingDisabledIsIdentity() {
+        let results = [
+            result(frameId: 1, score: 0.40, preview: "alpha"),
+            result(frameId: 2, score: 0.35, preview: "beta"),
+        ]
+        var stats = FrameAccessStats(frameId: 2, nowMs: 1_700_000_000_000)
+        stats.accessCount = 32
+        stats.engagementCount = 32
+        stats.lastEngagementMs = stats.lastImpressionMs
+
+        let ranked = RankedSearch.applyAccessRanking(
+            results: results,
+            query: "alpha",
+            accessStats: [2: stats],
+            nowMs: 1_700_000_000_000,
+            maxWindow: 2,
+            enabled: false
+        )
+        #expect(ranked == results)
+    }
+
+    @Test
+    func applyAccessRankingEnabledMatchesAccessFrequencyRanker() {
+        let nowMs: Int64 = 1_700_000_000_000
+        let results = [
+            result(frameId: 1, score: 0.50, preview: "shared token"),
+            result(frameId: 2, score: 0.50, preview: "shared token"),
+        ]
+        var stale = FrameAccessStats(frameId: 1, nowMs: nowMs - 30 * 24 * 60 * 60 * 1000)
+        stale.accessCount = 1
+        stale.engagementCount = 1
+        stale.lastEngagementMs = stale.lastImpressionMs
+        var recent = FrameAccessStats(frameId: 2, nowMs: nowMs - 6 * 60 * 60 * 1000)
+        recent.accessCount = 8
+        recent.engagementCount = 8
+        recent.lastEngagementMs = recent.lastImpressionMs
+        let stats: [UInt64: FrameAccessStats] = [1: stale, 2: recent]
+
+        let viaHelper = RankedSearch.applyAccessRanking(
+            results: results,
+            query: "shared token",
+            accessStats: stats,
+            nowMs: nowMs,
+            maxWindow: 2,
+            enabled: true
+        )
+        let viaRanker = AccessFrequencyRanker.rerank(
+            results: results,
+            query: "shared token",
+            accessStats: stats,
+            nowMs: nowMs,
+            maxWindow: 2
+        )
+        #expect(viaHelper == viaRanker)
+        #expect(viaHelper.map(\.frameId) == [2, 1])
+    }
+
+    private func result(frameId: UInt64, score: Float, preview: String) -> SearchResponse.Result {
+        SearchResponse.Result(
+            frameId: frameId,
+            score: score,
+            previewText: preview,
+            sources: [.text]
+        )
+    }
+}

--- a/Tests/WaxTests/EvaluationClockTests.swift
+++ b/Tests/WaxTests/EvaluationClockTests.swift
@@ -163,17 +163,16 @@ struct EvaluationClockTests {
             )
             let config = FastRAGConfig(searchMode: .textOnly)
             #expect(config.deterministicNowMs == nil)
-            let context = try await FastRAGContextBuilder().build(
-                query: "Waxfile ranking-clock",
-                wax: orchestrator.wax,
-                session: orchestrator.session,
-                config: config
-            )
-            let item = try #require(context.items.first)
-            // Wall clock (~2026) would mark a 2023 handoff stale. SearchRequest.nowMs
-            // is non-optional, so the nil-clock path passes 0, which looks recent.
-            #expect(item.explanations.contains("recent handoff"))
-            #expect(item.explanations.contains("stale handoff") == false)
+            // Missing clock must not fall back to wall time or epoch/zero
+            // (zero looks "recent" in MemorySemantics). Build requires an explicit nowMs.
+            await #expect(throws: WaxError.self) {
+                _ = try await FastRAGContextBuilder().build(
+                    query: "Waxfile ranking-clock",
+                    wax: orchestrator.wax,
+                    session: orchestrator.session,
+                    config: config
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Ticket T2

Functional-evolution Strong candidate: one ranked-search kernel.

`searchExecution` and `FastRAGContextBuilder` both overfetched for access ranking and reranked separately (`*3` vs `*2`). FastRAG used `nowMs ?? 0`, which `MemorySemantics` treats as recent. This shares `AccessRankingWindow` / `RankedSearch.applyAccessRanking` (multipliers stay parameterized) and throws if `deterministicNowMs` is missing.

Spec (not in this public tree): architecture pipeline run `7eba74a0`, ticket T2.

### Review

- Skill: `swift-adversarial-pr-review` (largest file `MemoryOrchestrator.swift` ≥ 1500 LOC)
- First pass: nil-clock test + caller pins (`d393755b1`)
- Final pass: pin remaining Darwin FastRAG integration clocks (`5212b378f`) — APPROVE

### Tests

- `swift test --filter AccessRankingWindowTests`
- `swift test --filter EvaluationClockTests`
- `swift test --filter FastRAGTests`
- `swift test --filter SearchPlanTests`

No public `Memory.search` signature change. Independent of T1.