### PR TITLE
SearchLane: prove vector-only search has an embedding

### DIFF
--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -1279,6 +1279,7 @@ package actor MemoryOrchestrator {
             requested: mode,
             embeddingAvailable: queryEmbedding.embedding != nil
         )
+        let lane = try SearchLane.from(mode: searchMode, embedding: queryEmbedding.embedding)
 
         // Access-aware ranking needs additional candidates so a stale top hit
         // can be displaced by a close, recently/frequently used result. The
@@ -1293,12 +1294,11 @@ package actor MemoryOrchestrator {
         // One ranking-now for this search: UnifiedSearch recency and later
         // access ranking must not tick the wall clock twice.
         let searchNowMs = config.rag.deterministicNowMs ?? nowProvider()
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: trimmed,
-            embedding: queryEmbedding.embedding,
+            lane: lane,
             vectorEnginePreference: preference,
             vectorSearchTimeout: config.vectorSearchTimeout,
-            mode: searchMode,
             topK: searchTopK,
             timeRange: timeRange,
             frameFilter: frameFilter,

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -254,7 +254,7 @@ package actor PhotoRAGOrchestrator {
 
         let queryEmbedding = try await buildQueryEmbedding(text: queryText, image: query.image)
 
-        let mode: SearchMode = {
+        let resolvedMode: SearchMode = {
             switch (queryText, queryEmbedding) {
             case (.none, .some):
                 return .vectorOnly
@@ -264,6 +264,7 @@ package actor PhotoRAGOrchestrator {
                 return .textOnly
             }
         }()
+        let lane = try SearchLane.from(mode: resolvedMode, embedding: queryEmbedding)
 
         let timeRange = Self.toWaxTimeRange(query.timeRange)
 
@@ -293,11 +294,10 @@ package actor PhotoRAGOrchestrator {
             rootMetaById = direct.rootMetaById
             picked = Array(direct.candidates.prefix(query.resultLimit))
         } else {
-            let request = SearchRequest(
+            let request = try SearchRequest(
                 query: queryText,
-                embedding: queryEmbedding,
+                lane: lane,
                 vectorEnginePreference: config.vectorEnginePreference,
-                mode: mode,
                 topK: max(query.resultLimit, config.searchTopK),
                 timeRange: timeRange,
                 frameFilter: frameFilter,

--- a/Sources/Wax/RAG/FastRAGContextBuilder.swift
+++ b/Sources/Wax/RAG/FastRAGContextBuilder.swift
@@ -49,12 +49,11 @@ package struct FastRAGContextBuilder: Sendable {
             multiplier: 2,
             applyWhenRequestedTopKAtMost: 24
         )
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: query,
-            embedding: embedding,
+            lane: try SearchLane.from(mode: clamped.searchMode, embedding: embedding),
             vectorEnginePreference: vectorEnginePreference,
             vectorSearchTimeout: vectorSearchTimeout,
-            mode: clamped.searchMode,
             topK: searchTopK,
             timeRange: timeRange,
             frameFilter: frameFilter,

--- a/Sources/Wax/UnifiedSearch/SearchPlan.swift
+++ b/Sources/Wax/UnifiedSearch/SearchPlan.swift
@@ -23,16 +23,16 @@ package extension SearchPlan {
 
         let includeText: Bool
         let includeVector: Bool
-        switch request.mode {
+        switch request.lane {
         case .textOnly:
             includeText = true
             includeVector = false
         case .vectorOnly:
             includeText = false
-            includeVector = true
+            includeVector = request.lane.hasNonEmptyEmbedding
         case .hybrid:
             includeText = true
-            includeVector = true
+            includeVector = request.lane.hasNonEmptyEmbedding
         }
 
         let requestedTopK = max(0, request.topK)

--- a/Sources/Wax/UnifiedSearch/SearchPlan.swift
+++ b/Sources/Wax/UnifiedSearch/SearchPlan.swift
@@ -29,7 +29,7 @@ package extension SearchPlan {
             includeVector = false
         case .vectorOnly:
             includeText = false
-            includeVector = request.lane.hasNonEmptyEmbedding
+            includeVector = true
         case .hybrid:
             includeText = true
             includeVector = request.lane.hasNonEmptyEmbedding

--- a/Sources/Wax/UnifiedSearch/SearchRequest.swift
+++ b/Sources/Wax/UnifiedSearch/SearchRequest.swift
@@ -5,8 +5,9 @@ import WaxVectorSearch
 /// Retrieval lane paired with the query embedding that lane needs.
 ///
 /// `vectorOnly` without a non-empty embedding is rejected by ``from(mode:embedding:)``
-/// and by the throwing `SearchRequest` factory. Hybrid with a nil embedding stays
-/// legal (text degradation).
+/// and by the throwing `SearchRequest` factory. The source-compatible `mode` +
+/// `embedding` initializer maps that case to `textOnly` instead of storing an
+/// empty vector-only lane. Hybrid with a nil embedding stays legal (text degradation).
 package enum SearchLane: Sendable, Equatable {
     case textOnly
     case vectorOnly(embedding: [Float])
@@ -73,19 +74,23 @@ package enum SearchLane: Sendable, Equatable {
         }
     }
 
-    /// Source-compatible mapping used by the `mode` + `embedding` initializer.
-    fileprivate init(mode: SearchMode, embedding: [Float]?) {
+    /// Source-compatible mapping used by the non-throwing `mode` + `embedding`
+    /// initializer. `vectorOnly` without a non-empty embedding becomes `textOnly`
+    /// so that illegal empty vector-only state is never stored.
+    fileprivate static func compatible(mode: SearchMode, embedding: [Float]?) -> SearchLane {
         switch mode {
         case .textOnly:
-            self = .textOnly
+            return .textOnly
         case .vectorOnly:
-            self = .vectorOnly(embedding: embedding ?? [])
+            if let embedding, !embedding.isEmpty {
+                return .vectorOnly(embedding: embedding)
+            }
+            return .textOnly
         case .hybrid(let alpha):
             if let embedding, !embedding.isEmpty {
-                self = .hybrid(alpha: alpha, embedding: embedding)
-            } else {
-                self = .hybrid(alpha: alpha, embedding: nil)
+                return .hybrid(alpha: alpha, embedding: embedding)
             }
+            return .hybrid(alpha: alpha, embedding: nil)
         }
     }
 }
@@ -93,7 +98,7 @@ package enum SearchLane: Sendable, Equatable {
 /// Unified search request.
 package struct SearchRequest: Sendable, Equatable {
     package var query: String?
-    package var lane: SearchLane
+    package let lane: SearchLane
     package var vectorEnginePreference: VectorEnginePreference
     package var vectorSearchTimeout: Duration?
     package var topK: Int
@@ -193,7 +198,7 @@ package struct SearchRequest: Sendable, Equatable {
     ) {
         self.init(
             query: query,
-            uncheckedLane: SearchLane(mode: mode, embedding: embedding),
+            uncheckedLane: SearchLane.compatible(mode: mode, embedding: embedding),
             vectorEnginePreference: vectorEnginePreference,
             vectorSearchTimeout: vectorSearchTimeout,
             topK: topK,

--- a/Sources/Wax/UnifiedSearch/SearchRequest.swift
+++ b/Sources/Wax/UnifiedSearch/SearchRequest.swift
@@ -2,13 +2,100 @@ import Foundation
 import WaxCore
 import WaxVectorSearch
 
+/// Retrieval lane paired with the query embedding that lane needs.
+///
+/// `vectorOnly` without a non-empty embedding is rejected by ``from(mode:embedding:)``
+/// and by the throwing `SearchRequest` factory. Hybrid with a nil embedding stays
+/// legal (text degradation).
+package enum SearchLane: Sendable, Equatable {
+    case textOnly
+    case vectorOnly(embedding: [Float])
+    case hybrid(alpha: Float, embedding: [Float]?)
+
+    package static let missingVectorOnlyEmbeddingMessage =
+        "vectorOnly search requires a non-empty query embedding"
+
+    package var mode: SearchMode {
+        switch self {
+        case .textOnly: .textOnly
+        case .vectorOnly: .vectorOnly
+        case .hybrid(let alpha, _): .hybrid(alpha: alpha)
+        }
+    }
+
+    package var embedding: [Float]? {
+        switch self {
+        case .textOnly:
+            nil
+        case .vectorOnly(let embedding):
+            embedding
+        case .hybrid(_, let embedding):
+            embedding
+        }
+    }
+
+    package var hasNonEmptyEmbedding: Bool {
+        switch self {
+        case .textOnly:
+            false
+        case .vectorOnly(let embedding):
+            !embedding.isEmpty
+        case .hybrid(_, let embedding):
+            embedding.map { !$0.isEmpty } ?? false
+        }
+    }
+
+    /// Maps public ``SearchMode`` × embedding availability onto a lane.
+    /// Throws ``WaxError/io(_:)`` when `vectorOnly` has a missing or empty embedding.
+    package static func from(mode: SearchMode, embedding: [Float]?) throws -> SearchLane {
+        switch mode {
+        case .textOnly:
+            return .textOnly
+        case .vectorOnly:
+            guard let embedding, !embedding.isEmpty else {
+                throw WaxError.io(missingVectorOnlyEmbeddingMessage)
+            }
+            return .vectorOnly(embedding: embedding)
+        case .hybrid(let alpha):
+            let value: [Float]?
+            if let embedding, !embedding.isEmpty {
+                value = embedding
+            } else {
+                value = nil
+            }
+            return .hybrid(alpha: alpha, embedding: value)
+        }
+    }
+
+    fileprivate func validateVectorOnlyEmbedding() throws {
+        if case .vectorOnly(let embedding) = self, embedding.isEmpty {
+            throw WaxError.io(Self.missingVectorOnlyEmbeddingMessage)
+        }
+    }
+
+    /// Source-compatible mapping used by the `mode` + `embedding` initializer.
+    fileprivate init(mode: SearchMode, embedding: [Float]?) {
+        switch mode {
+        case .textOnly:
+            self = .textOnly
+        case .vectorOnly:
+            self = .vectorOnly(embedding: embedding ?? [])
+        case .hybrid(let alpha):
+            if let embedding, !embedding.isEmpty {
+                self = .hybrid(alpha: alpha, embedding: embedding)
+            } else {
+                self = .hybrid(alpha: alpha, embedding: nil)
+            }
+        }
+    }
+}
+
 /// Unified search request.
 package struct SearchRequest: Sendable, Equatable {
     package var query: String?
-    package var embedding: [Float]?
+    package var lane: SearchLane
     package var vectorEnginePreference: VectorEnginePreference
     package var vectorSearchTimeout: Duration?
-    package var mode: SearchMode
     package var topK: Int
     package var minScore: Float?
     package var timeRange: SearchTimeRange?
@@ -30,6 +117,58 @@ package struct SearchRequest: Sendable, Equatable {
     package var enableRankingDiagnostics: Bool
     package var rankingDiagnosticsTopK: Int
 
+    /// Diagnostics / fusion view of the stored lane. Not an independent stored field.
+    package var mode: SearchMode { lane.mode }
+
+    /// Query embedding carried by the stored lane, if any.
+    package var embedding: [Float]? { lane.embedding }
+
+    package init(
+        query: String? = nil,
+        lane: SearchLane,
+        vectorEnginePreference: VectorEnginePreference = .auto,
+        vectorSearchTimeout: Duration? = .seconds(10),
+        topK: Int = 10,
+        minScore: Float? = nil,
+        timeRange: SearchTimeRange? = nil,
+        frameFilter: FrameFilter? = nil,
+        asOfMs: Int64 = Int64.max,
+        nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
+        structuredMemory: StructuredMemorySearchOptions = .init(),
+        scopeContext: MemoryScopeContext? = nil,
+        rrfK: Int = 60,
+        previewMaxBytes: Int = 512,
+        metadataLoadingThreshold: Int = 50,
+        allowTimelineFallback: Bool = false,
+        timelineFallbackLimit: Int = 10,
+        enableRankingDiagnostics: Bool = false,
+        rankingDiagnosticsTopK: Int = 10
+    ) throws {
+        try lane.validateVectorOnlyEmbedding()
+        self.init(
+            query: query,
+            uncheckedLane: lane,
+            vectorEnginePreference: vectorEnginePreference,
+            vectorSearchTimeout: vectorSearchTimeout,
+            topK: topK,
+            minScore: minScore,
+            timeRange: timeRange,
+            frameFilter: frameFilter,
+            asOfMs: asOfMs,
+            nowMs: nowMs,
+            structuredMemory: structuredMemory,
+            scopeContext: scopeContext,
+            rrfK: rrfK,
+            previewMaxBytes: previewMaxBytes,
+            metadataLoadingThreshold: metadataLoadingThreshold,
+            allowTimelineFallback: allowTimelineFallback,
+            timelineFallbackLimit: timelineFallbackLimit,
+            enableRankingDiagnostics: enableRankingDiagnostics,
+            rankingDiagnosticsTopK: rankingDiagnosticsTopK
+        )
+    }
+
+    /// Source-compatible constructor. Prefer the throwing `lane:` factory.
     package init(
         query: String? = nil,
         embedding: [Float]? = nil,
@@ -52,11 +191,54 @@ package struct SearchRequest: Sendable, Equatable {
         enableRankingDiagnostics: Bool = false,
         rankingDiagnosticsTopK: Int = 10
     ) {
+        self.init(
+            query: query,
+            uncheckedLane: SearchLane(mode: mode, embedding: embedding),
+            vectorEnginePreference: vectorEnginePreference,
+            vectorSearchTimeout: vectorSearchTimeout,
+            topK: topK,
+            minScore: minScore,
+            timeRange: timeRange,
+            frameFilter: frameFilter,
+            asOfMs: asOfMs,
+            nowMs: nowMs,
+            structuredMemory: structuredMemory,
+            scopeContext: scopeContext,
+            rrfK: rrfK,
+            previewMaxBytes: previewMaxBytes,
+            metadataLoadingThreshold: metadataLoadingThreshold,
+            allowTimelineFallback: allowTimelineFallback,
+            timelineFallbackLimit: timelineFallbackLimit,
+            enableRankingDiagnostics: enableRankingDiagnostics,
+            rankingDiagnosticsTopK: rankingDiagnosticsTopK
+        )
+    }
+
+    private init(
+        query: String?,
+        uncheckedLane: SearchLane,
+        vectorEnginePreference: VectorEnginePreference,
+        vectorSearchTimeout: Duration?,
+        topK: Int,
+        minScore: Float?,
+        timeRange: SearchTimeRange?,
+        frameFilter: FrameFilter?,
+        asOfMs: Int64,
+        nowMs: Int64,
+        structuredMemory: StructuredMemorySearchOptions,
+        scopeContext: MemoryScopeContext?,
+        rrfK: Int,
+        previewMaxBytes: Int,
+        metadataLoadingThreshold: Int,
+        allowTimelineFallback: Bool,
+        timelineFallbackLimit: Int,
+        enableRankingDiagnostics: Bool,
+        rankingDiagnosticsTopK: Int
+    ) {
         self.query = query
-        self.embedding = embedding
+        self.lane = uncheckedLane
         self.vectorEnginePreference = vectorEnginePreference
         self.vectorSearchTimeout = vectorSearchTimeout
-        self.mode = mode
         self.topK = topK
         self.minScore = minScore
         self.timeRange = timeRange

--- a/Sources/Wax/UnifiedSearch/SearchRequest.swift
+++ b/Sources/Wax/UnifiedSearch/SearchRequest.swift
@@ -7,15 +7,21 @@ import WaxVectorSearch
 /// `vectorOnly` without a non-empty embedding is rejected by ``from(mode:embedding:)``
 /// and by the throwing `SearchRequest` factory. The source-compatible `mode` +
 /// `embedding` initializer maps that case to `textOnly` instead of storing an
-/// empty vector-only lane. Hybrid with a nil embedding stays legal (text degradation).
+/// empty vector-only lane. Hybrid with a missing or empty embedding is stored
+/// as `nil` (text degradation).
 package enum SearchLane: Sendable, Equatable {
+    /// Full-text retrieval only.
     case textOnly
+    /// Vector-index retrieval. Must be non-empty when stored on a `SearchRequest`.
     case vectorOnly(embedding: [Float])
-    case hybrid(alpha: Float, embedding: [Float]?)
+    /// Blend text and vector. Empty embeddings are stored as `nil`.
+    case hybrid(alpha: Float = 0.5, embedding: [Float]?)
 
+    /// Message for ``WaxError/io(_:)`` when `vectorOnly` lacks a non-empty embedding.
     package static let missingVectorOnlyEmbeddingMessage =
         "vectorOnly search requires a non-empty query embedding"
 
+    /// Public ``SearchMode`` this lane maps to.
     package var mode: SearchMode {
         switch self {
         case .textOnly: .textOnly
@@ -24,6 +30,7 @@ package enum SearchLane: Sendable, Equatable {
         }
     }
 
+    /// Query embedding carried by this lane, if any.
     package var embedding: [Float]? {
         switch self {
         case .textOnly:
@@ -35,6 +42,7 @@ package enum SearchLane: Sendable, Equatable {
         }
     }
 
+    /// Whether this lane carries a non-empty query embedding.
     package var hasNonEmptyEmbedding: Bool {
         switch self {
         case .textOnly:
@@ -68,29 +76,14 @@ package enum SearchLane: Sendable, Equatable {
         }
     }
 
-    fileprivate func validateVectorOnlyEmbedding() throws {
-        if case .vectorOnly(let embedding) = self, embedding.isEmpty {
-            throw WaxError.io(Self.missingVectorOnlyEmbeddingMessage)
-        }
-    }
-
     /// Source-compatible mapping used by the non-throwing `mode` + `embedding`
     /// initializer. `vectorOnly` without a non-empty embedding becomes `textOnly`
     /// so that illegal empty vector-only state is never stored.
     fileprivate static func compatible(mode: SearchMode, embedding: [Float]?) -> SearchLane {
-        switch mode {
-        case .textOnly:
+        do {
+            return try from(mode: mode, embedding: embedding)
+        } catch {
             return .textOnly
-        case .vectorOnly:
-            if let embedding, !embedding.isEmpty {
-                return .vectorOnly(embedding: embedding)
-            }
-            return .textOnly
-        case .hybrid(let alpha):
-            if let embedding, !embedding.isEmpty {
-                return .hybrid(alpha: alpha, embedding: embedding)
-            }
-            return .hybrid(alpha: alpha, embedding: nil)
         }
     }
 }
@@ -98,6 +91,7 @@ package enum SearchLane: Sendable, Equatable {
 /// Unified search request.
 package struct SearchRequest: Sendable, Equatable {
     package var query: String?
+    /// Canonical retrieval lane stored by this request.
     package let lane: SearchLane
     package var vectorEnginePreference: VectorEnginePreference
     package var vectorSearchTimeout: Duration?
@@ -128,6 +122,14 @@ package struct SearchRequest: Sendable, Equatable {
     /// Query embedding carried by the stored lane, if any.
     package var embedding: [Float]? { lane.embedding }
 
+    /// Creates a unified search request for `lane`.
+    ///
+    /// Canonicalizes `lane` through ``SearchLane/from(mode:embedding:)`` so hybrid
+    /// empty embeddings become `nil` and `vectorOnly` without a non-empty
+    /// embedding is rejected.
+    ///
+    /// - Throws: ``WaxError/io(_:)`` when `lane` is `vectorOnly` with a missing
+    ///   or empty embedding.
     package init(
         query: String? = nil,
         lane: SearchLane,
@@ -149,10 +151,9 @@ package struct SearchRequest: Sendable, Equatable {
         enableRankingDiagnostics: Bool = false,
         rankingDiagnosticsTopK: Int = 10
     ) throws {
-        try lane.validateVectorOnlyEmbedding()
         self.init(
             query: query,
-            uncheckedLane: lane,
+            uncheckedLane: try SearchLane.from(mode: lane.mode, embedding: lane.embedding),
             vectorEnginePreference: vectorEnginePreference,
             vectorSearchTimeout: vectorSearchTimeout,
             topK: topK,

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -41,9 +41,6 @@ extension Wax {
         let candidateLimit = plan.candidateLimit
         let filter = request.frameFilter ?? FrameFilter()
 
-        if case .vectorOnly(let embedding) = request.lane, embedding.isEmpty {
-            throw WaxError.io(SearchLane.missingVectorOnlyEmbeddingMessage)
-        }
         let cache = UnifiedSearchEngineCache.shared
         let textEngine: FTS5SearchEngine? = if includeText {
             if let override = engineOverrides?.textEngine {

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -41,11 +41,8 @@ extension Wax {
         let candidateLimit = plan.candidateLimit
         let filter = request.frameFilter ?? FrameFilter()
 
-        if case .vectorOnly = request.mode {
-            let hasEmbedding = !(request.embedding?.isEmpty ?? true)
-            guard hasEmbedding else {
-                throw WaxError.io("vectorOnly search requires a non-empty query embedding")
-            }
+        if case .vectorOnly(let embedding) = request.lane, embedding.isEmpty {
+            throw WaxError.io(SearchLane.missingVectorOnlyEmbeddingMessage)
         }
         let cache = UnifiedSearchEngineCache.shared
         let textEngine: FTS5SearchEngine? = if includeText {
@@ -72,7 +69,7 @@ extension Wax {
             }
         }
 
-        let resolvedVectorEngine: ResolvedVectorEngine? = if includeVector, let embedding = request.embedding, !embedding.isEmpty {
+        let resolvedVectorEngine: ResolvedVectorEngine? = if includeVector, let embedding = request.lane.embedding, !embedding.isEmpty {
             if let override = engineOverrides?.vectorEngine {
                 .override(override)
             } else if let loaded = engineOverrides?.loadedVectorEngine {
@@ -170,7 +167,7 @@ extension Wax {
         }()
 
         async let vectorLaneAsync: (results: [(frameId: UInt64, score: Float)], timedOut: Bool) = {
-            guard includeVector, let resolvedVectorEngine, let embedding = request.embedding, !embedding.isEmpty else {
+            guard includeVector, let resolvedVectorEngine, let embedding = request.lane.embedding, !embedding.isEmpty else {
                 return ([], false)
             }
             if let timeout = request.vectorSearchTimeout {
@@ -181,7 +178,7 @@ extension Wax {
                     return (results, false)
                 } catch let error as AsyncTimeout.TimeoutError {
                     // Hybrid/text modes can degrade to non-vector lanes; vectorOnly should fail hard.
-                    if request.mode == .vectorOnly {
+                    if case .vectorOnly = request.lane {
                         throw error
                     }
                     WaxDiagnostics.logSwallowed(
@@ -268,7 +265,7 @@ extension Wax {
         }
 
         var baseResults: [BaseResult]
-        switch request.mode {
+        switch request.lane {
         case .textOnly:
             if structuredIds.isEmpty || structuredWeight <= 0 {
                 baseResults = textResults.enumerated().map { index, result in
@@ -371,7 +368,7 @@ extension Wax {
                     )
                 }
             }
-        case .hybrid(let alpha):
+        case .hybrid(let alpha, _):
             let clampedAlpha = min(1, max(0, alpha))
             let textWeight = weights.bm25 * clampedAlpha
             let vectorWeight = weights.vector * (1 - clampedAlpha)
@@ -474,7 +471,7 @@ extension Wax {
         // those IDs so include_deleted / include_superseded can return them.
         // Constraint-only queries (no text) already rank via timeline — do not
         // reinsert the allowlist in ID order and scramble that ranking.
-        let hasLexicalOrVectorQuery = (request.query?.isEmpty == false) || request.embedding != nil
+        let hasLexicalOrVectorQuery = (request.query?.isEmpty == false) || request.lane.hasNonEmptyEmbedding
         if hasLexicalOrVectorQuery, let allowlist = filter.frameIds, !allowlist.isEmpty {
             let seen = Set(baseResults.map(\.frameId))
             for frameId in allowlist.sorted() where !seen.contains(frameId) {

--- a/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
+++ b/Sources/Wax/VideoRAG/VideoRAGOrchestrator.swift
@@ -200,7 +200,7 @@ package actor VideoRAGOrchestrator {
         let queryEmbedding = try await buildQueryEmbedding(text: queryText)
         let isConstraintOnly = (queryText == nil && queryEmbedding == nil)
 
-        let mode: SearchMode = {
+        let resolvedMode: SearchMode = {
             switch (queryText, queryEmbedding) {
             case (nil, nil):
                 return .textOnly
@@ -212,6 +212,7 @@ package actor VideoRAGOrchestrator {
                 return .hybrid(alpha: config.hybridAlpha)
             }
         }()
+        let lane = try SearchLane.from(mode: resolvedMode, embedding: queryEmbedding)
 
         let timeRange = Self.toWaxTimeRange(query.timeRange)
 
@@ -242,11 +243,10 @@ package actor VideoRAGOrchestrator {
         let topK = max(config.searchTopK, query.resultLimit * max(1, query.segmentLimitPerVideo) * 8)
         let timelineFallbackLimit = max(config.timelineFallbackLimit, query.resultLimit * 4)
 
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: queryText,
-            embedding: queryEmbedding,
+            lane: lane,
             vectorEnginePreference: config.vectorEnginePreference,
-            mode: mode,
             topK: topK,
             timeRange: timeRange,
             frameFilter: frameFilter,

--- a/Tests/WaxIntegrationTests/READMEExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/READMEExamplesTests.swift
@@ -214,7 +214,7 @@ func readmeExampleUnifiedSearchAPI() async throws {
         try await vec.commit()
         try await text.commit()
 
-        let request = SearchRequest(query: "Hello", mode: .hybrid(alpha: 0.5), topK: 10)
+        let request = try SearchRequest(query: "Hello", lane: .hybrid(alpha: 0.5, embedding: nil), topK: 10)
         let response = try await wax.search(request)
         #expect(response.results.count >= 0)
 

--- a/Tests/WaxIntegrationTests/TextSearchORFallbackTests.swift
+++ b/Tests/WaxIntegrationTests/TextSearchORFallbackTests.swift
@@ -26,7 +26,7 @@ import WaxVectorSearch
         let response = try await wax.search(
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 10
             )
         )
@@ -63,7 +63,7 @@ import WaxVectorSearch
         let response = try await wax.search(
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 10
             )
         )
@@ -96,7 +96,7 @@ import WaxVectorSearch
         let response = try await wax.search(
             SearchRequest(
                 query: "alpha drop",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 10
             )
         )
@@ -127,7 +127,7 @@ import WaxVectorSearch
         let response = try await wax.search(
             SearchRequest(
                 query: "alpha beta drop",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 10
             )
         )
@@ -158,7 +158,7 @@ import WaxVectorSearch
         let response = try await wax.search(
             SearchRequest(
                 query: "7f3a91",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 10
             )
         )
@@ -192,9 +192,8 @@ import WaxVectorSearch
         let response = try await wax.search(
             SearchRequest(
                 query: "adversarial-fp.md stash-drop deny",
-                embedding: [1.0, 0.0, 0.0, 0.0],
+                lane: .hybrid(alpha: 0.5, embedding: [1.0, 0.0, 0.0, 0.0]),
                 vectorEnginePreference: .cpuOnly,
-                mode: .hybrid(alpha: 0.5),
                 topK: 10
             ),
             engineOverrides: UnifiedSearchEngineOverrides(

--- a/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
+++ b/Tests/WaxIntegrationTests/UnifiedSearchTests.swift
@@ -53,7 +53,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         try await text.commit()
 
-        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10)
+        let request = try SearchRequest(query: "Swift", lane: .textOnly, topK: 10)
         let response = try await wax.search(request)
 
         #expect(response.results.count == 1)
@@ -76,7 +76,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         try await text.commit()
 
-        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 10, minScore: 0.9)
+        let request = try SearchRequest(query: "Swift", lane: .textOnly, topK: 10, minScore: 0.9)
         let response = try await wax.search(request)
 
         #expect(response.results.map(\.frameId) == [exact])
@@ -97,7 +97,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await vec.commit()
 
         let queryEmbedding = VectorMath.normalizeL2([0.9, 0.1, 0.0, 0.0])
-        let request = SearchRequest(embedding: queryEmbedding, mode: .vectorOnly, topK: 10)
+        let request = try SearchRequest(lane: .vectorOnly(embedding: queryEmbedding), topK: 10)
         let response = try await wax.search(request)
 
         #expect(response.results.first?.frameId == id0)
@@ -122,10 +122,9 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await vec.commit()
         try await text.commit()
 
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: "Swift",
-            embedding: [1.0, 0.0, 0.0, 0.0],
-            mode: .hybrid(alpha: 0.5),
+            lane: .hybrid(alpha: 0.5, embedding: [1.0, 0.0, 0.0, 0.0]),
             topK: 10
         )
         let response = try await wax.search(request)
@@ -146,7 +145,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await text.indexText(frameId: id0, text: "Swift")
         try await text.commit()
 
-        let request = SearchRequest(query: "Swift", mode: .textOnly, topK: 0)
+        let request = try SearchRequest(query: "Swift", lane: .textOnly, topK: 0)
         let response = try await wax.search(request)
 
         #expect(response.results.isEmpty)
@@ -166,7 +165,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         let response = try await wax.search(
             SearchRequest(
                 query: "WAX-OVERFLOW-CANARY",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: Int.max
             )
         )
@@ -220,7 +219,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         let latestResponse = try await session.search(
             SearchRequest(
                 query: "F027 Alice",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5,
                 timeRange: SearchTimeRange(before: 200),
                 asOfMs: .max
@@ -233,7 +232,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         let outOfFrameRangeResponse = try await session.search(
             SearchRequest(
                 query: "F027 Alice",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5,
                 timeRange: SearchTimeRange(before: 50),
                 asOfMs: .max
@@ -245,7 +244,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         let historicalResponse = try await session.search(
             SearchRequest(
                 query: "F027 Alice",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5,
                 asOfMs: 200
             )
@@ -303,7 +302,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await session.commit()
 
         let response = try await session.search(
-            SearchRequest(query: "F025ObjectParis", mode: .textOnly, topK: 5, asOfMs: .max)
+            SearchRequest(query: "F025ObjectParis", lane: .textOnly, topK: 5, asOfMs: .max)
         )
 
         #expect(response.results.map(\.frameId) == [evidenceFrame])
@@ -326,9 +325,8 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         try await vec.commit()
 
         let allowlist = FrameFilter(frameIds: [id2, id3])
-        let request = SearchRequest(
-            embedding: [1.0, 0.0],
-            mode: .vectorOnly,
+        let request = try SearchRequest(
+            lane: .vectorOnly(embedding: [1.0, 0.0]),
             topK: 2,
             frameFilter: allowlist
         )
@@ -363,9 +361,9 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         let filter = FrameFilter(
             metadataFilter: .init(requiredEntries: ["source": "email"])
         )
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: "alpha",
-            mode: .textOnly,
+            lane: .textOnly,
             topK: 10,
             frameFilter: filter
         )
@@ -403,7 +401,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         let response = try await wax.search(
             SearchRequest(
                 query: query,
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 1,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "allowed"])
@@ -439,8 +437,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
         let vectorEngine = DeterministicVectorResultsEngine(dimensions: 4, results: vectorResults)
         let response = try await wax.search(
             SearchRequest(
-                embedding: [1.0, 0.0, 0.0, 0.0],
-                mode: .vectorOnly,
+                lane: .vectorOnly(embedding: [1.0, 0.0, 0.0, 0.0]),
                 topK: 1,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "allowed"])
@@ -476,8 +473,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         let response = try await wax.search(
             SearchRequest(
-                embedding: [1.0, 0.0, 0.0, 0.0],
-                mode: .vectorOnly,
+                lane: .vectorOnly(embedding: [1.0, 0.0, 0.0, 0.0]),
                 topK: 1_100,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "allowed"])
@@ -512,8 +508,7 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         let response = try await wax.search(
             SearchRequest(
-                embedding: [1.0, 0.0, 0.0, 0.0],
-                mode: .vectorOnly,
+                lane: .vectorOnly(embedding: [1.0, 0.0, 0.0, 0.0]),
                 topK: 1,
                 frameFilter: FrameFilter(
                     metadataFilter: MetadataFilter(requiredEntries: ["scope": "pending"])
@@ -564,9 +559,9 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
                 requiredLabels: ["public"]
             )
         )
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: "Quarterly summary",
-            mode: .textOnly,
+            lane: .textOnly,
             topK: 10,
             frameFilter: filter
         )
@@ -596,9 +591,9 @@ private actor DeterministicVectorResultsEngine: VectorSearchEngine {
 
         try await text.commit()
 
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: "query-with-no-primary-hits",
-            mode: .textOnly,
+            lane: .textOnly,
             topK: 10,
             frameFilter: FrameFilter(
                 metadataFilter: .init(requiredEntries: ["source": "email"])
@@ -662,9 +657,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
 
         let id0 = try await vec.putWithEmbedding(Data("Pending".utf8), embedding: [0.0, 1.0])
 
-        let request = SearchRequest(
-            embedding: [0.0, 1.0],
-            mode: .vectorOnly,
+        let request = try SearchRequest(
+            lane: .vectorOnly(embedding: [0.0, 1.0]),
             topK: 5
         )
         let response = try await wax.search(request)
@@ -690,7 +684,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let wax = try await Wax.create(at: url)
 
         do {
-            _ = try await wax.search(SearchRequest(mode: .vectorOnly, topK: 5))
+            _ = try await wax.search(SearchRequest(lane: .vectorOnly(embedding: []), topK: 5))
             Issue.record("Expected WaxError for vectorOnly search without embedding")
         } catch let error as WaxError {
             guard case .io(let message) = error else {
@@ -729,7 +723,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "Which city did Person18 move to",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -762,7 +756,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "What is the public launch date for Atlas 10",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -794,7 +788,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: #"What is the public launch date for "Atlas-10"? -- !!!"#,
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -826,7 +820,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "Which city did Priya move to",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -861,7 +855,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "which city noah moved to",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -899,7 +893,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "for noah on atlas-10 in 2026 what is the public launch date",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -937,7 +931,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: #"what is "Atlas-10 launch date" ???"#,
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -975,7 +969,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "what is 'Atlas-10 launch date' ???",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -1013,7 +1007,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "What is the public launch date for Atlas-10?",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5
             )
         )
@@ -1052,11 +1046,10 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await vec.commit()
         try await text.commit()
 
-        let request = SearchRequest(
+        let request = try SearchRequest(
             query: "Swift concurrency",
-            embedding: [1.0, 0.0, 0.0, 0.0],
+            lane: .hybrid(alpha: 0.5, embedding: [1.0, 0.0, 0.0, 0.0]),
             vectorEnginePreference: .cpuOnly,
-            mode: .hybrid(alpha: 0.5),
             topK: 3,
             enableRankingDiagnostics: true,
             rankingDiagnosticsTopK: 1
@@ -1107,9 +1100,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: query,
-                embedding: [1.0, 0.0, 0.0, 0.0],
+                lane: .hybrid(alpha: 0.3, embedding: [1.0, 0.0, 0.0, 0.0]),
                 vectorEnginePreference: .cpuOnly,
-                mode: .hybrid(alpha: 0.3),
                 topK: 2,
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 2
@@ -1165,7 +1157,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "auth rollout decision",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 2,
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
@@ -1208,7 +1200,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.commit()
 
         let response = try await wax.search(
-            SearchRequest(query: "rollout note", mode: .textOnly, topK: 5)
+            SearchRequest(query: "rollout note", lane: .textOnly, topK: 5)
         )
 
         #expect(response.results.map(\.frameId).contains(activeID))
@@ -1238,7 +1230,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "concise release notes",
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 3,
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
@@ -1292,7 +1284,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let textResponse = try await wax.search(
             SearchRequest(
                 query: token,
-                mode: .textOnly,
+                lane: .textOnly,
                 topK: 5,
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             )
@@ -1302,9 +1294,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let hybridResponse = try await wax.search(
             SearchRequest(
                 query: token,
-                embedding: [1.0, 0.0, 0.0, 0.0],
+                lane: .hybrid(alpha: 0.5, embedding: [1.0, 0.0, 0.0, 0.0]),
                 vectorEnginePreference: .cpuOnly,
-                mode: .hybrid(alpha: 0.5),
                 topK: 5,
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
@@ -1368,9 +1359,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let hybridResponse = try await wax.search(
             SearchRequest(
                 query: token,
-                embedding: [1.0, 0.0, 0.0, 0.0],
+                lane: .hybrid(alpha: 0.5, embedding: [1.0, 0.0, 0.0, 0.0]),
                 vectorEnginePreference: .cpuOnly,
-                mode: .hybrid(alpha: 0.5),
                 topK: 5,
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
@@ -1431,9 +1421,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: token,
-                embedding: [1.0, 0.0, 0.0, 0.0],
+                lane: .vectorOnly(embedding: [1.0, 0.0, 0.0, 0.0]),
                 vectorEnginePreference: .cpuOnly,
-                mode: .vectorOnly,
                 topK: 5,
                 scopeContext: MemoryScopeContext(repoName: "Wax", projectName: "Wax")
             ),
@@ -1470,7 +1459,7 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.commit()
 
         let response = try await wax.search(
-            SearchRequest(query: "cats OR dogs", mode: .textOnly, topK: 10)
+            SearchRequest(query: "cats OR dogs", lane: .textOnly, topK: 10)
         )
         let catsHit = try #require(response.results.first { $0.frameId == catsOnly })
         let dogsHit = try #require(response.results.first { $0.frameId == dogsOnly })
@@ -1491,12 +1480,12 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         try await text.commit()
 
         let stopwordOnly = try await wax.search(
-            SearchRequest(query: "the and or", mode: .textOnly, topK: 10)
+            SearchRequest(query: "the and or", lane: .textOnly, topK: 10)
         )
         #expect(stopwordOnly.results.isEmpty)
 
         let operatorOnly = try await wax.search(
-            SearchRequest(query: "NOT NEAR", mode: .textOnly, topK: 10)
+            SearchRequest(query: "NOT NEAR", lane: .textOnly, topK: 10)
         )
         #expect(operatorOnly.results.isEmpty)
 
@@ -1566,9 +1555,8 @@ func metalVectorSearchNormalizesNonNormalizedQueryEmbedding() async throws {
         let response = try await wax.search(
             SearchRequest(
                 query: "when was F027Alice last seen",
-                embedding: [1.0, 0.0, 0.0, 0.0],
+                lane: .hybrid(alpha: 0.5, embedding: [1.0, 0.0, 0.0, 0.0]),
                 vectorEnginePreference: .cpuOnly,
-                mode: .hybrid(alpha: 0.5),
                 topK: 10,
                 enableRankingDiagnostics: true,
                 rankingDiagnosticsTopK: 10

--- a/Tests/WaxIntegrationTests/VectorLaneDiagnosticsTests.swift
+++ b/Tests/WaxIntegrationTests/VectorLaneDiagnosticsTests.swift
@@ -29,8 +29,10 @@ struct VectorLaneDiagnosticsTests {
             let wax = try await Wax.create(at: url)
             do {
                 let frameID = try await wax.put(Data("A candidate document with no lexical query overlap".utf8))
-                let request = SearchRequest(
-                    query: "vehicle stopping system", embedding: [1, 0], mode: .hybrid(), topK: 4
+                let request = try SearchRequest(
+                    query: "vehicle stopping system",
+                    lane: .hybrid(alpha: 0.5, embedding: [1, 0]),
+                    topK: 4
                 )
                 let relevant = try await wax.search(request, engineOverrides: .init(
                     vectorEngine: DiagnosticVectorEngine(hang: false, hits: [(frameID, 0.95)])
@@ -78,11 +80,15 @@ struct VectorLaneDiagnosticsTests {
             do {
                 // Hang uses a tight budget. The empty lane must use a wide one so
                 // actor scheduling under parallel `swift test` cannot look like a timeout.
-                let response = try await wax.search(.init(
-                    query: "memory reliability", embedding: [1, 0],
-                    vectorSearchTimeout: hang ? .milliseconds(40) : .seconds(2),
-                    mode: .hybrid(), topK: 4
-                ), engineOverrides: .init(vectorEngine: DiagnosticVectorEngine(hang: hang)))
+                let response = try await wax.search(
+                    SearchRequest(
+                        query: "memory reliability",
+                        lane: .hybrid(alpha: 0.5, embedding: [1, 0]),
+                        vectorSearchTimeout: hang ? .milliseconds(40) : .seconds(2),
+                        topK: 4
+                    ),
+                    engineOverrides: .init(vectorEngine: DiagnosticVectorEngine(hang: hang))
+                )
                 #expect(response.vectorSearchTimedOut == hang)
                 try await wax.close()
             } catch {

--- a/Tests/WaxIntegrationTests/WaxSessionTests.swift
+++ b/Tests/WaxIntegrationTests/WaxSessionTests.swift
@@ -125,8 +125,7 @@ import WaxCore
 
         let beforeCommit = try await writer.search(
             SearchRequest(
-                embedding: [1.0, 0.0],
-                mode: .vectorOnly,
+                lane: .vectorOnly(embedding: [1.0, 0.0]),
                 topK: 2
             )
         )
@@ -140,8 +139,7 @@ import WaxCore
         let reader = try await reopened.openSession(.readOnly, config: config)
         let afterCommit = try await reader.search(
             SearchRequest(
-                embedding: [1.0, 0.0],
-                mode: .vectorOnly,
+                lane: .vectorOnly(embedding: [1.0, 0.0]),
                 topK: 2
             )
         )
@@ -218,8 +216,7 @@ import WaxCore
         let reader = try await reopened.openSession(.readOnly, config: config)
         let response = try await reader.search(
             SearchRequest(
-                embedding: [1.0, 0.0],
-                mode: .vectorOnly,
+                lane: .vectorOnly(embedding: [1.0, 0.0]),
                 topK: 2
             )
         )
@@ -254,8 +251,7 @@ struct WaxSessionCacheIsolationTests {
 
             _ = try await session.search(
                 SearchRequest(
-                    embedding: [1.0, 0.0],
-                    mode: .vectorOnly,
+                    lane: .vectorOnly(embedding: [1.0, 0.0]),
                     topK: 1
                 )
             )

--- a/Tests/WaxTests/SearchLaneTests.swift
+++ b/Tests/WaxTests/SearchLaneTests.swift
@@ -83,6 +83,19 @@ struct SearchLaneTests {
     }
 
     @Test
+    func searchRequestFactoryCanonicalizesHybridEmptyEmbeddingToNil() throws {
+        let request = try SearchRequest(lane: .hybrid(alpha: 0.5, embedding: []), nowMs: 0)
+        #expect(request.embedding == nil)
+        #expect(request.lane == .hybrid(alpha: 0.5, embedding: nil))
+        #expect(SearchPlan.make(request).includeVector == false)
+    }
+
+    @Test
+    func hybridDefaultsAlphaToPointFive() {
+        #expect(SearchLane.hybrid(embedding: nil) == .hybrid(alpha: 0.5, embedding: nil))
+    }
+
+    @Test
     func hybridWithEmbeddingIncludesVectorLane() throws {
         let embedding: [Float] = [1, 0, 0, 0]
         let lane = try SearchLane.from(mode: .hybrid(alpha: 0.5), embedding: embedding)

--- a/Tests/WaxTests/SearchLaneTests.swift
+++ b/Tests/WaxTests/SearchLaneTests.swift
@@ -19,6 +19,28 @@ struct SearchLaneTests {
         }
     }
 
+    @Test(arguments: [[Float](), nil])
+    func compatibilityInitDoesNotStoreVectorOnlyWithoutEmbedding(embedding: [Float]?) {
+        let request = SearchRequest(query: "q", embedding: embedding, mode: .vectorOnly, nowMs: 0)
+        #expect(request.lane == .textOnly)
+        #expect(request.mode == .textOnly)
+        #expect(request.embedding == nil)
+
+        let plan = SearchPlan.make(request)
+        #expect(plan.includeText)
+        #expect(plan.includeVector == false)
+    }
+
+    @Test
+    func compatibilityInitKeepsVectorOnlyWhenEmbeddingIsNonEmpty() {
+        let embedding: [Float] = [1, 0]
+        let request = SearchRequest(embedding: embedding, mode: .vectorOnly, nowMs: 0)
+        #expect(request.lane == .vectorOnly(embedding: embedding))
+        #expect(request.mode == .vectorOnly)
+        #expect(request.embedding == embedding)
+        #expect(SearchPlan.make(request).includeVector)
+    }
+
     @Test
     func searchRequestFactoryRejectsEmptyVectorOnlyEmbedding() {
         do {

--- a/Tests/WaxTests/SearchLaneTests.swift
+++ b/Tests/WaxTests/SearchLaneTests.swift
@@ -1,0 +1,103 @@
+import Testing
+@testable import Wax
+import WaxCore
+
+struct SearchLaneTests {
+    @Test(arguments: [[Float](), nil])
+    func fromRejectsVectorOnlyWithoutNonEmptyEmbedding(embedding: [Float]?) {
+        do {
+            _ = try SearchLane.from(mode: .vectorOnly, embedding: embedding)
+            Issue.record("expected WaxError for vectorOnly without a non-empty embedding")
+        } catch let error as WaxError {
+            guard case .io(let message) = error else {
+                Issue.record("expected WaxError.io, got \(error)")
+                return
+            }
+            #expect(message.contains("requires a non-empty query embedding"))
+        } catch {
+            Issue.record("wrong error thrown: \(error)")
+        }
+    }
+
+    @Test
+    func searchRequestFactoryRejectsEmptyVectorOnlyEmbedding() {
+        do {
+            _ = try SearchRequest(query: "q", lane: .vectorOnly(embedding: []))
+            Issue.record("expected WaxError for empty vectorOnly embedding")
+        } catch let error as WaxError {
+            guard case .io(let message) = error else {
+                Issue.record("expected WaxError.io, got \(error)")
+                return
+            }
+            #expect(message.contains("requires a non-empty query embedding"))
+        } catch {
+            Issue.record("wrong error thrown: \(error)")
+        }
+    }
+
+    @Test
+    func hybridNilEmbeddingIsLegalAndOmitsVectorLane() throws {
+        let lane = try SearchLane.from(mode: .hybrid(alpha: 0.5), embedding: nil)
+        #expect(lane == .hybrid(alpha: 0.5, embedding: nil))
+
+        let request = try SearchRequest(query: "hello world", lane: lane, nowMs: 0)
+        #expect(request.mode == .hybrid(alpha: 0.5))
+        #expect(request.embedding == nil)
+        #expect(request.lane == lane)
+
+        let plan = SearchPlan.make(request)
+        #expect(plan.includeText)
+        #expect(plan.includeVector == false)
+    }
+
+    @Test
+    func hybridEmptyEmbeddingTreatsVectorAsAbsent() throws {
+        let lane = try SearchLane.from(mode: .hybrid(alpha: 0.25), embedding: [])
+        #expect(lane == .hybrid(alpha: 0.25, embedding: nil))
+
+        let plan = SearchPlan.make(try SearchRequest(query: "hello world", lane: lane, nowMs: 0))
+        #expect(plan.includeText)
+        #expect(plan.includeVector == false)
+    }
+
+    @Test
+    func hybridWithEmbeddingIncludesVectorLane() throws {
+        let embedding: [Float] = [1, 0, 0, 0]
+        let lane = try SearchLane.from(mode: .hybrid(alpha: 0.5), embedding: embedding)
+        #expect(lane == .hybrid(alpha: 0.5, embedding: embedding))
+
+        let plan = SearchPlan.make(
+            try SearchRequest(query: "hello world", lane: lane, nowMs: 0)
+        )
+        #expect(plan.includeText)
+        #expect(plan.includeVector)
+    }
+
+    @Test
+    func vectorOnlyWithEmbeddingIncludesVectorLaneOnly() throws {
+        let embedding: [Float] = [0.2, 0.8]
+        let request = try SearchRequest(
+            query: "7f3a91",
+            lane: .vectorOnly(embedding: embedding),
+            nowMs: 0
+        )
+        #expect(request.mode == .vectorOnly)
+        #expect(request.embedding == embedding)
+
+        let plan = SearchPlan.make(request)
+        #expect(plan.includeText == false)
+        #expect(plan.includeVector)
+        #expect(plan.exactIntentWindow == nil)
+    }
+
+    @Test
+    func textOnlyOmitsVectorLane() throws {
+        let request = try SearchRequest(query: "hello", lane: .textOnly, nowMs: 0)
+        #expect(request.mode == .textOnly)
+        #expect(request.embedding == nil)
+
+        let plan = SearchPlan.make(request)
+        #expect(plan.includeText)
+        #expect(plan.includeVector == false)
+    }
+}

--- a/Tests/WaxTests/SearchPlanTests.swift
+++ b/Tests/WaxTests/SearchPlanTests.swift
@@ -35,34 +35,30 @@ struct SearchPlanTests {
     }
 
     @Test
-    func vectorOnlyWithoutEmbeddingSetsIncludeFlagsAndDoesNotThrow() {
-        let missing = SearchPlan.make(
-            SearchRequest(query: "7f3a91", embedding: nil, mode: .vectorOnly, nowMs: 0)
-        )
-        #expect(missing.includeText == false)
-        #expect(missing.includeVector)
-        #expect(missing.exactIntentWindow == nil)
-        #expect(missing.queryType == .factual)
-
-        let empty = SearchPlan.make(
-            SearchRequest(query: "7f3a91", embedding: [], mode: .vectorOnly, nowMs: 0)
-        )
-        #expect(empty.includeText == false)
-        #expect(empty.includeVector)
-        #expect(empty.exactIntentWindow == nil)
-    }
-
-    @Test
-    func hybridIncludesBothLanesWithoutExactIntentWindow() {
+    func hybridWithoutEmbeddingOmitsVectorLane() {
         let plan = SearchPlan.make(
             SearchRequest(query: "hello world", mode: .hybrid(), nowMs: 0)
         )
         #expect(plan.includeText)
-        #expect(plan.includeVector)
+        #expect(plan.includeVector == false)
         #expect(plan.queryType == .exploratory)
         #expect(plan.exactIntentWindow == nil)
         #expect(plan.candidateLimit == 30)
         #expect(plan.matchPlan != nil)
+    }
+
+    @Test
+    func hybridWithEmbeddingIncludesBothLanes() throws {
+        let plan = SearchPlan.make(
+            try SearchRequest(
+                query: "hello world",
+                lane: .hybrid(alpha: 0.5, embedding: [1, 0, 0, 0]),
+                nowMs: 0
+            )
+        )
+        #expect(plan.includeText)
+        #expect(plan.includeVector)
+        #expect(plan.exactIntentWindow == nil)
     }
 
     @Test(arguments: [(1, 12), (10, 30), (20, 48)])


### PR DESCRIPTION
Package `SearchRequest` stored `mode` and `embedding` as independent fields. `vectorOnly` with a missing embedding compiled and threw in UnifiedSearch.

This ticket stores a `SearchLane` enum so that combination cannot be stored. Public `SearchMode` / `Memory.search` are unchanged. Hybrid with a nil embedding still degrades to text.

**Ticket:** T1 (type-system architecture)
**Reviews:** `swift-adversarial-pr-review` (fix pass + final pass, both APPROVE)
**Proof:** `swift test --filter SearchLaneTests` / `SearchPlanTests` / `UnifiedSearchTests`

A non-throwing `SearchRequest(mode:embedding:)` shim remains for tests outside this ticket; empty `vectorOnly` maps to `textOnly` instead of storing `[]`.