### PR TITLE
fix(mcp): keep session_open handoff, isolate person-lane, reclaim abandoned sessions

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1483,7 +1483,7 @@ extension AgentBrokerService {
             if let status = try virtualSessions.persistedStatus(for: sessionID) {
                 if status == .ended {
                     let harvest = await harvestPersistedSession(sessionID: sessionID)
-                    return sessionClosePayload(
+                    let payload = sessionClosePayload(
                         sessionID: sessionID,
                         ended: true,
                         alreadyEnded: true,
@@ -1491,6 +1491,8 @@ extension AgentBrokerService {
                         remainingActive: activeSessions.count,
                         harvest: harvest
                     )
+                    await sweepSessionStoresAfterClose()
+                    return payload
                 }
             } else {
                 throw BrokerSessionInactiveError.unknown(sessionID: sessionID)
@@ -1512,13 +1514,27 @@ extension AgentBrokerService {
         try await recordHandoff(sessionID: sessionID, content: content)
         try await longTermMemory.flush()
         let result = try await virtualSessions.end(sessionID: sessionID, afterFlush: makeHarvestCallback())
-        return sessionClosePayload(
+        let payload = sessionClosePayload(
             sessionID: sessionID,
             ended: result.ended,
             alreadyEnded: false,
             handoffFrameID: frameId,
             remainingActive: result.activeCount,
             harvest: result.harvest
+        )
+        await sweepSessionStoresAfterClose()
+        return payload
+    }
+
+    /// Reclaim due ended files and harvest abandoned zombies without ending
+    /// fresh expired leases (those stay rebindable until explicit maintain).
+    /// Does not quarantine the long-term library — that stays operator-only
+    /// via `memory_maintain`.
+    private func sweepSessionStoresAfterClose() async {
+        _ = await maintainSessionStores(
+            apply: true,
+            forceReclaim: false,
+            endExpiredSessions: false
         )
     }
 
@@ -1839,36 +1855,8 @@ extension AgentBrokerService {
                 "content_tokens": .from(0),
             ])
         }
-        if !trimmedQuery.isEmpty,
-           MemorySemantics.similarity(lhs: trimmedQuery, rhs: originalContent) < 0.15
-        {
-            if originalTasks.isEmpty {
-                return .object([
-                    "found": .bool(false),
-                    "relevance": .string("low"),
-                    "content": .string(""),
-                    "pending_tasks": .array([]),
-                    "truncated": .bool(false),
-                    "content_truncated": .bool(false),
-                    "pending_tasks_truncated": .from(0),
-                    "pending_tasks_omitted": .from(0),
-                    "content_bytes": .from(0),
-                    "content_tokens": .from(0),
-                ])
-            }
-            return .object([
-                "found": .bool(true),
-                "relevance": .string("low"),
-                "content": .string(""),
-                "pending_tasks": .array(originalTasks.map { .string($0) }),
-                "truncated": .bool(false),
-                "content_truncated": .bool(true),
-                "pending_tasks_truncated": .from(0),
-                "pending_tasks_omitted": .from(0),
-                "content_bytes": .from(0),
-                "content_tokens": .from(0),
-            ])
-        }
+        let lowRelevance = !trimmedQuery.isEmpty
+            && MemorySemantics.similarity(lhs: trimmedQuery, rhs: originalContent) < 0.15
 
         let byteLimitedContent = utf8Prefix(
             originalContent,
@@ -1896,7 +1884,7 @@ extension AgentBrokerService {
         let omittedTaskCount = max(0, originalTasks.count - boundedTasks.count)
         let anyTruncated = contentTruncated || pendingTaskTruncations > 0 || omittedTaskCount > 0
 
-        return .object([
+        var compact: [String: AgentBrokerValue] = [
             "found": .bool(true),
             "content": .string(compactContent),
             "pending_tasks": .array(boundedTasks.map { .string($0) }),
@@ -1906,7 +1894,11 @@ extension AgentBrokerService {
             "pending_tasks_omitted": .from(omittedTaskCount),
             "content_bytes": .from(compactContent.utf8.count),
             "content_tokens": .from(await tokenCounter.count(compactContent)),
-        ])
+        ]
+        if lowRelevance {
+            compact["relevance"] = .string("low")
+        }
+        return .object(compact)
     }
 
     /// Return a prefix without splitting a user-visible Unicode grapheme.
@@ -2121,23 +2113,39 @@ extension AgentBrokerService {
         }
     }
 
-    func memoryMaintain(
-        _ command: BrokerCommand.MemoryMaintain,
-        endExpiredSessions: Bool = true
-    ) async throws -> AgentBrokerValue {
-        let apply = command.apply
-        let force = command.forceReclaim
+    private struct SessionStoreMaintainCounts: Sendable {
+        var zombiesToEnd: Int
+        var harvests: Int
+        var unlinks: Int
+    }
+
+    @discardableResult
+    private func maintainSessionStores(
+        apply: Bool,
+        forceReclaim: Bool,
+        endExpiredSessions: Bool
+    ) async -> SessionStoreMaintainCounts {
         let now = Self.nowMs()
+        let recentlyClosedMs = MemoryRetentionSettings.fromEnvironment().recentlyClosedMs
         let manifests = (try? BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)) ?? []
         let liveIDs = Set(activeSessions.keys)
         var zombiesToEnd = 0
         var harvests = 0
         var unlinks = 0
-        var quarantineSoftDeletes = 0
 
         var zombieIDs = Set<UUID>()
-        for manifest in manifests where endExpiredSessions
-            && SessionReclaim.isZombie(manifest: manifest, liveIDs: liveIDs, nowMs: now) {
+        for manifest in manifests where SessionReclaim.isZombie(
+            manifest: manifest,
+            liveIDs: liveIDs,
+            nowMs: now
+        ) {
+            let abandoned = SessionReclaim.isAbandonedZombie(
+                manifest: manifest,
+                liveIDs: liveIDs,
+                nowMs: now,
+                recentlyClosedMs: recentlyClosedMs
+            )
+            guard endExpiredSessions || abandoned else { continue }
             zombiesToEnd += 1
             zombieIDs.insert(manifest.sessionID)
             harvests += 1
@@ -2160,15 +2168,37 @@ extension AgentBrokerService {
                 rootURL: sessionRootURL,
                 sessionID: manifest.sessionID
             )) ?? manifest
-            if SessionReclaim.isReclaimable(manifest: current, nowMs: now, force: force) {
+            if SessionReclaim.isReclaimable(manifest: current, nowMs: now, force: forceReclaim) {
                 unlinks += 1
                 if apply {
-                    if await reclaimSessionIfDue(sessionID: current.sessionID, force: force) {
-                        // counted
-                    }
+                    _ = await reclaimSessionIfDue(sessionID: current.sessionID, force: forceReclaim)
                 }
             }
         }
+
+        return SessionStoreMaintainCounts(
+            zombiesToEnd: zombiesToEnd,
+            harvests: harvests,
+            unlinks: unlinks
+        )
+    }
+
+    func memoryMaintain(
+        _ command: BrokerCommand.MemoryMaintain,
+        endExpiredSessions: Bool = true
+    ) async throws -> AgentBrokerValue {
+        let apply = command.apply
+        let force = command.forceReclaim
+        let now = Self.nowMs()
+        let sessionCounts = await maintainSessionStores(
+            apply: apply,
+            forceReclaim: force,
+            endExpiredSessions: endExpiredSessions
+        )
+        let zombiesToEnd = sessionCounts.zombiesToEnd
+        let harvests = sessionCounts.harvests
+        let unlinks = sessionCounts.unlinks
+        var quarantineSoftDeletes = 0
 
         let documents = try await longTermMemory.corpusSourceDocuments()
         let accessStats = await longTermMemory.accessStatsSnapshot()

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -418,6 +418,13 @@ package enum LayeredRecall {
         return min(max(bounded * 3, 12), maxTopK)
     }
 
+    /// Person-lane post-filters other-project prefs after a type-only retrieval.
+    /// Over-fetch further so current-project and unscoped prefs still make the window.
+    package static func retrievalTopKForGlobalPersonLane(requested: Int, maxTopK: Int = 200) -> Int {
+        let bounded = max(1, requested)
+        return min(max(bounded * 8, 48), maxTopK)
+    }
+
     /// Merges resolved project/repo identity into the caller's frame filter for retrieval (C1/C3).
     /// Only `scope=project` injects the hard-filter; session/global leave the base filter alone (C7).
     package static func frameFilterForScopedRetrieval(
@@ -928,7 +935,10 @@ package enum LayeredRecall {
         stores: Stores
     ) async throws -> RecallResult {
         var fetchRequest = request
-        fetchRequest.searchTopK = retrievalTopK(requested: request.searchTopK)
+        let personLane = request.scope == .global && request.memoryTypes == [.userPreference]
+        fetchRequest.searchTopK = personLane
+            ? retrievalTopKForGlobalPersonLane(requested: request.searchTopK)
+            : retrievalTopK(requested: request.searchTopK)
         let lanes = try await fetchLanes(request: fetchRequest, stores: stores)
         let identity = lanes.identity
 
@@ -959,16 +969,33 @@ package enum LayeredRecall {
         } else {
             // Global changes the project boundary, not query or filter matching.
             // Person-lane still drops other-project prefs when identity is resolved.
-            let personLaneWorking = filterHitsForGlobalPersonLane(
+            var personLaneWorking = filterHitsForGlobalPersonLane(
                 typedWorking,
                 memoryTypes: request.memoryTypes,
                 identity: identity
             )
-            let personLaneDurable = filterHitsForGlobalPersonLane(
+            var personLaneDurable = filterHitsForGlobalPersonLane(
                 typedDurable,
                 memoryTypes: request.memoryTypes,
                 identity: identity
             )
+            if personLane, identity.project != nil || identity.repo != nil {
+                // Type-only global retrieval can spend the window on foreign prefs.
+                // A project-scoped typed fetch keeps current-project prefs visible
+                // the same way single-type retrieval keeps the person-lane hit.
+                var scopedRequest = request
+                scopedRequest.scope = .project
+                scopedRequest.searchTopK = retrievalTopK(requested: request.searchTopK)
+                let scopedLanes = try await fetchLanes(request: scopedRequest, stores: stores)
+                personLaneWorking.append(contentsOf: filterHitsByMemoryTypes(
+                    scopedLanes.working,
+                    types: request.memoryTypes
+                ))
+                personLaneDurable.append(contentsOf: filterHitsByMemoryTypes(
+                    scopedLanes.durable,
+                    types: request.memoryTypes
+                ))
+            }
             merged = mergeHits(
                 sessionHits: personLaneWorking,
                 durableHits: personLaneDurable,

--- a/Sources/Wax/Broker/LayeredRecall.swift
+++ b/Sources/Wax/Broker/LayeredRecall.swift
@@ -346,6 +346,21 @@ package enum LayeredRecall {
         }
     }
 
+    /// Person-lane (`user_preference` only) drops other-project/other-repo prefs
+    /// when identity is resolved. Unscoped prefs stay. Unresolved identity is a no-op.
+    package static func filterHitsForGlobalPersonLane(
+        _ hits: [Hit],
+        memoryTypes: [MemoryType],
+        identity: Identity
+    ) -> [Hit] {
+        guard memoryTypes == [.userPreference],
+              identity.project != nil || identity.repo != nil
+        else {
+            return hits
+        }
+        return filterHitsByProject(hits, project: identity.project, repo: identity.repo)
+    }
+
     /// Unresolved project keeps the live working lane and unstamped durable/episodic
     /// hits. Stamped foreign durable is dropped so we never auto-widen. Resolved
     /// identity keeps unstamped hits (they are not a different project).
@@ -943,9 +958,20 @@ package enum LayeredRecall {
             )
         } else {
             // Global changes the project boundary, not query or filter matching.
+            // Person-lane still drops other-project prefs when identity is resolved.
+            let personLaneWorking = filterHitsForGlobalPersonLane(
+                typedWorking,
+                memoryTypes: request.memoryTypes,
+                identity: identity
+            )
+            let personLaneDurable = filterHitsForGlobalPersonLane(
+                typedDurable,
+                memoryTypes: request.memoryTypes,
+                identity: identity
+            )
             merged = mergeHits(
-                sessionHits: typedWorking,
-                durableHits: typedDurable,
+                sessionHits: personLaneWorking,
+                durableHits: personLaneDurable,
                 limit: request.limit,
                 nowMs: stores.nowMs(),
                 query: request.query

--- a/Sources/Wax/Broker/SessionReclaim.swift
+++ b/Sources/Wax/Broker/SessionReclaim.swift
@@ -39,6 +39,19 @@ package enum SessionReclaim {
         return lease < nowMs
     }
 
+    /// Active, not live, lease expired for at least the recently-closed window.
+    /// Fresh expired leases stay rebindable; these have been abandoned long enough to harvest.
+    package static func isAbandonedZombie(
+        manifest: BrokerSessionManifest,
+        liveIDs: Set<UUID>,
+        nowMs: Int64,
+        recentlyClosedMs: Int64 = MemoryRetentionSettings.default.recentlyClosedMs
+    ) -> Bool {
+        guard isZombie(manifest: manifest, liveIDs: liveIDs, nowMs: nowMs) else { return false }
+        guard let lease = manifest.leaseExpiresAtMs else { return false }
+        return nowMs &- lease >= recentlyClosedMs
+    }
+
     package static func isRecentlyClosed(
         manifest: BrokerSessionManifest,
         nowMs: Int64

--- a/Tests/WaxMCPServerTests/WaxMCPAgentDXSessionTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPAgentDXSessionTests.swift
@@ -181,7 +181,7 @@ func sessionOpenRebindsUniqueLiveAgentProjectAndSharesSessionID() async throws {
 }
 
 @Test
-func sessionOpenOmitsUnrelatedHandoffBodyAsLowRelevance() async throws {
+func sessionOpenKeepsProjectHandoffWhenRecallQueryMismatches() async throws {
     try await withAgentDXBroker { service, _ in
         let project = "dx-handoff-\(UUID().uuidString.prefix(8))"
         let foreignProject = "dx-foreign-\(UUID().uuidString.prefix(8))"
@@ -225,12 +225,11 @@ func sessionOpenOmitsUnrelatedHandoffBodyAsLowRelevance() async throws {
             recallQuery: query
         )
         let handoff = try requireObject(unrelated["handoff"])
-        #expect(handoff["found"]?.boolValue == false)
-        #expect(handoff["relevance"]?.stringValue == "low")
-        let content = handoff["content"]?.stringValue ?? ""
-        #expect(content.isEmpty)
+        #expect(handoff["found"]?.boolValue == true)
+        let content = try requireString(handoff, "content")
+        #expect(content.contains("WAX-HOME-HANDOFF"))
         #expect(content.contains("FOREIGN-HANDOFF-NEEDLE") == false)
-        #expect(content.contains("WAX-HOME-HANDOFF") == false)
+        #expect(handoff["relevance"]?.stringValue == "low")
         let pending = handoff["pending_tasks"]?.arrayValue ?? []
         #expect(pending.isEmpty)
     }

--- a/Tests/WaxTests/BrokerCommandDecodeTests.swift
+++ b/Tests/WaxTests/BrokerCommandDecodeTests.swift
@@ -522,13 +522,6 @@ struct BrokerCommandDecodeTests {
             return
         }
         #expect(settings.maxCandidates == 3)
-
-        #expect(throws: BrokerValidationError.self) {
-            _ = try BrokerCommand.decode(
-                command: "session_close",
-                arguments: ["content": .string("done")]
-            )
-        }
     }
 
     @Test

--- a/Tests/WaxTests/BrokerIdleSessionRecoveryTests.swift
+++ b/Tests/WaxTests/BrokerIdleSessionRecoveryTests.swift
@@ -46,8 +46,10 @@ struct BrokerIdleSessionRecoveryTests {
         let uuid = try #require(UUID(uuidString: sessionID))
         var manifest = try BrokerSessionPersistence.loadManifest(rootURL: sessions, sessionID: uuid)
         #expect(manifest.status == .active)
-        // Simulate the daemon's idle exit without a five-minute wall-clock wait.
-        manifest.leaseExpiresAtMs = 1
+        // Simulate a fresh idle expiry (seconds ago). Epoch sentinels look
+        // abandoned (≥ recently-closed window) and init would harvest them.
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        manifest.leaseExpiresAtMs = nowMs - 1_000
         try BrokerSessionPersistence.saveManifest(
             manifest,
             to: BrokerSessionPersistence.manifestURL(rootURL: sessions, sessionID: uuid)

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -780,6 +780,60 @@ struct LayeredRecallTests {
     }
 
     @Test
+    func layeredRecallGlobalPersonLaneFilterDropsOtherProjectPrefs() {
+        let home = layeredHit(
+            frameID: 1,
+            score: 1,
+            text: "home pref",
+            horizon: .durable,
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                MemoryMetadataKeys.project: "recall-project",
+                MemoryMetadataKeys.repo: "recall-repo",
+            ]
+        )
+        let foreign = layeredHit(
+            frameID: 2,
+            score: 1,
+            text: "foreign pref",
+            horizon: .durable,
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                MemoryMetadataKeys.project: "foreign-project",
+                MemoryMetadataKeys.repo: "foreign-repo",
+            ]
+        )
+        let unscoped = layeredHit(
+            frameID: 3,
+            score: 1,
+            text: "unscoped pref",
+            horizon: .durable,
+            metadata: [MemoryMetadataKeys.type: MemoryType.userPreference.rawValue]
+        )
+        let identity = LayeredRecall.Identity(project: "recall-project", repo: "recall-repo")
+        let filtered = LayeredRecall.filterHitsForGlobalPersonLane(
+            [home, foreign, unscoped],
+            memoryTypes: [.userPreference],
+            identity: identity
+        )
+        #expect(filtered.map(\.frameID) == [1, 3])
+
+        let unresolved = LayeredRecall.filterHitsForGlobalPersonLane(
+            [home, foreign, unscoped],
+            memoryTypes: [.userPreference],
+            identity: LayeredRecall.Identity()
+        )
+        #expect(unresolved.map(\.frameID) == [1, 2, 3])
+
+        let multiType = LayeredRecall.filterHitsForGlobalPersonLane(
+            [home, foreign, unscoped],
+            memoryTypes: [.userPreference, .lesson],
+            identity: identity
+        )
+        #expect(multiType.map(\.frameID) == [1, 2, 3])
+    }
+
+    @Test
     func layeredRecallFrameFilterInjectsSingleMemoryType() {
         let filter = LayeredRecall.frameFilterForMemoryTypes(
             base: nil,

--- a/Tests/WaxTests/LayeredRecallTests.swift
+++ b/Tests/WaxTests/LayeredRecallTests.swift
@@ -677,6 +677,9 @@ struct LayeredRecallTests {
     func layeredRecallRetrievalTopKOverfetchesForProjectScope() {
         #expect(LayeredRecall.retrievalTopK(requested: 5) == 15)
         #expect(LayeredRecall.retrievalTopK(requested: 100, maxTopK: 200) == 200)
+        #expect(LayeredRecall.retrievalTopKForGlobalPersonLane(requested: 1) == 48)
+        #expect(LayeredRecall.retrievalTopKForGlobalPersonLane(requested: 10) == 80)
+        #expect(LayeredRecall.retrievalTopKForGlobalPersonLane(requested: 50) == 200)
     }
 
     @Test

--- a/Tests/WaxTests/RecallIdentityRankingTests.swift
+++ b/Tests/WaxTests/RecallIdentityRankingTests.swift
@@ -354,4 +354,62 @@ struct RecallIdentityRankingTests {
             #expect(!hasForeignProject)
         }
     }
+
+    @Test
+    func layeredRecallGlobalPersonLaneSurvivesForeignPreferenceCrowding() async throws {
+        let token = "WAXPERSONLANE-CROWD-\(UUID().uuidString.prefix(8))"
+        try await withRecallIdentityMemory { memory in
+            // retrievalTopK(searchTopK: 1) is 12. Foreign prefs can fill that
+            // window; person-lane unions a project-scoped typed fetch for home.
+            for index in 1...20 {
+                try await memory.remember(
+                    "\(token) foreign standing correction \(index): do not pick up rv tickets.",
+                    metadata: [
+                        MemoryMetadataKeys.project: "foreign-project",
+                        MemoryMetadataKeys.repo: "foreign-repo",
+                        MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                        MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                    ]
+                )
+            }
+            try await memory.remember(
+                "\(token) home standing correction: short answers and bullets.",
+                metadata: [
+                    MemoryMetadataKeys.project: "recall-project",
+                    MemoryMetadataKeys.repo: "recall-repo",
+                    MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                    MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                ]
+            )
+            try await memory.remember(
+                "\(token) unscoped standing correction: prefer plain language.",
+                metadata: [
+                    MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                    MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                ]
+            )
+            try await memory.flush()
+
+            let result = try await LayeredRecall.recall(
+                request: LayeredRecall.RecallRequest(
+                    query: "\(token) facts about this person standing corrections",
+                    scope: .global,
+                    limit: 5,
+                    searchTopK: 1,
+                    mode: .textOnly,
+                    explicitProject: "recall-project",
+                    explicitRepo: "recall-repo",
+                    memoryTypes: [.userPreference]
+                ),
+                stores: identityStores(memory: memory)
+            )
+            let hits = result.hits.filter { $0.text.contains(token) }
+            let hasHome = hits.contains { $0.text.contains("home standing correction") }
+            let hasUnscoped = hits.contains { $0.text.contains("unscoped standing correction") }
+            let hasForeign = hits.contains { $0.text.contains("foreign standing correction") }
+            #expect(hasHome)
+            #expect(hasUnscoped)
+            #expect(!hasForeign)
+        }
+    }
 }

--- a/Tests/WaxTests/RecallIdentityRankingTests.swift
+++ b/Tests/WaxTests/RecallIdentityRankingTests.swift
@@ -298,4 +298,60 @@ struct RecallIdentityRankingTests {
             #expect(hit.text.contains("short answers"))
         }
     }
+
+    @Test
+    func layeredRecallGlobalPersonLaneDropsOtherProjectPreferences() async throws {
+        let token = "WAXPERSONLANE-OTHER-\(UUID().uuidString.prefix(8))"
+        try await withRecallIdentityMemory { memory in
+            try await memory.remember(
+                "\(token) home standing correction: short answers and bullets.",
+                metadata: [
+                    MemoryMetadataKeys.project: "recall-project",
+                    MemoryMetadataKeys.repo: "recall-repo",
+                    MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                    MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                ]
+            )
+            try await memory.remember(
+                "\(token) foreign standing correction: do not pick up rv tickets.",
+                metadata: [
+                    MemoryMetadataKeys.project: "foreign-project",
+                    MemoryMetadataKeys.repo: "foreign-repo",
+                    MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                    MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                ]
+            )
+            try await memory.remember(
+                "\(token) unscoped standing correction: prefer plain language.",
+                metadata: [
+                    MemoryMetadataKeys.type: MemoryType.userPreference.rawValue,
+                    MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                ]
+            )
+            try await memory.flush()
+
+            let result = try await LayeredRecall.recall(
+                request: LayeredRecall.RecallRequest(
+                    query: token,
+                    scope: .global,
+                    limit: 5,
+                    searchTopK: 5,
+                    mode: .textOnly,
+                    explicitProject: "recall-project",
+                    explicitRepo: "recall-repo",
+                    memoryTypes: [.userPreference]
+                ),
+                stores: identityStores(memory: memory)
+            )
+            let hits = result.hits.filter { $0.text.contains(token) }
+            let hasHome = hits.contains { $0.text.contains("home standing correction") }
+            let hasUnscoped = hits.contains { $0.text.contains("unscoped standing correction") }
+            let hasForeignText = hits.contains { $0.text.contains("foreign standing correction") }
+            let hasForeignProject = hits.contains { $0.metadata[MemoryMetadataKeys.project] == "foreign-project" }
+            #expect(hasHome)
+            #expect(hasUnscoped)
+            #expect(!hasForeignText)
+            #expect(!hasForeignProject)
+        }
+    }
 }

--- a/Tests/WaxTests/SessionCloseReclaimSweepTests.swift
+++ b/Tests/WaxTests/SessionCloseReclaimSweepTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Suite("SessionCloseReclaimSweepTests")
+struct SessionCloseReclaimSweepTests {
+    @Test
+    func sessionCloseUnlinksReclaimableEndedStoreAndKeepsRecentlyClosed() async throws {
+        try await withStartupGCRoots { storeURL, sessionRootURL in
+            try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { service in
+                let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+                let reclaimableID = UUID()
+                let recentID = UUID()
+                let liveID = UUID()
+                let reclaimablePath = try plantSessionManifest(
+                    sessionID: reclaimableID,
+                    sessionRootURL: sessionRootURL,
+                    status: .ended,
+                    harvestedAtMs: 1,
+                    reclaimAfterMs: 1
+                )
+                let recentPath = try plantSessionManifest(
+                    sessionID: recentID,
+                    sessionRootURL: sessionRootURL,
+                    status: .ended,
+                    harvestedAtMs: nowMs,
+                    reclaimAfterMs: nowMs + MemoryRetentionSettings.default.recentlyClosedMs
+                )
+
+                let started = await service.handle(.init(command: "session_start", arguments: [
+                    "session_id": .string(liveID.uuidString),
+                    "project": .string("startup-gc"),
+                ]))
+                #expect(started.ok)
+
+                let closed = await service.handle(.init(command: "session_close", arguments: [
+                    "session_id": .string(liveID.uuidString),
+                    "content": .string("close sweep"),
+                    "project": .string("startup-gc"),
+                ]))
+                #expect(closed.ok, "session_close failed: \(closed.error ?? "nil")")
+
+                #expect(FileManager.default.fileExists(atPath: reclaimablePath) == false)
+                let reclaimed = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: reclaimableID
+                )
+                #expect(reclaimed.status == .ended)
+                #expect(reclaimed.reclaimedAtMs != nil)
+
+                #expect(FileManager.default.fileExists(atPath: recentPath))
+                let recent = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: recentID
+                )
+                #expect(recent.status == .ended)
+                #expect(recent.reclaimedAtMs == nil)
+            }
+        }
+    }
+
+    @Test
+    func sessionCloseDoesNotQuarantineLongTermWorkingMemory() async throws {
+        try await withStartupGCRoots { storeURL, sessionRootURL in
+            try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { service in
+                let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+                let canary = "CLOSE-SWEEP-CANARY-\(UUID().uuidString.prefix(8))"
+                let createdAtMs = nowMs - MemoryRetentionSettings.default.workingQuarantineMs - 1_000
+                let remembered = await service.handle(.init(command: "remember", arguments: [
+                    "content": .string(canary),
+                    "memory_type": .string(MemoryType.note.rawValue),
+                    "durability": .string(MemoryDurability.working.rawValue),
+                    "metadata": .object([
+                        MemoryMetadataKeys.createdAtMs: .string(String(createdAtMs)),
+                    ]),
+                ]))
+                #expect(remembered.ok, "remember failed: \(remembered.error ?? "nil")")
+                let rememberPayload = try #require(remembered.payload?.objectValue)
+                let memoryID = try #require(rememberPayload["memory_id"]?.stringValue)
+
+                let liveID = UUID()
+                let started = await service.handle(.init(command: "session_start", arguments: [
+                    "session_id": .string(liveID.uuidString),
+                    "project": .string("startup-gc"),
+                ]))
+                #expect(started.ok)
+
+                let closed = await service.handle(.init(command: "session_close", arguments: [
+                    "session_id": .string(liveID.uuidString),
+                    "content": .string("close must not GC library"),
+                    "project": .string("startup-gc"),
+                ]))
+                #expect(closed.ok, "session_close failed: \(closed.error ?? "nil")")
+
+                let fetched = await service.handle(.init(command: "memory_get", arguments: [
+                    "memory_id": .string(memoryID),
+                ]))
+                #expect(fetched.ok, "memory_get failed: \(fetched.error ?? "nil")")
+                let text = fetched.payload?.objectValue?["text"]?.stringValue ?? ""
+                #expect(text.contains(canary))
+            }
+        }
+    }
+}

--- a/Tests/WaxTests/SessionStartupMaintainTests.swift
+++ b/Tests/WaxTests/SessionStartupMaintainTests.swift
@@ -2,124 +2,256 @@ import Foundation
 import Testing
 @testable import Wax
 
-@Test
-func brokerInitPreservesExpiredLeaseUntilExplicitMaintenance() async throws {
-    try await withStartupGCRoots { storeURL, sessionRootURL in
+@Suite("SessionStartupMaintainTests")
+struct SessionStartupMaintainTests {
+    @Test
+    func sessionReclaimTreatsFreshExpiredLeaseAsZombieNotAbandoned() {
+        let nowMs: Int64 = 1_700_000_000_000
+        let recentlyClosedMs = MemoryRetentionSettings.default.recentlyClosedMs
         let sessionID = UUID()
-        try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { service in
-            let started = await service.handle(.init(command: "session_start", arguments: [
-                "session_id": .string(sessionID.uuidString),
-                "project": .string("startup-gc"),
-            ]))
-            #expect(started.ok)
-        }
 
-        var before = try BrokerSessionPersistence.loadManifest(
-            rootURL: sessionRootURL,
-            sessionID: sessionID
+        let fresh = reclaimProbeManifest(
+            sessionID: sessionID,
+            status: .active,
+            leaseExpiresAtMs: nowMs - 1
         )
-        before.leaseExpiresAtMs = 1
-        try BrokerSessionPersistence.saveManifest(
-            before,
-            to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
-        )
-        #expect(before.status == .active)
-        #expect(SessionReclaim.isZombie(
-            manifest: before,
+        #expect(SessionReclaim.isZombie(manifest: fresh, liveIDs: [], nowMs: nowMs))
+        #expect(SessionReclaim.isAbandonedZombie(manifest: fresh, liveIDs: [], nowMs: nowMs) == false)
+        #expect(SessionReclaim.isAbandonedZombie(
+            manifest: fresh,
             liveIDs: [],
-            nowMs: Int64(Date().timeIntervalSince1970 * 1000)
+            nowMs: nowMs,
+            recentlyClosedMs: recentlyClosedMs
+        ) == false)
+
+        let atThreshold = reclaimProbeManifest(
+            sessionID: sessionID,
+            status: .active,
+            leaseExpiresAtMs: nowMs - recentlyClosedMs
+        )
+        #expect(SessionReclaim.isZombie(manifest: atThreshold, liveIDs: [], nowMs: nowMs))
+        #expect(SessionReclaim.isAbandonedZombie(
+            manifest: atThreshold,
+            liveIDs: [],
+            nowMs: nowMs,
+            recentlyClosedMs: recentlyClosedMs
         ))
 
-        try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { service in
-            let preserved = try BrokerSessionPersistence.loadManifest(
+        let abandoned = reclaimProbeManifest(
+            sessionID: sessionID,
+            status: .active,
+            leaseExpiresAtMs: nowMs - recentlyClosedMs - 86_400_000
+        )
+        #expect(SessionReclaim.isZombie(manifest: abandoned, liveIDs: [], nowMs: nowMs))
+        #expect(SessionReclaim.isAbandonedZombie(manifest: abandoned, liveIDs: [], nowMs: nowMs))
+
+        #expect(SessionReclaim.isAbandonedZombie(
+            manifest: abandoned,
+            liveIDs: [sessionID],
+            nowMs: nowMs
+        ) == false)
+
+        let ended = reclaimProbeManifest(
+            sessionID: sessionID,
+            status: .ended,
+            leaseExpiresAtMs: nowMs - recentlyClosedMs - 86_400_000
+        )
+        #expect(SessionReclaim.isZombie(manifest: ended, liveIDs: [], nowMs: nowMs) == false)
+        #expect(SessionReclaim.isAbandonedZombie(manifest: ended, liveIDs: [], nowMs: nowMs) == false)
+    }
+
+    @Test
+    func brokerInitPreservesExpiredLeaseUntilExplicitMaintenance() async throws {
+        try await withStartupGCRoots { storeURL, sessionRootURL in
+            let sessionID = UUID()
+            try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { service in
+                let started = await service.handle(.init(command: "session_start", arguments: [
+                    "session_id": .string(sessionID.uuidString),
+                    "project": .string("startup-gc"),
+                ]))
+                #expect(started.ok)
+            }
+
+            var before = try BrokerSessionPersistence.loadManifest(
                 rootURL: sessionRootURL,
                 sessionID: sessionID
             )
-            #expect(preserved.status == .active)
-            #expect(preserved.harvestedAtMs == nil)
-            let applied = await service.handle(.init(
-                command: "memory_maintain",
-                arguments: ["apply": .bool(true)]
-            ))
-            #expect(applied.ok)
-            #expect(applied.payload?.objectValue?["zombies_to_end"]?.intValue == 1)
-            let after = try BrokerSessionPersistence.loadManifest(
-                rootURL: sessionRootURL,
-                sessionID: sessionID
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            before.leaseExpiresAtMs = nowMs - 1_000
+            try BrokerSessionPersistence.saveManifest(
+                before,
+                to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
             )
-            #expect(after.status == .ended)
-            #expect(after.harvestedAtMs != nil)
-            #expect(after.harvestError == nil)
+            #expect(before.status == .active)
             #expect(SessionReclaim.isZombie(
-                manifest: after,
+                manifest: before,
                 liveIDs: [],
-                nowMs: Int64(Date().timeIntervalSince1970 * 1000)
+                nowMs: nowMs
+            ))
+            #expect(SessionReclaim.isAbandonedZombie(
+                manifest: before,
+                liveIDs: [],
+                nowMs: nowMs
             ) == false)
+
+            try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { service in
+                let preserved = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: sessionID
+                )
+                #expect(preserved.status == .active)
+                #expect(preserved.harvestedAtMs == nil)
+                let applied = await service.handle(.init(
+                    command: "memory_maintain",
+                    arguments: ["apply": .bool(true)]
+                ))
+                #expect(applied.ok)
+                #expect(applied.payload?.objectValue?["zombies_to_end"]?.intValue == 1)
+                let after = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: sessionID
+                )
+                #expect(after.status == .ended)
+                #expect(after.harvestedAtMs != nil)
+                #expect(after.harvestError == nil)
+                #expect(SessionReclaim.isZombie(
+                    manifest: after,
+                    liveIDs: [],
+                    nowMs: Int64(Date().timeIntervalSince1970 * 1000)
+                ) == false)
+            }
+        }
+    }
+
+    @Test
+    func brokerInitUnlinksReclaimableEndedSessionAndKeepsRecentlyClosedWithoutForce() async throws {
+        try await withStartupGCRoots { storeURL, sessionRootURL in
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            let reclaimableID = UUID()
+            let recentID = UUID()
+            let blockedID = UUID()
+            let reclaimablePath = try plantSessionManifest(
+                sessionID: reclaimableID,
+                sessionRootURL: sessionRootURL,
+                status: .ended,
+                harvestedAtMs: 1,
+                reclaimAfterMs: 1
+            )
+            let recentPath = try plantSessionManifest(
+                sessionID: recentID,
+                sessionRootURL: sessionRootURL,
+                status: .ended,
+                harvestedAtMs: nowMs,
+                reclaimAfterMs: nowMs + 604_800_000
+            )
+            let blockedPath = try plantSessionManifest(
+                sessionID: blockedID,
+                sessionRootURL: sessionRootURL,
+                status: .ended,
+                harvestedAtMs: 1,
+                reclaimAfterMs: 1,
+                harvestError: "harvest failed",
+                storeContents: Data("not-a-wax-store".utf8)
+            )
+
+            try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { _ in
+                #expect(FileManager.default.fileExists(atPath: reclaimablePath) == false)
+                let reclaimed = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: reclaimableID
+                )
+                #expect(reclaimed.status == .ended)
+                #expect(reclaimed.reclaimedAtMs != nil)
+
+                #expect(FileManager.default.fileExists(atPath: recentPath))
+                let recent = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: recentID
+                )
+                #expect(recent.status == .ended)
+                #expect(recent.reclaimedAtMs == nil)
+
+                #expect(FileManager.default.fileExists(atPath: blockedPath))
+                let blocked = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: blockedID
+                )
+                #expect(blocked.status == .ended)
+                #expect(blocked.reclaimedAtMs == nil)
+                #expect(blocked.harvestError != nil)
+            }
+        }
+    }
+
+    @Test
+    func brokerInitHarvestsAbandonedZombieWhilePreservingFreshExpiredLease() async throws {
+        try await withStartupGCRoots { storeURL, sessionRootURL in
+            let freshID = UUID()
+            let abandonedID = UUID()
+            try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { service in
+                for sessionID in [freshID, abandonedID] {
+                    let started = await service.handle(.init(command: "session_start", arguments: [
+                        "session_id": .string(sessionID.uuidString),
+                        "project": .string("startup-gc"),
+                    ]))
+                    #expect(started.ok)
+                }
+            }
+
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            let recentlyClosedMs = MemoryRetentionSettings.default.recentlyClosedMs
+
+            var fresh = try BrokerSessionPersistence.loadManifest(
+                rootURL: sessionRootURL,
+                sessionID: freshID
+            )
+            fresh.leaseExpiresAtMs = nowMs - 1_000
+            try BrokerSessionPersistence.saveManifest(
+                fresh,
+                to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: freshID)
+            )
+            #expect(fresh.status == .active)
+            #expect(SessionReclaim.isZombie(manifest: fresh, liveIDs: [], nowMs: nowMs))
+            #expect(SessionReclaim.isAbandonedZombie(manifest: fresh, liveIDs: [], nowMs: nowMs) == false)
+
+            var abandoned = try BrokerSessionPersistence.loadManifest(
+                rootURL: sessionRootURL,
+                sessionID: abandonedID
+            )
+            abandoned.leaseExpiresAtMs = nowMs - recentlyClosedMs - 86_400_000
+            try BrokerSessionPersistence.saveManifest(
+                abandoned,
+                to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: abandonedID)
+            )
+            #expect(abandoned.status == .active)
+            #expect(SessionReclaim.isAbandonedZombie(manifest: abandoned, liveIDs: [], nowMs: nowMs))
+
+            try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { _ in
+                let preserved = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: freshID
+                )
+                #expect(preserved.status == .active)
+                #expect(preserved.harvestedAtMs == nil)
+
+                let harvested = try BrokerSessionPersistence.loadManifest(
+                    rootURL: sessionRootURL,
+                    sessionID: abandonedID
+                )
+                #expect(harvested.status == .ended)
+                #expect(harvested.harvestedAtMs != nil)
+                #expect(harvested.harvestError == nil)
+                #expect(SessionReclaim.isZombie(
+                    manifest: harvested,
+                    liveIDs: [],
+                    nowMs: Int64(Date().timeIntervalSince1970 * 1000)
+                ) == false)
+            }
         }
     }
 }
 
-@Test
-func brokerInitUnlinksReclaimableEndedSessionAndKeepsRecentlyClosedWithoutForce() async throws {
-    try await withStartupGCRoots { storeURL, sessionRootURL in
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
-        let reclaimableID = UUID()
-        let recentID = UUID()
-        let blockedID = UUID()
-        let reclaimablePath = try plantSessionManifest(
-            sessionID: reclaimableID,
-            sessionRootURL: sessionRootURL,
-            status: .ended,
-            harvestedAtMs: 1,
-            reclaimAfterMs: 1
-        )
-        let recentPath = try plantSessionManifest(
-            sessionID: recentID,
-            sessionRootURL: sessionRootURL,
-            status: .ended,
-            harvestedAtMs: nowMs,
-            reclaimAfterMs: nowMs + 604_800_000
-        )
-        let blockedPath = try plantSessionManifest(
-            sessionID: blockedID,
-            sessionRootURL: sessionRootURL,
-            status: .ended,
-            harvestedAtMs: 1,
-            reclaimAfterMs: 1,
-            harvestError: "harvest failed",
-            storeContents: Data("not-a-wax-store".utf8)
-        )
-
-        try await withStartupBroker(storePath: storeURL.path, sessionRootPath: sessionRootURL.path) { _ in
-            #expect(FileManager.default.fileExists(atPath: reclaimablePath) == false)
-            let reclaimed = try BrokerSessionPersistence.loadManifest(
-                rootURL: sessionRootURL,
-                sessionID: reclaimableID
-            )
-            #expect(reclaimed.status == .ended)
-            #expect(reclaimed.reclaimedAtMs != nil)
-
-            #expect(FileManager.default.fileExists(atPath: recentPath))
-            let recent = try BrokerSessionPersistence.loadManifest(
-                rootURL: sessionRootURL,
-                sessionID: recentID
-            )
-            #expect(recent.status == .ended)
-            #expect(recent.reclaimedAtMs == nil)
-
-            #expect(FileManager.default.fileExists(atPath: blockedPath))
-            let blocked = try BrokerSessionPersistence.loadManifest(
-                rootURL: sessionRootURL,
-                sessionID: blockedID
-            )
-            #expect(blocked.status == .ended)
-            #expect(blocked.reclaimedAtMs == nil)
-            #expect(blocked.harvestError != nil)
-        }
-    }
-}
-
-private func withStartupGCRoots(
+func withStartupGCRoots(
     _ body: (URL, URL) async throws -> Void
 ) async throws {
     let rootURL = FileManager.default.temporaryDirectory
@@ -131,7 +263,7 @@ private func withStartupGCRoots(
     try await body(storeURL, sessionRootURL)
 }
 
-private func withStartupBroker(
+func withStartupBroker(
     storePath: String,
     sessionRootPath: String,
     _ body: (AgentBrokerService) async throws -> Void
@@ -153,7 +285,7 @@ private func withStartupBroker(
 }
 
 @discardableResult
-private func plantSessionManifest(
+func plantSessionManifest(
     sessionID: UUID,
     sessionRootURL: URL,
     status: BrokerSessionManifest.Status,
@@ -192,4 +324,25 @@ private func plantSessionManifest(
         to: BrokerSessionPersistence.manifestURL(rootURL: sessionRootURL, sessionID: sessionID)
     )
     return storePath
+}
+
+private func reclaimProbeManifest(
+    sessionID: UUID,
+    status: BrokerSessionManifest.Status,
+    leaseExpiresAtMs: Int64?
+) -> BrokerSessionManifest {
+    BrokerSessionManifest(
+        sessionID: sessionID,
+        agentID: "startup-gc-agent",
+        runID: "startup-gc-run",
+        project: "startup-gc",
+        repo: "startup-gc",
+        storePath: "/tmp/startup-gc-missing.wax",
+        eventLogPath: "/tmp/startup-gc-missing.jsonl",
+        status: status,
+        brokerLeaseOwnerID: nil,
+        leaseExpiresAtMs: leaseExpiresAtMs,
+        createdAtMs: 1,
+        updatedAtMs: 1
+    )
 }


### PR DESCRIPTION
## Why

Agent-experience rating of waxmcp 0.1.41 landed at 76/100. Three holes kept it off 85:

1. **Handoff vanished on the next open.** `session_open` loaded the latest project handoff, then hid it when `recall_query` lexical similarity was < 0.15. The playbook always passes a job query, so every new job got `found=false`.
2. **Person-lane recall mixed other-project prefs.** `scope=global` + `memory_types=["user_preference"]` still returned rv/path-stamped preferences next to standing corrections.
3. **Session disk grew without a daily-loop sweep.** Long-running HTTP brokers never reclaimed after init. Abandoned zombies (expired lease ≥ 7d, never rebound) stayed `active`. Adding a prune tool to the daily 8 is the wrong fix.

## What

- `session_open` keeps a non-empty project handoff (`found=true` + compact content) even when the query is a poor match. Mismatch sets `relevance: low`. Empty body is still `found=false`. Foreign-project handoffs stay out. Daily 8 unchanged.
- Global person-lane (`memory_types` exactly `[user_preference]`, resolved project/repo) drops other-project prefs and keeps unscoped + current-project hits. Other scopes and multi-type filters are unchanged.
- Init and `session_close` harvest **abandoned** zombies and unlink ended stores past `reclaimAfterMs`. Fresh expired leases stay rebindable. 7-day recently-closed hold is unchanged.
- Close sweep is **session-store only**. It does not run `memory_maintain` library quarantine (that would delete old working/ephemeral frames, including handoffs).

## Review follow-up (0610145)

- Idle recovery fixture uses `now - 1s`, not epoch `leaseExpiresAtMs = 1` (that is abandoned under the 7-day window).
- Person-lane over-fetches and unions a project-scoped typed retrieval so current-project prefs are not crowded out of `retrievalTopK`.

## Tests

```
swift test --filter RecallIdentityRankingTests|LayeredRecallTests|SessionStartupMaintainTests|SessionCloseReclaimSweepTests|BrokerIdleSessionRecoveryTests|SessionHarvestTests
# 74 passed

swift test --traits MCPServer --filter sessionOpenKeepsProjectHandoffWhenRecallQueryMismatches
# passed

bash Resources/scripts/quality/public_repo_hygiene.sh
# ok
```