### PR TITLE
PhotoID: match VideoID on the experimental photo facade

### DIFF
--- a/Examples/WaxHNDemo/WaxHNDemo/PhotoEvidencePrompt.swift
+++ b/Examples/WaxHNDemo/WaxHNDemo/PhotoEvidencePrompt.swift
@@ -3,7 +3,7 @@ import Wax
 enum PhotoEvidencePrompt {
     static func make(query: String, items: [PhotoRAGItem]) -> String {
         let evidence = items
-            .map { item in "[\(item.assetID)]\n\(item.summaryText)" }
+            .map { item in "[\(item.photoID.id)]\n\(item.summaryText)" }
             .joined(separator: "\n\n")
         return """
         Answer using only this on-device photo evidence. If the evidence does not contain the answer, say you cannot find it.

--- a/Examples/WaxHNDemo/WaxHNDemo/PhotoHitRow.swift
+++ b/Examples/WaxHNDemo/WaxHNDemo/PhotoHitRow.swift
@@ -11,7 +11,7 @@ struct PhotoHitRow: View {
                 Text(item.summaryText)
                     .font(.body)
                     .lineLimit(3)
-                Text(item.assetID)
+                Text(item.photoID.id)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -19,6 +19,6 @@ struct PhotoHitRow: View {
             }
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(item.summaryText), asset \(item.assetID)")
+        .accessibilityLabel("\(item.summaryText), asset \(item.photoID.id)")
     }
 }

--- a/Examples/WaxHNDemo/WaxHNDemo/PhotoRAGItem+EvidenceText.swift
+++ b/Examples/WaxHNDemo/WaxHNDemo/PhotoRAGItem+EvidenceText.swift
@@ -1,7 +1,7 @@
 import Wax
 
 extension PhotoRAGItem: Identifiable {
-    public var id: String { assetID }
+    public var id: PhotoID { photoID }
 
     /// Text snippets from `.text` evidence, or `summaryText` when none exist.
     var evidenceText: String {

--- a/Examples/WaxHNDemo/WaxHNDemo/PhotoSearchModel.swift
+++ b/Examples/WaxHNDemo/WaxHNDemo/PhotoSearchModel.swift
@@ -61,7 +61,7 @@ final class PhotoSearchModel {
 
         do {
             let memory = try await openPhotoMemory()
-            try await memory.ingest(assetIDs: assetIDs)
+            try await memory.ingest(assetIDs: assetIDs.map { PhotoID(source: .photos, id: $0) })
             try await memory.flush()
             refreshPhotoStoreSize()
             isPermissionBlocked = false
@@ -191,7 +191,7 @@ final class PhotoSearchModel {
     ) async throws -> PhotoIngestReport {
         let probe = try await memory.recall(
             PhotoQuery(
-                filters: PhotoFilters(assetIDs: Set(assetIDs)),
+                filters: PhotoFilters(assetIDs: Set(assetIDs.map { PhotoID(source: .photos, id: $0) })),
                 resultLimit: max(assetIDs.count, 1)
             )
         )

--- a/Examples/WaxHNDemo/WaxHNDemoTests/FoundationModelsGroundingTests.swift
+++ b/Examples/WaxHNDemo/WaxHNDemoTests/FoundationModelsGroundingTests.swift
@@ -9,13 +9,13 @@ struct PhotoEvidencePromptTests {
     func buildsExactPrompt() {
         let items = [
             PhotoRAGItem(
-                assetID: "A1",
+                photoID: PhotoID(source: .photos, id: "A1"),
                 score: 1,
                 evidence: [.text(snippet: "must-not-appear")],
                 summaryText: "OCR: WAX-99"
             ),
             PhotoRAGItem(
-                assetID: "B2",
+                photoID: PhotoID(source: .photos, id: "B2"),
                 score: 0.5,
                 evidence: [.vector],
                 summaryText: "Caption: mug"

--- a/Examples/WaxHNDemo/WaxHNDemoTests/PhotoDropTests.swift
+++ b/Examples/WaxHNDemo/WaxHNDemoTests/PhotoDropTests.swift
@@ -11,7 +11,7 @@ struct PhotoDropTests {
         let notes = URL(fileURLWithPath: "/tmp/notes.txt")
         let files = PhotoDrop.photoFiles(from: [receipt, notes])
         #expect(files.count == 1)
-        #expect(files[0].id == "receipt.PNG")
+        #expect(files[0].id == PhotoID(source: .file, id: "receipt.PNG"))
         #expect(files[0].url == receipt)
     }
 }

--- a/Examples/WaxHNDemo/WaxHNDemoTests/PhotoRAGItemEvidenceTests.swift
+++ b/Examples/WaxHNDemo/WaxHNDemoTests/PhotoRAGItemEvidenceTests.swift
@@ -8,7 +8,7 @@ struct PhotoRAGItemEvidenceTests {
     @Test("Joins non-empty text snippets and skips blank ones")
     func joinsTextSnippets() {
         let item = PhotoRAGItem(
-            assetID: "asset-1",
+            photoID: PhotoID(source: .file, id: "asset-1"),
             score: 1,
             evidence: [
                 .text(snippet: "WAX 1234"),
@@ -25,7 +25,7 @@ struct PhotoRAGItemEvidenceTests {
     @Test("Falls back to summaryText when evidence has no text snippets")
     func fallsBackToSummaryText() {
         let item = PhotoRAGItem(
-            assetID: "asset-2",
+            photoID: PhotoID(source: .file, id: "asset-2"),
             score: 0.4,
             evidence: [.vector, .timeline],
             summaryText: "Caption: coffee receipt"

--- a/Resources/skills/public/wax/references/public-api.md
+++ b/Resources/skills/public/wax/references/public-api.md
@@ -110,13 +110,15 @@ Available when `canImport(ImageIO)`. These are the public facades. Do not constr
 - `public actor VideoMemory` — segment videos, embed keyframes, optional host-supplied transcripts, ranked segment recall
 - `public enum BuiltInMultimodalEmbeddings { public static func make(_:options:) async throws -> any MultimodalEmbeddingProvider }`
 - `public protocol MultimodalEmbeddingProvider` — shared image + text embedder for the photo/video facades
-- Supporting public types: `PhotoRAGConfig`, `PhotoFile`, `PhotoQuery`, `PhotoScope`, `PhotoRAGContext`, `VideoRAGConfig`, `VideoFile`, `VideoQuery`, `VideoScope`, `VideoRAGContext`, `VideoTranscriptProvider`, `VisionOCRProvider`
+- Supporting public types: `PhotoID`, `PhotoRAGConfig`, `PhotoFile`, `PhotoQuery`, `PhotoScope`, `PhotoRAGContext`, `VideoID`, `VideoRAGConfig`, `VideoFile`, `VideoQuery`, `VideoScope`, `VideoRAGContext`, `VideoTranscriptProvider`, `VisionOCRProvider`
+- `PhotoID` matches `VideoID` (`source` + `id`). Photo delete, filters, file ingest, and `PhotoRAGItem` use `PhotoID`. Wrap Photos `localIdentifier` as `PhotoID(source: .photos, id:)`. On-disk photo metadata stays strings.
 
 ```swift
 let embedder = try await BuiltInMultimodalEmbeddings.make(.miniLM)
 let photos = try await PhotoMemory(at: storeURL, embedder: embedder, ocr: VisionOCRProvider())
-try await photos.ingest(files: [PhotoFile(id: "receipt-1", url: imageURL)])
+try await photos.ingest(files: [PhotoFile(id: PhotoID(source: .file, id: "receipt-1"), url: imageURL)])
 let context = try await photos.recall(PhotoQuery(text: "coffee receipt"))
+try await photos.delete(photoID: PhotoID(source: .file, id: "receipt-1"))
 try await photos.close()
 ```
 

--- a/Sources/Wax/PhotoRAG/PhotoMemory.swift
+++ b/Sources/Wax/PhotoRAG/PhotoMemory.swift
@@ -18,8 +18,9 @@ import Foundation
 ///     embedder: embedder,
 ///     ocr: VisionOCRProvider()
 /// )
-/// try await photos.ingest(files: [PhotoFile(id: "receipt-1", url: imageURL)])
+/// try await photos.ingest(files: [PhotoFile(id: PhotoID(source: .file, id: "receipt-1"), url: imageURL)])
 /// let context = try await photos.recall(PhotoQuery(text: "coffee receipt"))
+/// try await photos.delete(photoID: PhotoID(source: .file, id: "receipt-1"))
 /// try await photos.close()
 /// ```
 public actor PhotoMemory {
@@ -58,10 +59,11 @@ public actor PhotoMemory {
         try await orchestrator.syncLibrary(scope: scope)
     }
 
-    /// Ingest Photos-library assets by local identifier.
+    /// Ingest Photos-library assets by ``PhotoID``.
     ///
-    /// Requires Photos authorization.
-    public func ingest(assetIDs: [String]) async throws {
+    /// Requires Photos authorization. Wrap `PHAsset.localIdentifier` as
+    /// `PhotoID(source: .photos, id:)`.
+    public func ingest(assetIDs: [PhotoID]) async throws {
         try await orchestrator.ingest(assetIDs: assetIDs)
     }
     #endif
@@ -77,8 +79,8 @@ public actor PhotoMemory {
     }
 
     /// Delete a photo and all derived frames (OCR, caption, tags, regions) plus vectors.
-    public func delete(assetID: String) async throws {
-        try await orchestrator.delete(assetID: assetID)
+    public func delete(photoID: PhotoID) async throws {
+        try await orchestrator.delete(photoID: photoID)
     }
 
     /// Force pending writes to durable storage.

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -73,8 +73,8 @@ package actor PhotoRAGOrchestrator {
     }
 
     private struct IndexState: Sendable {
-        var rootByAssetID: [String: UInt64] = [:]
-        var assetIDByRoot: [UInt64: String] = [:]
+        var rootByPhotoID: [PhotoID: UInt64] = [:]
+        var photoIDByRoot: [UInt64: PhotoID] = [:]
         var derivedByRoot: [UInt64: DerivedRefs] = [:]
         var locationBins: [LocationBin: Set<UInt64>] = [:]
         var locationByFrame: [UInt64: PhotoCoordinate] = [:]
@@ -93,7 +93,7 @@ package actor PhotoRAGOrchestrator {
     private let queryEmbeddingCache: EmbeddingMemoizer?
 
     private var index = IndexState()
-    private var inFlightAssetIDs: Set<String> = []
+    private var inFlightPhotoIDs: Set<PhotoID> = []
 
     package init(
         storeURL: URL,
@@ -152,7 +152,7 @@ package actor PhotoRAGOrchestrator {
     /// The implementation fetches asset identifiers on the MainActor, then ingests by identifier only.
     package func syncLibrary(scope: PhotoScope) async throws {
         #if canImport(Photos)
-        let ids: [String] = switch scope {
+        let ids: [PhotoID] = switch scope {
         case .assetIDs(let ids):
             ids
         case .fullLibrary:
@@ -161,10 +161,10 @@ package actor PhotoRAGOrchestrator {
                 opts.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
                 let result = PHAsset.fetchAssets(with: .image, options: opts)
                 if result.count == 0 { return [] }
-                var ids: [String] = []
+                var ids: [PhotoID] = []
                 ids.reserveCapacity(result.count)
                 for index in 0..<result.count {
-                    ids.append(result.object(at: index).localIdentifier)
+                    ids.append(PhotoID(source: .photos, id: result.object(at: index).localIdentifier))
                 }
                 return ids
             }
@@ -176,18 +176,20 @@ package actor PhotoRAGOrchestrator {
         #endif
     }
 
+    #if canImport(Photos)
     /// Convenience wrapper: accepts PHAssets but only passes stable IDs into the actor.
     package nonisolated func ingest(assets: [PHAsset]) async throws {
-        let ids = await MainActor.run { assets.map(\.localIdentifier) }
+        let ids = await MainActor.run { assets.map { PhotoID(source: .photos, id: $0.localIdentifier) } }
         try await self.ingest(assetIDs: ids)
     }
+    #endif
 
-    /// Ingest photos by `PHAsset.localIdentifier`.
+    /// Ingest photos by ``PhotoID``.
     ///
     /// This method enforces offline-only ingestion. If an asset’s bytes are not locally available
     /// (iCloud-only), it is indexed as metadata-only and marked degraded.
-    package func ingest(assetIDs: [String]) async throws {
-        let uniqueAssetIDs = Self.dedupeAssetIDs(assetIDs)
+    package func ingest(assetIDs: [PhotoID]) async throws {
+        let uniqueAssetIDs = Self.dedupePhotoIDs(assetIDs)
         guard !uniqueAssetIDs.isEmpty else { return }
 
         // Throttled concurrency: the actor's executor serializes state mutations, while
@@ -197,17 +199,17 @@ package actor PhotoRAGOrchestrator {
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<concurrency {
-                guard let assetID = iterator.next() else { break }
+                guard let photoID = iterator.next() else { break }
                 group.addTask {
                     try Task.checkCancellation()
-                    try await self.ingestOne(assetID: assetID)
+                    try await self.ingestOne(photoID: photoID)
                 }
             }
             for try await _ in group {
-                if let assetID = iterator.next() {
+                if let photoID = iterator.next() {
                     group.addTask {
                         try Task.checkCancellation()
-                        try await self.ingestOne(assetID: assetID)
+                        try await self.ingestOne(photoID: photoID)
                     }
                 }
             }
@@ -371,18 +373,18 @@ package actor PhotoRAGOrchestrator {
         }
         let rootIdsPicked = picked.map(\.rootId)
 
-        // Resolve asset IDs and derived frame refs.
-        var assetIdByRoot: [UInt64: String] = [:]
-        assetIdByRoot.reserveCapacity(rootIdsPicked.count)
+        // Resolve photo IDs and derived frame refs.
+        var photoIDByRoot: [UInt64: PhotoID] = [:]
+        photoIDByRoot.reserveCapacity(rootIdsPicked.count)
         for rootId in rootIdsPicked {
-            if let cached = index.assetIDByRoot[rootId] {
-                assetIdByRoot[rootId] = cached
+            if let cached = index.photoIDByRoot[rootId] {
+                photoIDByRoot[rootId] = cached
                 continue
             }
             if let meta = rootMetaById[rootId],
                let entries = meta.metadata?.entries,
-               let assetID = entries[MetaKey.assetID] {
-                assetIdByRoot[rootId] = assetID
+               let photoID = Self.photoID(from: entries) {
+                photoIDByRoot[rootId] = photoID
             }
         }
 
@@ -408,7 +410,7 @@ package actor PhotoRAGOrchestrator {
         items.reserveCapacity(picked.count)
 
         for candidate in picked {
-            guard let assetID = assetIdByRoot[candidate.rootId] else { continue }
+            guard let photoID = photoIDByRoot[candidate.rootId] else { continue }
             let refs = index.derivedByRoot[candidate.rootId] ?? DerivedRefs()
 
             let caption = text(from: refs.caption)
@@ -427,7 +429,7 @@ package actor PhotoRAGOrchestrator {
 
             items.append(
                 PhotoRAGItem(
-                    assetID: assetID,
+                    photoID: photoID,
                     score: candidate.score,
                     evidence: candidate.evidence,
                     summaryText: summary,
@@ -462,14 +464,14 @@ package actor PhotoRAGOrchestrator {
             maxRegions: query.contextBudget.maxRegions
         )
 
-        let degradedCount = await degradedResultCount(assetIDs: itemsWithPixels.map(\.assetID))
+        let degradedCount = await degradedResultCount(photoIDs: itemsWithPixels.map(\.photoID))
         let diagnostics = PhotoRAGContext.Diagnostics(usedTextTokens: usedTokens, degradedResultCount: degradedCount)
         return PhotoRAGContext(query: query, items: itemsWithPixels, diagnostics: diagnostics)
     }
 
-    /// Delete all frames associated with a given `PHAsset.localIdentifier`.
-    package func delete(assetID: String) async throws {
-        guard let rootId = index.rootByAssetID[assetID] else { return }
+    /// Delete all frames associated with a given ``PhotoID``.
+    package func delete(photoID: PhotoID) async throws {
+        guard let rootId = index.rootByPhotoID[photoID] else { return }
 
         var toDelete: [UInt64] = [rootId]
         if let refs = index.derivedByRoot[rootId] {
@@ -556,18 +558,19 @@ package actor PhotoRAGOrchestrator {
         }
     }
 
-    private func ingestOne(assetID: String) async throws {
-        guard inFlightAssetIDs.insert(assetID).inserted else { return }
-        defer { inFlightAssetIDs.remove(assetID) }
+    private func ingestOne(photoID: PhotoID) async throws {
+        guard inFlightPhotoIDs.insert(photoID).inserted else { return }
+        defer { inFlightPhotoIDs.remove(photoID) }
 
         #if canImport(Photos)
-        let metadata = try await PhotosAssetMetadata.load(assetID: assetID)
+        let metadata = try await PhotosAssetMetadata.load(photoID: photoID)
+        let resolvedID = metadata.photoID
 
         let captureMs = metadata.captureMs
         let frameTimestampMs = captureMs ?? Int64(Date().timeIntervalSince1970 * 1000)
         let isLocal = metadata.isLocal
         let baseMeta = Self.baseMetadata(
-            assetID: assetID,
+            photoID: resolvedID,
             captureMs: captureMs,
             pipelineVersion: config.pipelineVersion,
             isLocal: isLocal,
@@ -580,7 +583,7 @@ package actor PhotoRAGOrchestrator {
         // If we have a previous root, we supersede it after writing the new root.
         // Note: We intentionally keep old frames for audit/debug; superseded roots (and their children)
         // are filtered out by default in indexing and retrieval.
-        let previousRoot = index.rootByAssetID[assetID]
+        let previousRoot = index.rootByPhotoID[resolvedID]
 
         if !isLocal {
             // Metadata-only ingest
@@ -844,12 +847,12 @@ package actor PhotoRAGOrchestrator {
     }
 
     private func ingestOne(file: PhotoFile) async throws {
-        let assetID = file.id
-        guard inFlightAssetIDs.insert(assetID).inserted else { return }
-        defer { inFlightAssetIDs.remove(assetID) }
+        let photoID = file.id
+        guard inFlightPhotoIDs.insert(photoID).inserted else { return }
+        defer { inFlightPhotoIDs.remove(photoID) }
 
         guard FileManager.default.fileExists(atPath: file.url.path(percentEncoded: false)) else {
-            throw PhotoIngestError.fileMissing(id: assetID, url: file.url)
+            throw PhotoIngestError.fileMissing(id: photoID.id, url: file.url)
         }
 
         let imageData: Data
@@ -876,7 +879,7 @@ package actor PhotoRAGOrchestrator {
             nil
         }
         let metadata = PhotosAssetMetadata.Record(
-            assetID: assetID,
+            photoID: photoID,
             creationDateMs: nil,
             captureMs: captureMs,
             location: location,
@@ -888,7 +891,7 @@ package actor PhotoRAGOrchestrator {
             exif: exif
         )
         let baseMeta = Self.baseMetadata(
-            assetID: assetID,
+            photoID: photoID,
             captureMs: captureMs,
             pipelineVersion: config.pipelineVersion,
             isLocal: true,
@@ -896,10 +899,9 @@ package actor PhotoRAGOrchestrator {
             pixelWidth: originalDimensions.width,
             pixelHeight: originalDimensions.height,
             exif: exif,
-            source: "file",
             fileURL: file.url
         )
-        let previousRoot = index.rootByAssetID[assetID]
+        let previousRoot = index.rootByPhotoID[photoID]
 
         var globalEmbedding = try await embedder.embed(image: embedImage)
         if embedder.normalize, !globalEmbedding.isEmpty {
@@ -1132,7 +1134,7 @@ package actor PhotoRAGOrchestrator {
             guard let kind = meta.kind else { continue }
             if !kind.hasPrefix("photo.") && FrameKind(rawKind: kind) != .photo(.syncState) { continue }
             guard let entries = meta.metadata?.entries,
-                  let assetID = entries[MetaKey.assetID]
+                  let photoID = Self.photoID(from: entries)
             else { continue }
 
             if FrameKind(rawKind: kind) == .photo(.root) {
@@ -1140,8 +1142,8 @@ package actor PhotoRAGOrchestrator {
                     retiredVectorIds.insert(meta.id)
                     continue
                 }
-                next.rootByAssetID[assetID] = meta.id
-                next.assetIDByRoot[meta.id] = assetID
+                next.rootByPhotoID[photoID] = meta.id
+                next.photoIDByRoot[meta.id] = photoID
             }
 
             if let parentId = meta.parentId {
@@ -1296,21 +1298,21 @@ package actor PhotoRAGOrchestrator {
         return [minBin...maxBin]
     }
 
-    static func dedupeAssetIDs(_ assetIDs: [String]) -> [String] {
-        guard assetIDs.count > 1 else { return assetIDs }
-        var seen: Set<String> = []
-        seen.reserveCapacity(assetIDs.count)
-        var unique: [String] = []
-        unique.reserveCapacity(assetIDs.count)
-        for assetID in assetIDs where seen.insert(assetID).inserted {
-            unique.append(assetID)
+    static func dedupePhotoIDs(_ photoIDs: [PhotoID]) -> [PhotoID] {
+        guard photoIDs.count > 1 else { return photoIDs }
+        var seen: Set<PhotoID> = []
+        seen.reserveCapacity(photoIDs.count)
+        var unique: [PhotoID] = []
+        unique.reserveCapacity(photoIDs.count)
+        for photoID in photoIDs where seen.insert(photoID).inserted {
+            unique.append(photoID)
         }
         return unique
     }
 
     static func dedupePhotoFiles(_ files: [PhotoFile]) -> [PhotoFile] {
         guard files.count > 1 else { return files }
-        var seen: Set<String> = []
+        var seen: Set<PhotoID> = []
         seen.reserveCapacity(files.count)
         var unique: [PhotoFile] = []
         unique.reserveCapacity(files.count)
@@ -1318,6 +1320,11 @@ package actor PhotoRAGOrchestrator {
             unique.append(file)
         }
         return unique
+    }
+
+    private static func photoID(from entries: [String: String]) -> PhotoID? {
+        guard let id = entries[MetaKey.assetID] else { return nil }
+        return PhotoID.fromMetadata(id: id, source: entries[MetaKey.source])
     }
 
     private static func locationBin(from meta: [String: String]) -> LocationBin? {
@@ -1435,8 +1442,8 @@ package actor PhotoRAGOrchestrator {
         let thumbCount = min(maxImages, updated.count)
         if config.includeThumbnailsInContext, thumbCount > 0 {
             for index in 0..<thumbCount {
-                let assetID = updated[index].assetID
-                if let pixel = try await loadThumbnail(assetID: assetID) {
+                let photoID = updated[index].photoID
+                if let pixel = try await loadThumbnail(photoID: photoID) {
                     updated[index].thumbnail = pixel
                 }
             }
@@ -1446,12 +1453,12 @@ package actor PhotoRAGOrchestrator {
         if config.includeRegionCropsInContext, maxRegions > 0 {
             var remaining = maxRegions
             for index in 0..<updated.count where remaining > 0 {
-                let assetID = updated[index].assetID
-                guard let rootId = indexStateRootId(for: assetID) else { continue }
+                let photoID = updated[index].photoID
+                guard let rootId = indexStateRootId(for: photoID) else { continue }
                 let matched = rootCandidates.first(where: { $0.rootId == rootId })?.matchedRegions ?? []
                 guard !matched.isEmpty else { continue }
 
-                let source = try await loadRegionSourceImage(assetID: assetID)
+                let source = try await loadRegionSourceImage(photoID: photoID)
                 guard let source else { continue }
 
                 var regions: [PhotoRAGItem.RegionContext] = []
@@ -1475,16 +1482,16 @@ package actor PhotoRAGOrchestrator {
         return updated
     }
 
-    private func indexStateRootId(for assetID: String) -> UInt64? {
-        index.rootByAssetID[assetID]
+    private func indexStateRootId(for photoID: PhotoID) -> UInt64? {
+        index.rootByPhotoID[photoID]
     }
 
-    private func degradedResultCount(assetIDs: [String]) async -> Int {
+    private func degradedResultCount(photoIDs: [PhotoID]) async -> Int {
         var rootIds: [UInt64] = []
-        rootIds.reserveCapacity(assetIDs.count)
+        rootIds.reserveCapacity(photoIDs.count)
         var missingRootCount = 0
-        for assetID in assetIDs {
-            if let rootId = index.rootByAssetID[assetID] {
+        for photoID in photoIDs {
+            if let rootId = index.rootByPhotoID[photoID] {
                 rootIds.append(rootId)
             } else {
                 missingRootCount += 1
@@ -1551,13 +1558,13 @@ package actor PhotoRAGOrchestrator {
         return (rootMetaById, candidates)
     }
 
-    private func buildAssetAllowlist(assetIDs: Set<String>?) -> Set<UInt64>? {
+    private func buildAssetAllowlist(assetIDs: Set<PhotoID>?) -> Set<UInt64>? {
         guard let assetIDs else { return nil }
         var frameIds: Set<UInt64> = []
         frameIds.reserveCapacity(assetIDs.count * 4)
 
-        for assetID in assetIDs {
-            guard let rootId = index.rootByAssetID[assetID] else { continue }
+        for photoID in assetIDs {
+            guard let rootId = index.rootByPhotoID[photoID] else { continue }
             frameIds.insert(rootId)
             if let refs = index.derivedByRoot[rootId] {
                 if let id = refs.ocrSummary { frameIds.insert(id) }
@@ -1613,8 +1620,8 @@ package actor PhotoRAGOrchestrator {
         return true
     }
 
-    private func loadThumbnail(assetID: String) async throws -> PhotoPixel? {
-        if let data = try await localFileImageData(assetID: assetID) {
+    private func loadThumbnail(photoID: PhotoID) async throws -> PhotoPixel? {
+        if let data = try await localFileImageData(photoID: photoID) {
             do {
                 let thumb = try Self.decodeThumbnail(from: data, maxPixelSize: config.thumbnailMaxPixelSize)
                 let encoded = try Self.encodePNG(thumb)
@@ -1625,7 +1632,7 @@ package actor PhotoRAGOrchestrator {
         }
 
         #if canImport(Photos)
-        let data = try await PhotosAssetMetadata.loadImageData(assetID: assetID)
+        let data = try await PhotosAssetMetadata.loadImageData(photoID: photoID)
         guard let data else { return nil }
         let thumb = try Self.decodeThumbnail(from: data, maxPixelSize: config.thumbnailMaxPixelSize)
         let encoded = try Self.encodePNG(thumb)
@@ -1635,8 +1642,8 @@ package actor PhotoRAGOrchestrator {
         #endif
     }
 
-    private func loadRegionSourceImage(assetID: String) async throws -> CGImage? {
-        if let data = try await localFileImageData(assetID: assetID) {
+    private func loadRegionSourceImage(photoID: PhotoID) async throws -> CGImage? {
+        if let data = try await localFileImageData(photoID: photoID) {
             do {
                 return try Self.decodeThumbnail(from: data, maxPixelSize: config.regionCropMaxPixelSize)
             } catch {
@@ -1645,7 +1652,7 @@ package actor PhotoRAGOrchestrator {
         }
 
         #if canImport(Photos)
-        let data = try await PhotosAssetMetadata.loadImageData(assetID: assetID)
+        let data = try await PhotosAssetMetadata.loadImageData(photoID: photoID)
         guard let data else { return nil }
         return try Self.decodeThumbnail(from: data, maxPixelSize: config.regionCropMaxPixelSize)
         #else
@@ -1653,8 +1660,8 @@ package actor PhotoRAGOrchestrator {
         #endif
     }
 
-    private func localFileImageData(assetID: String) async throws -> Data? {
-        guard let rootId = index.rootByAssetID[assetID] else { return nil }
+    private func localFileImageData(photoID: PhotoID) async throws -> Data? {
+        guard let rootId = index.rootByPhotoID[photoID] else { return nil }
         let metas = await wax.frameMetasIncludingPending(frameIds: [rootId])
         guard let meta = metas[rootId],
               meta.metadata?.entries[MetaKey.source] == "file",
@@ -1843,7 +1850,7 @@ package actor PhotoRAGOrchestrator {
     }
 
     private static func baseMetadata(
-        assetID: String,
+        photoID: PhotoID,
         captureMs: Int64?,
         pipelineVersion: String,
         isLocal: Bool,
@@ -1851,12 +1858,11 @@ package actor PhotoRAGOrchestrator {
         pixelWidth: Int,
         pixelHeight: Int,
         exif: PhotosAssetMetadata.EXIF,
-        source: String = "photos",
         fileURL: URL? = nil
     ) -> Metadata {
         var meta = Metadata()
-        meta.entries[MetaKey.assetID] = assetID
-        meta.entries[MetaKey.source] = source
+        meta.entries[MetaKey.assetID] = photoID.id
+        meta.entries[MetaKey.source] = photoID.metadataSource
         if let fileURL {
             meta.entries[MetaKey.fileURL] = fileURL.absoluteString
         }

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -189,7 +189,7 @@ package actor PhotoRAGOrchestrator {
     /// This method enforces offline-only ingestion. If an asset’s bytes are not locally available
     /// (iCloud-only), it is indexed as metadata-only and marked degraded.
     package func ingest(assetIDs: [PhotoID]) async throws {
-        let uniqueAssetIDs = Self.dedupePhotoIDs(assetIDs)
+        let uniqueAssetIDs = Self.photosLibraryIDs(assetIDs)
         guard !uniqueAssetIDs.isEmpty else { return }
 
         // Throttled concurrency: the actor's executor serializes state mutations, while
@@ -559,11 +559,12 @@ package actor PhotoRAGOrchestrator {
     }
 
     private func ingestOne(photoID: PhotoID) async throws {
-        guard inFlightPhotoIDs.insert(photoID).inserted else { return }
-        defer { inFlightPhotoIDs.remove(photoID) }
+        let libraryID = PhotoID(source: .photos, id: photoID.id)
+        guard inFlightPhotoIDs.insert(libraryID).inserted else { return }
+        defer { inFlightPhotoIDs.remove(libraryID) }
 
         #if canImport(Photos)
-        let metadata = try await PhotosAssetMetadata.load(photoID: photoID)
+        let metadata = try await PhotosAssetMetadata.load(photoID: libraryID)
         let resolvedID = metadata.photoID
 
         let captureMs = metadata.captureMs
@@ -1308,6 +1309,11 @@ package actor PhotoRAGOrchestrator {
             unique.append(photoID)
         }
         return unique
+    }
+
+    /// Photos-library ingest seam: wrap `localIdentifier` as ``PhotoID`` with `source: .photos`.
+    static func photosLibraryIDs(_ photoIDs: [PhotoID]) -> [PhotoID] {
+        dedupePhotoIDs(photoIDs.map { PhotoID(source: .photos, id: $0.id) })
     }
 
     static func dedupePhotoFiles(_ files: [PhotoFile]) -> [PhotoFile] {

--- a/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift
@@ -1311,7 +1311,7 @@ package actor PhotoRAGOrchestrator {
         return unique
     }
 
-    /// Photos-library ingest seam: wrap `localIdentifier` as ``PhotoID`` with `source: .photos`.
+    /// Rewrites source to `.photos`, then order-preserving-dedupes.
     static func photosLibraryIDs(_ photoIDs: [PhotoID]) -> [PhotoID] {
         dedupePhotoIDs(photoIDs.map { PhotoID(source: .photos, id: $0.id) })
     }

--- a/Sources/Wax/PhotoRAG/PhotoRAGTypes.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGTypes.swift
@@ -1,5 +1,38 @@
 import Foundation
 
+/// Stable, type-safe identifier for a photo across Photos library and file ingest.
+public struct PhotoID: Sendable, Hashable, Equatable {
+    public enum Source: Sendable, Hashable, Equatable {
+        case photos
+        case file
+    }
+
+    public var source: Source
+    public var id: String
+
+    public init(source: Source, id: String) {
+        self.source = source
+        self.id = id
+    }
+
+    /// Wire value stored in `photo.source`. Persistence stays a string.
+    package var metadataSource: String {
+        switch source {
+        case .photos: PhotoSource.photos.rawValue
+        case .file: PhotoSource.file.rawValue
+        }
+    }
+
+    /// Reconstruct from on-disk metadata. Missing/unknown `photo.source` is `.photos`
+    /// (legacy Photos ingest omitted the key; file ingest always writes `file`).
+    package static func fromMetadata(id: String, source: String?) -> PhotoID? {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let parsed: Source = (source == PhotoSource.file.rawValue) ? .file : .photos
+        return PhotoID(source: parsed, id: trimmed)
+    }
+}
+
 /// Token and image limits for assembled ``PhotoMemory`` recall context.
 public struct PhotoContextBudget: Sendable, Equatable {
     public var maxTextTokens: Int
@@ -24,12 +57,12 @@ public struct PhotoContextBudget: Sendable, Equatable {
 
 /// Optional filters applied during photo recall.
 public struct PhotoFilters: Sendable, Equatable {
-    public var assetIDs: Set<String>?
+    public var assetIDs: Set<PhotoID>?
     public var source: PhotoSource?
     public var isLocal: Bool?
 
     public init(
-        assetIDs: Set<String>? = nil,
+        assetIDs: Set<PhotoID>? = nil,
         source: PhotoSource? = nil,
         isLocal: Bool? = nil
     ) {
@@ -44,9 +77,16 @@ public struct PhotoFilters: Sendable, Equatable {
         assetIDs == nil && source == nil && isLocal == nil
     }
 
-    private static func normalizedNonEmptySet(_ values: Set<String>?) -> Set<String>? {
+    private static func normalizedNonEmptySet(_ values: Set<PhotoID>?) -> Set<PhotoID>? {
         guard let values else { return nil }
-        let normalized = Set(values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty })
+        var normalized: Set<PhotoID> = []
+        normalized.reserveCapacity(values.count)
+        for photoID in values {
+            guard let parsed = PhotoID.fromMetadata(id: photoID.id, source: photoID.metadataSource) else {
+                continue
+            }
+            normalized.insert(parsed)
+        }
         return normalized.isEmpty ? nil : normalized
     }
 }
@@ -87,24 +127,32 @@ public struct PhotoLocationQuery: Sendable, Equatable {
 public enum PhotoScope: Sendable, Equatable {
     /// Sync all photos in the library.
     case fullLibrary
-    /// Sync only the specified asset identifiers.
-    case assetIDs([String])
+    /// Sync only the specified photo identifiers.
+    case assetIDs([PhotoID])
 }
 
 /// A local image file to ingest into ``PhotoMemory``.
 public struct PhotoFile: Sendable, Equatable {
-    /// Stable caller-provided identifier used as the photo asset ID in Wax metadata.
-    public var id: String
+    /// Stable caller-provided identity stored as `photos.asset_id` + `photo.source`.
+    public var id: PhotoID
     /// Local file URL for the image bytes.
     public var url: URL
     /// Optional capture date when no image metadata timestamp is available.
     public var captureDate: Date?
 
-    public init(id: String, url: URL, captureDate: Date? = nil) {
-        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.id = trimmed.isEmpty ? url.standardizedFileURL.absoluteString : trimmed
+    public init(id: PhotoID, url: URL, captureDate: Date? = nil) {
+        let trimmed = id.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.id = PhotoID(
+            source: id.source,
+            id: trimmed.isEmpty ? url.standardizedFileURL.absoluteString : trimmed
+        )
         self.url = url
         self.captureDate = captureDate
+    }
+
+    /// File-ingest convenience. Wraps `id` as ``PhotoID`` with `source: .file`.
+    public init(id: String, url: URL, captureDate: Date? = nil) {
+        self.init(id: PhotoID(source: .file, id: id), url: url, captureDate: captureDate)
     }
 }
 
@@ -238,7 +286,7 @@ public struct PhotoRAGItem: Sendable, Equatable {
         }
     }
 
-    public var assetID: String
+    public var photoID: PhotoID
     public var score: Float
     public var evidence: [Evidence]
     public var summaryText: String
@@ -246,14 +294,14 @@ public struct PhotoRAGItem: Sendable, Equatable {
     public var regions: [RegionContext]
 
     public init(
-        assetID: String,
+        photoID: PhotoID,
         score: Float,
         evidence: [Evidence],
         summaryText: String,
         thumbnail: PhotoPixel? = nil,
         regions: [RegionContext] = []
     ) {
-        self.assetID = assetID
+        self.photoID = photoID
         self.score = score
         self.evidence = evidence
         self.summaryText = summaryText

--- a/Sources/Wax/PhotoRAG/PhotoRAGTypes.swift
+++ b/Sources/Wax/PhotoRAG/PhotoRAGTypes.swift
@@ -142,8 +142,9 @@ public struct PhotoFile: Sendable, Equatable {
 
     public init(id: PhotoID, url: URL, captureDate: Date? = nil) {
         let trimmed = id.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        // File ingest always records source `.file`.
         self.id = PhotoID(
-            source: id.source,
+            source: .file,
             id: trimmed.isEmpty ? url.standardizedFileURL.absoluteString : trimmed
         )
         self.url = url

--- a/Sources/Wax/PhotoRAG/PhotosAssetMetadata.swift
+++ b/Sources/Wax/PhotoRAG/PhotosAssetMetadata.swift
@@ -32,7 +32,7 @@ enum PhotosAssetMetadata {
     }
 
     struct Record: Sendable {
-        var assetID: String
+        var photoID: PhotoID
         var creationDateMs: Int64?
         var captureMs: Int64?
         var location: Location?
@@ -45,11 +45,11 @@ enum PhotosAssetMetadata {
     }
 
     @MainActor
-    static func load(assetID: String) async throws -> Record {
+    static func load(photoID: PhotoID) async throws -> Record {
         #if canImport(Photos)
-        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [assetID], options: nil)
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [photoID.id], options: nil)
         guard let asset = assets.firstObject else {
-            throw WaxError.io("PHAsset not found for id: \(assetID)")
+            throw WaxError.io("PHAsset not found for id: \(photoID.id)")
         }
 
         let (data, isLocal) = try await requestImageData(asset: asset)
@@ -73,7 +73,7 @@ enum PhotosAssetMetadata {
         }()
 
         return Record(
-            assetID: asset.localIdentifier,
+            photoID: PhotoID(source: .photos, id: asset.localIdentifier),
             creationDateMs: creationMs,
             captureMs: captureMs,
             location: location,
@@ -90,9 +90,9 @@ enum PhotosAssetMetadata {
     }
 
     @MainActor
-    static func loadImageData(assetID: String) async throws -> Data? {
+    static func loadImageData(photoID: PhotoID) async throws -> Data? {
         #if canImport(Photos)
-        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [assetID], options: nil)
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [photoID.id], options: nil)
         guard let asset = assets.firstObject else { return nil }
         let (data, isLocal) = try await requestImageData(asset: asset)
         return isLocal ? data : nil

--- a/Sources/Wax/PhotoRAG/PhotosAssetMetadata.swift
+++ b/Sources/Wax/PhotoRAG/PhotosAssetMetadata.swift
@@ -47,6 +47,9 @@ enum PhotosAssetMetadata {
     @MainActor
     static func load(photoID: PhotoID) async throws -> Record {
         #if canImport(Photos)
+        guard photoID.source == .photos else {
+            throw WaxError.io("Photos library load requires PhotoID(source: .photos)")
+        }
         let assets = PHAsset.fetchAssets(withLocalIdentifiers: [photoID.id], options: nil)
         guard let asset = assets.firstObject else {
             throw WaxError.io("PHAsset not found for id: \(photoID.id)")
@@ -92,6 +95,7 @@ enum PhotosAssetMetadata {
     @MainActor
     static func loadImageData(photoID: PhotoID) async throws -> Data? {
         #if canImport(Photos)
+        guard photoID.source == .photos else { return nil }
         let assets = PHAsset.fetchAssets(withLocalIdentifiers: [photoID.id], options: nil)
         guard let asset = assets.firstObject else { return nil }
         let (data, isLocal) = try await requestImageData(asset: asset)

--- a/Tests/WaxIntegrationTests/CoverageGapTests.swift
+++ b/Tests/WaxIntegrationTests/CoverageGapTests.swift
@@ -157,7 +157,7 @@ func photoRAGDeleteRemovesAssetFrames() async throws {
         )
 
         // Delete asset A
-        try await orchestrator.delete(assetID: "A")
+        try await orchestrator.delete(photoID: PhotoID(source: .photos, id: "A"))
 
         // Recall should only find asset B
         let query = PhotoQuery(
@@ -171,31 +171,41 @@ func photoRAGDeleteRemovesAssetFrames() async throws {
         )
 
         let ctx = try await orchestrator.recall(query)
-        let assetIDs = ctx.items.map(\.assetID)
+        let assetIDs = ctx.items.map(\.photoID.id)
         #expect(!assetIDs.contains("A"))
         try await orchestrator.flush()
     }
 }
 
-// MARK: - PhotoRAG dedupeAssetIDs edge cases
+// MARK: - PhotoRAG dedupePhotoIDs edge cases
 
 @Test
 func photoRAGDedupeEmptyArrayReturnsEmpty() {
-    let output = PhotoRAGOrchestrator.dedupeAssetIDs([])
+    let output = PhotoRAGOrchestrator.dedupePhotoIDs([])
     #expect(output.isEmpty)
 }
 
 @Test
 func photoRAGDedupeSingleElementReturnsSame() {
-    let output = PhotoRAGOrchestrator.dedupeAssetIDs(["X"])
-    #expect(output == ["X"])
+    let output = PhotoRAGOrchestrator.dedupePhotoIDs([PhotoID(source: .photos, id: "X")])
+    #expect(output == [PhotoID(source: .photos, id: "X")])
 }
 
 @Test
 func photoRAGDedupePreservesOrderOfFirstOccurrence() {
-    let input = ["C", "A", "B", "A", "C"]
-    let output = PhotoRAGOrchestrator.dedupeAssetIDs(input)
-    #expect(output == ["C", "A", "B"])
+    let input = [
+        PhotoID(source: .photos, id: "C"),
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .photos, id: "B"),
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .photos, id: "C"),
+    ]
+    let output = PhotoRAGOrchestrator.dedupePhotoIDs(input)
+    #expect(output == [
+        PhotoID(source: .photos, id: "C"),
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .photos, id: "B"),
+    ])
 }
 
 // MARK: - VideoRAG segment range calculation

--- a/Tests/WaxIntegrationTests/DocsPasteHarnessTests.swift
+++ b/Tests/WaxIntegrationTests/DocsPasteHarnessTests.swift
@@ -307,6 +307,9 @@ func docsPastePublicAPISkillAndWebsiteNamePhotoVideoFacades() throws {
         #expect(doc.contains("PhotoMemory"), "\(relativePath) must name PhotoMemory")
         #expect(doc.contains("VideoMemory"), "\(relativePath) must name VideoMemory")
         #expect(doc.contains("BuiltInMultimodalEmbeddings"), "\(relativePath) must name BuiltInMultimodalEmbeddings")
+        if relativePath.hasSuffix("public-api.md") {
+            #expect(doc.contains("PhotoID"), "\(relativePath) must name PhotoID")
+        }
         #expect(!doc.contains("wait for a stable public facade"), "\(relativePath)")
         #expect(!doc.contains("wait for a facade"), "\(relativePath)")
     }

--- a/Tests/WaxIntegrationTests/Mocks/FrameBuilders.swift
+++ b/Tests/WaxIntegrationTests/Mocks/FrameBuilders.swift
@@ -7,11 +7,13 @@ import WaxVectorSearch
 enum FrameBuilders {
     static func photoRootMetadata(
         assetID: String,
+        source: PhotoSource = .photos,
         captureMs: Int64 = 1_700_000_000_000,
         isLocal: Bool = true
     ) -> Metadata {
         var metadata = Metadata()
         metadata.entries[PhotoMetadataKey.assetID.rawValue] = assetID
+        metadata.entries[PhotoMetadataKey.source.rawValue] = source.rawValue
         metadata.entries[PhotoMetadataKey.captureMs.rawValue] = String(captureMs)
         metadata.entries[PhotoMetadataKey.isLocal.rawValue] = isLocal ? "true" : "false"
         metadata.entries[PhotoMetadataKey.pipelineVersion.rawValue] = "test"

--- a/Tests/WaxIntegrationTests/PhotoRAGConstraintQueriesTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGConstraintQueriesTests.swift
@@ -86,7 +86,7 @@ func photoRAGTimeOnlyQueryUsesTimelineFallback() async throws {
 
         let ctx = try await orchestrator.recall(query)
         #expect(!ctx.items.isEmpty)
-        #expect(ctx.items.first?.assetID == "B")
+        #expect(ctx.items.first?.photoID.id == "B")
         try await orchestrator.flush()
     }
 }
@@ -169,7 +169,7 @@ func photoRAGLocationOnlyRadiusZeroDoesNotFilterAll() async throws {
 
         let ctx = try await orchestrator.recall(query)
         #expect(!ctx.items.isEmpty)
-        #expect(Set(ctx.items.map(\.assetID)) == ["A", "B"])
+        #expect(Set(ctx.items.map(\.photoID.id)) == ["A", "B"])
         try await orchestrator.flush()
     }
 }
@@ -250,7 +250,7 @@ func photoRAGLocationRadiusAppliesExactDistanceAfterCoarseBin() async throws {
         )
 
         let ctx = try await orchestrator.recall(query)
-        #expect(ctx.items.map(\.assetID) == ["nearby"])
+        #expect(ctx.items.map(\.photoID.id) == ["nearby"])
         try await orchestrator.flush()
     }
 }
@@ -313,7 +313,7 @@ func photoRAGLocationRadiusHandlesAntimeridianBins() async throws {
             )
         )
 
-        #expect(ctx.items.map(\.assetID) == ["across-dateline"])
+        #expect(ctx.items.map(\.photoID.id) == ["across-dateline"])
         try await orchestrator.flush()
     }
 }
@@ -401,17 +401,17 @@ func photoRAGRecallAppliesLocalAvailabilityFilter() async throws {
             )
         )
 
-        #expect(ctx.items.map(\.assetID) == ["local-photo"])
+        #expect(ctx.items.map(\.photoID.id) == ["local-photo"])
 
         let remoteByAssetID = try await orchestrator.recall(
             PhotoQuery(
                 text: "receipt",
-                filters: PhotoFilters(assetIDs: ["icloud-only-photo"]),
+                filters: PhotoFilters(assetIDs: [PhotoID(source: .photos, id: "icloud-only-photo")]),
                 resultLimit: 10,
                 contextBudget: PhotoContextBudget(maxTextTokens: 200, maxImages: 0, maxRegions: 0, maxOCRLinesPerItem: 2)
             )
         )
-        #expect(remoteByAssetID.items.map(\.assetID) == ["icloud-only-photo"])
+        #expect(remoteByAssetID.items.map(\.photoID.id) == ["icloud-only-photo"])
 
         let remoteBySource = try await orchestrator.recall(
             PhotoQuery(
@@ -421,7 +421,7 @@ func photoRAGRecallAppliesLocalAvailabilityFilter() async throws {
                 contextBudget: PhotoContextBudget(maxTextTokens: 200, maxImages: 0, maxRegions: 0, maxOCRLinesPerItem: 2)
             )
         )
-        #expect(remoteBySource.items.map(\.assetID) == ["icloud-only-photo"])
+        #expect(remoteBySource.items.map(\.photoID.id) == ["icloud-only-photo"])
 
         try await orchestrator.flush()
     }
@@ -493,7 +493,7 @@ func photoRAGFilterOnlyRecallScansPastFallbackWindow() async throws {
                 contextBudget: PhotoContextBudget(maxTextTokens: 200, maxImages: 0, maxRegions: 0, maxOCRLinesPerItem: 2)
             )
         )
-        #expect(ctx.items.map(\.assetID) == ["old-file"])
+        #expect(ctx.items.map(\.photoID.id) == ["old-file"])
         try await orchestrator.flush()
     }
 }
@@ -557,13 +557,16 @@ func photoRAGDegradedDiagnosticsUseLocalAvailabilityMetadata() async throws {
 
         let ctx = try await orchestrator.recall(
             PhotoQuery(
-                filters: PhotoFilters(assetIDs: ["local-no-derived", "icloud-only"]),
+                filters: PhotoFilters(assetIDs: [
+                    PhotoID(source: .photos, id: "local-no-derived"),
+                    PhotoID(source: .photos, id: "icloud-only"),
+                ]),
                 resultLimit: 2,
                 contextBudget: PhotoContextBudget(maxTextTokens: 200, maxImages: 0, maxRegions: 0, maxOCRLinesPerItem: 2)
             )
         )
 
-        #expect(Set(ctx.items.map(\.assetID)) == ["local-no-derived", "icloud-only"])
+        #expect(Set(ctx.items.map(\.photoID.id)) == ["local-no-derived", "icloud-only"])
         #expect(ctx.diagnostics.degradedResultCount == 1)
         try await orchestrator.flush()
     }

--- a/Tests/WaxIntegrationTests/PhotoRAGDeleteVectorDurabilityTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGDeleteVectorDurabilityTests.swift
@@ -64,7 +64,7 @@ func photoRAGDeleteRemovesRootVectorFromCommittedVecBytes() async throws {
         #expect(beforeBytes != nil, "setup: committed vec must exist after flush")
         #expect(try photoDeleteCommittedVecFrameIds(from: beforeBytes!).contains(rootId))
 
-        try await orchestrator.delete(assetID: "delete-me")
+        try await orchestrator.delete(photoID: PhotoID(source: .file, id: "delete-me"))
 
         let afterBytes = try await wax.readCommittedVecIndexBytes()
         #expect(afterBytes != nil, "committed vec bytes must be non-nil after delete")

--- a/Tests/WaxIntegrationTests/PhotoRAGFileIngestTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGFileIngestTests.swift
@@ -40,7 +40,7 @@ func photoRAGIngestsLocalImageFilesAndRecallsCaptionMetadata() async throws {
                 contextBudget: PhotoContextBudget(maxTextTokens: 200, maxImages: 0, maxRegions: 0)
             )
         )
-        #expect(context.items.first?.assetID == "local-fixture")
+        #expect(context.items.first?.photoID == PhotoID(source: .file, id: "local-fixture"))
         #expect(context.items.first?.summaryText.contains("local receipt image") == true)
 
         let rootId = try #require(await orchestrator.wax.frameMetas().first {
@@ -128,7 +128,7 @@ func photoRAGLocalFileRecallSurvivesMissingPixelSource() async throws {
                 contextBudget: PhotoContextBudget(maxTextTokens: 200, maxImages: 1, maxRegions: 0)
             )
         )
-        #expect(context.items.first?.assetID == "deleted-file")
+        #expect(context.items.first?.photoID == PhotoID(source: .file, id: "deleted-file"))
         #expect(context.items.first?.thumbnail == nil)
     }
 }

--- a/Tests/WaxIntegrationTests/PhotoRAGIngestDedupeTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGIngestDedupeTests.swift
@@ -2,8 +2,30 @@ import Testing
 @testable import Wax
 
 @Test
-func photoRAGIngestDedupesAssetIDsStably() {
-    let input = ["A", "B", "A", "C", "B", "D", "D"]
-    let output = PhotoRAGOrchestrator.dedupeAssetIDs(input)
-    #expect(output == ["A", "B", "C", "D"])
+func photoRAGIngestDedupesPhotoIDsStably() {
+    let input = [
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .photos, id: "B"),
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .photos, id: "C"),
+        PhotoID(source: .photos, id: "B"),
+        PhotoID(source: .photos, id: "D"),
+        PhotoID(source: .photos, id: "D"),
+    ]
+    let output = PhotoRAGOrchestrator.dedupePhotoIDs(input)
+    #expect(output == [
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .photos, id: "B"),
+        PhotoID(source: .photos, id: "C"),
+        PhotoID(source: .photos, id: "D"),
+    ])
+}
+
+@Test
+func photoRAGIngestDedupeTreatsSourceAsPartOfIdentity() {
+    let mixed = [
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .file, id: "A"),
+    ]
+    #expect(PhotoRAGOrchestrator.dedupePhotoIDs(mixed) == mixed)
 }

--- a/Tests/WaxIntegrationTests/PhotoRAGIngestDedupeTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGIngestDedupeTests.swift
@@ -29,3 +29,17 @@ func photoRAGIngestDedupeTreatsSourceAsPartOfIdentity() {
     ]
     #expect(PhotoRAGOrchestrator.dedupePhotoIDs(mixed) == mixed)
 }
+
+@Test
+func photoLibraryIngestWrapsIdentifiersAsPhotosSourceBeforeDedupe() {
+    let mixed = [
+        PhotoID(source: .file, id: "A"),
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .file, id: "B"),
+        PhotoID(source: .photos, id: "B"),
+    ]
+    #expect(PhotoRAGOrchestrator.photosLibraryIDs(mixed) == [
+        PhotoID(source: .photos, id: "A"),
+        PhotoID(source: .photos, id: "B"),
+    ])
+}

--- a/Tests/WaxIntegrationTests/PhotoRAGOrchestratorTests.swift
+++ b/Tests/WaxIntegrationTests/PhotoRAGOrchestratorTests.swift
@@ -111,7 +111,7 @@ func photoRAGRecallReturnsAssetIDsFromOCR() async throws {
 
         let ctx = try await orchestrator.recall(query)
         #expect(!ctx.items.isEmpty)
-        #expect(ctx.items.first?.assetID == "A")
+        #expect(ctx.items.first?.photoID.id == "A")
         #expect(ctx.items.first?.summaryText.contains("COSTCO") == true)
         try await orchestrator.flush()
     }
@@ -249,7 +249,7 @@ func photoRAGRecallIncludesSearchableTagsFromIndexedFrames() async throws {
 
         let ctx = try await orchestrator.recall(query)
         #expect(!ctx.items.isEmpty)
-        #expect(ctx.items.first?.assetID == "A")
+        #expect(ctx.items.first?.photoID.id == "A")
         #expect(ctx.items.first?.summaryText.contains("Tags:") == true)
         #expect(ctx.items.first?.summaryText.contains("beach, sunset") == true)
 

--- a/Tests/WaxIntegrationTests/RAGConfigClampingTests.swift
+++ b/Tests/WaxIntegrationTests/RAGConfigClampingTests.swift
@@ -110,7 +110,7 @@ private func firstAssetIDForPhotoBlendWeight(_ textEmbeddingWeight: Float) async
         guard let first = result.items.first else {
             throw WaxError.io("Expected at least one PhotoRAG result")
         }
-        return first.assetID
+        return first.photoID.id
     }
 }
 

--- a/Tests/WaxTests/PhotoRAGDocsTests.swift
+++ b/Tests/WaxTests/PhotoRAGDocsTests.swift
@@ -134,10 +134,6 @@ func photoIDMatchesVideoIDShapeInPublicTypes() throws {
     )
 
     #expect(photoTypes.contains("public struct PhotoID: Sendable, Hashable, Equatable"))
-    #expect(photoTypes.contains("public enum Source: Sendable, Hashable, Equatable { case photos, file }")
-        || (photoTypes.contains("public enum Source: Sendable, Hashable, Equatable")
-            && photoTypes.contains("case photos")
-            && photoTypes.contains("case file")))
     #expect(photoTypes.contains("public var source: Source"))
     #expect(photoTypes.contains("public var id: String"))
     #expect(photoTypes.contains("public init(source: Source, id: String)"))
@@ -179,11 +175,8 @@ func photoMemoryDeleteRequiresPhotoIDNotStringOrVideoID() throws {
 
     #expect(photoMemory.contains("public func delete(photoID: PhotoID)"))
     #expect(!photoMemory.contains("public func delete(assetID: String)"))
-    #expect(!photoMemory.contains("func delete(photoID: VideoID)"))
-    #expect(!photoMemory.contains("func delete(videoID:"))
     #expect(orchestrator.contains("package func delete(photoID: PhotoID)"))
     #expect(!orchestrator.contains("package func delete(assetID: String)"))
-    #expect(!orchestrator.contains("func delete(photoID: VideoID)"))
 }
 
 @Test

--- a/Tests/WaxTests/PhotoRAGDocsTests.swift
+++ b/Tests/WaxTests/PhotoRAGDocsTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import Wax
 
 @Test
 func photoRAGDocsDoNotAdvertisePackageOnlyOrchestratorAsPublicAPI() throws {
@@ -82,7 +83,7 @@ func photoRAGPhotosRegionCropFailureDoesNotReturnBeforeSupersede() throws {
         contentsOf: repoRoot.appendingPathComponent("Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift"),
         encoding: .utf8
     )
-    let photosIngestStart = try #require(source.range(of: "private func ingestOne(assetID: String)"))
+    let photosIngestStart = try #require(source.range(of: "private func ingestOne(photoID: PhotoID)"))
     let localIngestStart = try #require(source[photosIngestStart.upperBound...].range(of: "private func ingestOne(file: PhotoFile)"))
     let photosIngestBody = source[photosIngestStart.lowerBound..<localIngestStart.lowerBound]
 
@@ -101,7 +102,7 @@ func photoRAGRegionCropResultsUseCompactCropIndices() throws {
         contentsOf: repoRoot.appendingPathComponent("Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift"),
         encoding: .utf8
     )
-    let photosIngestStart = try #require(source.range(of: "private func ingestOne(assetID: String)"))
+    let photosIngestStart = try #require(source.range(of: "private func ingestOne(photoID: PhotoID)"))
     let localIngestStart = try #require(source[photosIngestStart.upperBound...].range(of: "private func ingestOne(file: PhotoFile)"))
     let localHelperStart = try #require(source[localIngestStart.upperBound...].range(of: "private func writeRegionEmbeddingsIfNeeded"))
     let rebuildIndexStart = try #require(source[localHelperStart.upperBound...].range(of: "private func rebuildIndex"))
@@ -114,6 +115,82 @@ func photoRAGRegionCropResultsUseCompactCropIndices() throws {
         #expect(!regionEmbeddingBody.contains("crops.append((i, crop, region))"))
         #expect(!regionEmbeddingBody.contains("crops.append((index, crop, region))"))
     }
+}
+
+@Test
+func photoIDMatchesVideoIDShapeInPublicTypes() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    let photoTypes = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/PhotoRAG/PhotoRAGTypes.swift"),
+        encoding: .utf8
+    )
+    let videoTypes = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/VideoRAG/VideoRAGTypes.swift"),
+        encoding: .utf8
+    )
+
+    #expect(photoTypes.contains("public struct PhotoID: Sendable, Hashable, Equatable"))
+    #expect(photoTypes.contains("public enum Source: Sendable, Hashable, Equatable { case photos, file }")
+        || (photoTypes.contains("public enum Source: Sendable, Hashable, Equatable")
+            && photoTypes.contains("case photos")
+            && photoTypes.contains("case file")))
+    #expect(photoTypes.contains("public var source: Source"))
+    #expect(photoTypes.contains("public var id: String"))
+    #expect(photoTypes.contains("public init(source: Source, id: String)"))
+
+    #expect(videoTypes.contains("public struct VideoID: Sendable, Hashable, Equatable"))
+    #expect(photoTypes.contains("public var id: PhotoID"))
+    #expect(photoTypes.contains("public var assetIDs: Set<PhotoID>?"))
+    #expect(photoTypes.contains("case assetIDs([PhotoID])"))
+    #expect(photoTypes.contains("public var photoID: PhotoID"))
+
+    let photo = PhotoID(source: .file, id: "receipt-1")
+    let photosLibrary = PhotoID(source: .photos, id: "receipt-1")
+    let video = VideoID(source: .file, id: "receipt-1")
+    #expect(photo != photosLibrary)
+    #expect(photo.id == video.id)
+    #expect(Set([photo, photo]).count == 1)
+}
+
+@Test
+func photoMemoryDeleteRequiresPhotoIDNotStringOrVideoID() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    let photoMemory = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/PhotoRAG/PhotoMemory.swift"),
+        encoding: .utf8
+    )
+    let orchestrator = try String(
+        contentsOf: repoRoot.appendingPathComponent("Sources/Wax/PhotoRAG/PhotoRAGOrchestrator.swift"),
+        encoding: .utf8
+    )
+
+    #expect(photoMemory.contains("public func delete(photoID: PhotoID)"))
+    #expect(!photoMemory.contains("public func delete(assetID: String)"))
+    #expect(orchestrator.contains("package func delete(photoID: PhotoID)"))
+    #expect(!orchestrator.contains("package func delete(assetID: String)"))
+}
+
+@Test
+func publicAPINamesPhotoIDForExperimentalPhotoIdentity() throws {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    let publicAPI = try String(
+        contentsOf: repoRoot.appendingPathComponent("Resources/skills/public/wax/references/public-api.md"),
+        encoding: .utf8
+    )
+    #expect(publicAPI.contains("`PhotoID`"))
+    #expect(publicAPI.contains("PhotoID(source:"))
 }
 
 @Test

--- a/Tests/WaxTests/PhotoRAGDocsTests.swift
+++ b/Tests/WaxTests/PhotoRAGDocsTests.swift
@@ -154,6 +154,11 @@ func photoIDMatchesVideoIDShapeInPublicTypes() throws {
     #expect(photo != photosLibrary)
     #expect(photo.id == video.id)
     #expect(Set([photo, photo]).count == 1)
+
+    let fileURL = URL(fileURLWithPath: "/tmp/receipt-1.png")
+    #expect(PhotoFile(id: photo, url: fileURL).id == photo)
+    #expect(PhotoFile(id: photosLibrary, url: fileURL).id == photo)
+    #expect(PhotoFile(id: "receipt-1", url: fileURL).id == photo)
 }
 
 @Test
@@ -174,8 +179,11 @@ func photoMemoryDeleteRequiresPhotoIDNotStringOrVideoID() throws {
 
     #expect(photoMemory.contains("public func delete(photoID: PhotoID)"))
     #expect(!photoMemory.contains("public func delete(assetID: String)"))
+    #expect(!photoMemory.contains("func delete(photoID: VideoID)"))
+    #expect(!photoMemory.contains("func delete(videoID:"))
     #expect(orchestrator.contains("package func delete(photoID: PhotoID)"))
     #expect(!orchestrator.contains("package func delete(assetID: String)"))
+    #expect(!orchestrator.contains("func delete(photoID: VideoID)"))
 }
 
 @Test

--- a/Tests/WaxTests/VectorSearchDocsTests.swift
+++ b/Tests/WaxTests/VectorSearchDocsTests.swift
@@ -125,6 +125,7 @@ func publicAPINamesBuiltInMultimodalEmbeddingsForPhotoVideoFacades() throws {
     )
     #expect(publicAPI.contains("PhotoMemory"))
     #expect(publicAPI.contains("VideoMemory"))
+    #expect(publicAPI.contains("PhotoID"))
     #expect(publicAPI.contains("BuiltInMultimodalEmbeddings"))
     #expect(publicAPI.contains("BuiltInMultimodalEmbeddings.make"))
     #expect(!publicAPI.contains("wait for a facade"))


### PR DESCRIPTION
Photo asset identity was `String` while video already had `VideoID` (`source` + `id`). This ticket adds experimental public `PhotoID` and uses it on ingest, filters, and `PhotoMemory.delete`. On-disk metadata stays strings. Photos `localIdentifier` is wrapped at the Photos seam.

Stacked on T1 (`arch/2b047d4d/T1`, #201).

**Ticket:** T3 (type-system architecture)
**Reviews:** `swift-adversarial-pr-review` (fix pass + final pass, both APPROVE)
**Proof:** `swift test --filter PhotoRAGDocsTests` / `DocsPasteHarnessTests`
**Migration:** experimental PhotoMemory API — `delete(photoID:)`, `PhotoFile.id: PhotoID`.

Replaces #203 (closed when #201 deleted its T1 base). Rebased onto main after #201/#202.