### PR TITLE
Default embedQuery and batch on EmbeddingProvider

### DIFF
--- a/Sources/Wax/Embeddings/BuiltInMultimodalEmbeddings.swift
+++ b/Sources/Wax/Embeddings/BuiltInMultimodalEmbeddings.swift
@@ -58,6 +58,10 @@ package struct TextBridgedMultimodalEmbedder: MultimodalEmbeddingProvider, Senda
         try await base.embed(text)
     }
 
+    package func embedQuery(text: String) async throws -> [Float] {
+        try await base.embedQuery(text)
+    }
+
     package func embed(image: CGImage) async throws -> [Float] {
         let description = await Self.describe(image: image)
         return try await base.embed(description)

--- a/Sources/Wax/Embeddings/MemoryBindingCompatibility.swift
+++ b/Sources/Wax/Embeddings/MemoryBindingCompatibility.swift
@@ -27,13 +27,19 @@ enum MemoryBindingCompatibility {
            expected != actual {
             return "provider expected '\(expected)' got '\(actual)'"
         }
-        if let expected = binding.embeddingModel,
-           let actual = identity.model,
-           canonicalModel(expected) != canonicalModel(actual) {
-            return "model expected '\(expected)' got '\(actual)'"
+        if let expected = binding.embeddingModel {
+            guard let actual = identity.model else {
+                return "model expected '\(expected)' got nil"
+            }
+            if canonicalModel(expected) != canonicalModel(actual) {
+                return "model expected '\(expected)' got '\(actual)'"
+            }
         }
         if let expected = binding.embeddingDimensions {
-            guard let actual = identity.dimensions.flatMap({ UInt32(exactly: $0) }) else {
+            guard let raw = identity.dimensions else {
+                return "dimensions expected \(expected) got nil"
+            }
+            guard let actual = UInt32(exactly: raw) else {
                 return "dimensions could not be represented as UInt32"
             }
             if expected != actual {

--- a/Sources/Wax/MultimodalEmbeddingProvider.swift
+++ b/Sources/Wax/MultimodalEmbeddingProvider.swift
@@ -20,6 +20,8 @@ public protocol MultimodalEmbeddingProvider: Sendable {
 
     /// Compute a text embedding in the same space as image embeddings.
     func embed(text: String) async throws -> [Float]
+    /// Retrieval-optimized text embedding. Default calls ``embed(text:)``.
+    func embedQuery(text: String) async throws -> [Float]
     /// Compute an image embedding in the same space as text embeddings.
     func embed(image: CGImage) async throws -> [Float]
 }
@@ -31,6 +33,10 @@ extension MultimodalEmbeddingProvider {
     /// Provide an explicit `executionMode` property on your conformance.
     @available(*, deprecated, message: "Provide an explicit 'executionMode' on your MultimodalEmbeddingProvider conformance.")
     public var executionMode: ProviderExecutionMode { .onDeviceOnly }
+
+    public func embedQuery(text: String) async throws -> [Float] {
+        try await embed(text: text)
+    }
 }
 
 #endif // canImport(ImageIO)

--- a/Sources/Wax/MultimodalEmbeddingProvider.swift
+++ b/Sources/Wax/MultimodalEmbeddingProvider.swift
@@ -26,6 +26,12 @@ public protocol MultimodalEmbeddingProvider: Sendable {
     func embed(image: CGImage) async throws -> [Float]
 }
 
+extension MultimodalEmbeddingProvider {
+    public func embedQuery(text: String) async throws -> [Float] {
+        try await embed(text: text)
+    }
+}
+
 // MARK: - Deprecated Default (migration aid)
 
 extension MultimodalEmbeddingProvider {
@@ -33,10 +39,6 @@ extension MultimodalEmbeddingProvider {
     /// Provide an explicit `executionMode` property on your conformance.
     @available(*, deprecated, message: "Provide an explicit 'executionMode' on your MultimodalEmbeddingProvider conformance.")
     public var executionMode: ProviderExecutionMode { .onDeviceOnly }
-
-    public func embedQuery(text: String) async throws -> [Float] {
-        try await embed(text: text)
-    }
 }
 
 #endif // canImport(ImageIO)

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -30,16 +30,6 @@ package actor MemoryOrchestrator {
         case always
     }
 
-    /// Provider captured at attach. Ingest uses ``EmbeddingProvider/embed(batch:)``;
-    /// query uses ``EmbeddingProvider/embedQuery`` so Arctic prefixes survive erasure.
-    private struct AttachedEmbedder: Sendable {
-        let provider: any EmbeddingProvider
-
-        init(provider: any EmbeddingProvider) {
-            self.provider = provider
-        }
-    }
-
     /// Total lifecycle of the embedding provider. Replaces the former
     /// `(embedder?, embeddingStatus, text-only-write flag)` triple so illegal
     /// combinations are unrepresentable.
@@ -49,7 +39,7 @@ package actor MemoryOrchestrator {
         /// without vectors while waiting, forcing the first attach to report degraded.
         case loading(wroteTextOnly: Bool)
         case ready(
-            attached: AttachedEmbedder,
+            attached: any EmbeddingProvider,
             degradedReason: String?
         )
         case unavailable(reason: String)
@@ -268,9 +258,9 @@ package actor MemoryOrchestrator {
             .loading
         case .ready(let attached, let degradedReason):
             if let degradedReason {
-                .degraded(attached.provider.identity, reason: degradedReason)
+                .degraded(attached.identity, reason: degradedReason)
             } else {
-                .active(attached.provider.identity)
+                .active(attached.identity)
             }
         case .unavailable(let reason):
             .unavailable(reason: reason)
@@ -279,7 +269,9 @@ package actor MemoryOrchestrator {
 
     /// Atomic snapshot of the ready provider so a concurrent attach cannot
     /// pair one generation's provider with another's.
-    private var readyEmbedderSnapshot: AttachedEmbedder? {
+    /// Ingest uses ``EmbeddingProvider/embed(batch:)``; query uses
+    /// ``EmbeddingProvider/embedQuery`` so Arctic prefixes survive erasure.
+    private var readyEmbedderSnapshot: (any EmbeddingProvider)? {
         if case .ready(let attached, _) = embedderLifecycle {
             return attached
         }
@@ -397,7 +389,7 @@ package actor MemoryOrchestrator {
             )
         } else if let embedder {
             lifecycle = .ready(
-                attached: AttachedEmbedder(provider: embedder),
+                attached: embedder,
                 degradedReason: nil
             )
         } else if resolvedConfig.enableVectorSearch {
@@ -498,7 +490,7 @@ package actor MemoryOrchestrator {
         degradedReason: String?
     ) -> EmbedderLifecycle {
         guard let provider else { return .unavailable(reason: "no embedding provider") }
-        return .ready(attached: AttachedEmbedder(provider: provider), degradedReason: degradedReason)
+        return .ready(attached: provider, degradedReason: degradedReason)
     }
 
 
@@ -538,7 +530,7 @@ package actor MemoryOrchestrator {
         let contentHash = ContentHasher.hash(contentData).hexString
         let chunks = await TextChunker.chunk(text: content, strategy: config.chunking)
         let attached = readyEmbedderSnapshot
-        let localEmbedder = attached?.provider
+        let localEmbedder = attached
 
         var docMeta = Metadata(metadata)
         docMeta.entries[Self.contentHashMetadataKey] = contentHash
@@ -852,7 +844,7 @@ package actor MemoryOrchestrator {
                 guard let attached = readyEmbedderSnapshot else {
                     throw WaxError.missingEmbedder
                 }
-                let localEmbedder = attached.provider
+                let localEmbedder = attached
                 let embedding = try await Self.embedOne(
                     text,
                     attached: attached,
@@ -995,14 +987,14 @@ package actor MemoryOrchestrator {
     /// Minimizes cache lookups and maximizes batch embedding efficiency.
     private static func prepareEmbeddingsBatchOptimized(
         chunks: [String],
-        attached: AttachedEmbedder,
+        attached: any EmbeddingProvider,
         cache: EmbeddingMemoizer?,
         timeout: Duration? = nil
     ) async throws -> [[Float]] {
 #if DEBUG
         Self._recordBatchPreparationPathCallForTests()
 #endif
-        let embedder = attached.provider
+        let embedder = attached
         var results: [[Float]] = Array(repeating: [], count: chunks.count)
         let cacheKeys: [UInt64]? = if cache != nil {
             chunks.map {
@@ -1081,7 +1073,7 @@ package actor MemoryOrchestrator {
     /// Legacy method for backward compatibility
     private static func prepareEmbeddingsBatch(
         chunks: [String],
-        attached: AttachedEmbedder,
+        attached: any EmbeddingProvider,
         cache: EmbeddingMemoizer?,
         timeout: Duration? = nil
     ) async throws -> [[Float]] {
@@ -1384,7 +1376,7 @@ package actor MemoryOrchestrator {
         guard config.enableVectorSearch, let attached = readyEmbedderSnapshot else {
             throw WaxError.missingEmbedder
         }
-        let embedder = attached.provider
+        let embedder = attached
 
         let missing = try await embeddingBackfillStoreMutex.withLock { [self] in
             try Task.checkCancellation()
@@ -2420,7 +2412,7 @@ package actor MemoryOrchestrator {
         }
         guard !isClosed else { return }
         embedderLifecycle = .ready(
-            attached: AttachedEmbedder(provider: provider),
+            attached: provider,
             degradedReason: lacksVectors ? "some saved frames have no vectors" : nil
         )
         finishReadinessWaiters()
@@ -2484,7 +2476,7 @@ package actor MemoryOrchestrator {
     private func queryEmbeddingResult(
         for query: String,
         policy: QueryEmbeddingPolicy,
-        attached: AttachedEmbedder?
+        attached: (any EmbeddingProvider)?
     ) async throws -> QueryEmbeddingResult {
         switch policy {
         case .never:
@@ -2552,12 +2544,12 @@ package actor MemoryOrchestrator {
 
     private static func embedOne(
         _ text: String,
-        attached: AttachedEmbedder,
+        attached: any EmbeddingProvider,
         cache: EmbeddingMemoizer?,
         timeout: Duration? = nil,
         isQuery: Bool = false
     ) async throws -> [Float] {
-        let embedder = attached.provider
+        let embedder = attached
         let key = EmbeddingKey.make(
             text: text,
             identity: embedder.identity,
@@ -2602,10 +2594,10 @@ package actor MemoryOrchestrator {
 
     private static func prepareEmbeddings(
         chunks: [String],
-        attached: AttachedEmbedder,
+        attached: any EmbeddingProvider,
         cache: EmbeddingMemoizer?
     ) async throws -> [Int: [Float]] {
-        let embedder = attached.provider
+        let embedder = attached
         var out: [Int: [Float]] = [:]
         out.reserveCapacity(chunks.count)
 

--- a/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
+++ b/Sources/Wax/Orchestrator/MemoryOrchestrator.swift
@@ -30,16 +30,13 @@ package actor MemoryOrchestrator {
         case always
     }
 
-    /// Provider plus refined batch/query existentials, probed once at attach.
+    /// Provider captured at attach. Ingest uses ``EmbeddingProvider/embed(batch:)``;
+    /// query uses ``EmbeddingProvider/embedQuery`` so Arctic prefixes survive erasure.
     private struct AttachedEmbedder: Sendable {
         let provider: any EmbeddingProvider
-        let batch: (any BatchEmbeddingProvider)?
-        let queryAware: (any QueryAwareEmbeddingProvider)?
 
         init(provider: any EmbeddingProvider) {
             self.provider = provider
-            self.batch = provider as? BatchEmbeddingProvider
-            self.queryAware = provider as? QueryAwareEmbeddingProvider
         }
     }
 
@@ -280,8 +277,8 @@ package actor MemoryOrchestrator {
         }
     }
 
-    /// Atomic snapshot of the ready provider and its attach-time refined existentials,
-    /// so a concurrent attach cannot pair one generation's provider with another's.
+    /// Atomic snapshot of the ready provider so a concurrent attach cannot
+    /// pair one generation's provider with another's.
     private var readyEmbedderSnapshot: AttachedEmbedder? {
         if case .ready(let attached, _) = embedderLifecycle {
             return attached
@@ -1039,36 +1036,16 @@ package actor MemoryOrchestrator {
             missingTexts = chunks
         }
 
-        // Compute missing embeddings using batch API when available
         if !missingTexts.isEmpty {
             let vectors: [[Float]]
             let textsToEmbed = missingTexts // let-bind for @Sendable capture
 
-            // Prefer batch embedding for significantly better throughput
-            if let batchEmbedder = attached.batch {
-                if let timeout {
-                    vectors = try await AsyncTimeout.run(timeout: timeout, operation: "batch ingest embed") {
-                        try await batchEmbedder.embed(batch: textsToEmbed)
-                    }
-                } else {
-                    vectors = try await batchEmbedder.embed(batch: textsToEmbed)
+            if let timeout {
+                vectors = try await AsyncTimeout.run(timeout: timeout, operation: "batch ingest embed") {
+                    try await embedder.embed(batch: textsToEmbed)
                 }
             } else {
-                var sequentialVectors: [[Float]] = []
-                sequentialVectors.reserveCapacity(textsToEmbed.count)
-                for text in textsToEmbed {
-                    let vector: [Float]
-                    if let timeout {
-                        let textCopy = text
-                        vector = try await AsyncTimeout.run(timeout: timeout, operation: "ingest embed") {
-                            try await embedder.embed(textCopy)
-                        }
-                    } else {
-                        vector = try await embedder.embed(text)
-                    }
-                    sequentialVectors.append(vector)
-                }
-                vectors = sequentialVectors
+                vectors = try await embedder.embed(batch: textsToEmbed)
             }
 
             guard vectors.count == missingIndices.count else {
@@ -2581,31 +2558,40 @@ package actor MemoryOrchestrator {
         isQuery: Bool = false
     ) async throws -> [Float] {
         let embedder = attached.provider
-        let queryAware = isQuery ? attached.queryAware : nil
-        let useQueryEmbed = queryAware != nil
         let key = EmbeddingKey.make(
             text: text,
             identity: embedder.identity,
             dimensions: embedder.dimensions,
             normalized: embedder.normalize,
-            queryAware: useQueryEmbed
+            queryAware: isQuery
         )
         if let cached = await cache?.get(key) {
             return cached
         }
 
+        let produce: @Sendable () async throws -> [Float] = {
+            if isQuery {
+                return try await embedder.embedQuery(text)
+            }
+            let vectors = try await embedder.embed(batch: [text])
+            guard vectors.count == 1, let vector = vectors.first else {
+                throw WaxError.encodingError(
+                    reason: "batch embedding returned \(vectors.count) vectors for 1 inputs"
+                )
+            }
+            return vector
+        }
+
         var vector: [Float]
         if let timeout {
-            vector = try await AsyncTimeout.run(timeout: timeout, operation: "embedder.embed") {
-                if let queryAware {
-                    return try await queryAware.embedQuery(text)
-                }
-                return try await embedder.embed(text)
+            vector = try await AsyncTimeout.run(
+                timeout: timeout,
+                operation: isQuery ? "embedder.embedQuery" : "batch ingest embed"
+            ) {
+                try await produce()
             }
-        } else if let queryAware {
-            vector = try await queryAware.embedQuery(text)
         } else {
-            vector = try await embedder.embed(text)
+            vector = try await produce()
         }
         if embedder.normalize {
             vector = normalizedL2(vector)
@@ -2647,35 +2633,23 @@ package actor MemoryOrchestrator {
             return out
         }
 
-        if let batch = attached.batch {
-            let vectors = try await batch.embed(batch: missingTexts)
-            guard vectors.count == missingTexts.count else {
-                throw WaxError.io("batch embedding count mismatch: expected \(missingTexts.count), got \(vectors.count)")
+        let vectors = try await embedder.embed(batch: missingTexts)
+        guard vectors.count == missingTexts.count else {
+            throw WaxError.io("batch embedding count mismatch: expected \(missingTexts.count), got \(vectors.count)")
+        }
+        for (position, idx) in missingIndices.enumerated() {
+            var vector = vectors[position]
+            if embedder.normalize {
+                vector = normalizedL2(vector)
             }
-            for (position, idx) in missingIndices.enumerated() {
-                var vector = vectors[position]
-                if embedder.normalize {
-                    vector = normalizedL2(vector)
-                }
-                out[idx] = vector
-                let key = EmbeddingKey.make(
-                    text: chunks[idx],
-                    identity: embedder.identity,
-                    dimensions: embedder.dimensions,
-                    normalized: embedder.normalize
-                )
-                await cache?.set(key, value: vector)
-            }
-        } else {
-            for (position, idx) in missingIndices.enumerated() {
-                let chunk = missingTexts[position]
-                let vector = try await embedOne(
-                    chunk,
-                    attached: attached,
-                    cache: cache
-                )
-                out[idx] = vector
-            }
+            out[idx] = vector
+            let key = EmbeddingKey.make(
+                text: chunks[idx],
+                identity: embedder.identity,
+                dimensions: embedder.dimensions,
+                normalized: embedder.normalize
+            )
+            await cache?.set(key, value: vector)
         }
 
         return out

--- a/Sources/WaxVectorSearch/Embeddings/EmbeddingProvider.swift
+++ b/Sources/WaxVectorSearch/Embeddings/EmbeddingProvider.swift
@@ -14,10 +14,27 @@ public protocol EmbeddingProvider: Sendable {
     var identity: EmbeddingIdentity? { get }
     var executionMode: ProviderExecutionMode { get }
     func embed(_ text: String) async throws -> [Float]
+    /// Retrieval-optimized query embedding. Default calls ``embed(_:)``.
+    func embedQuery(_ text: String) async throws -> [Float]
+    /// Batch embedding. Default maps ``embed(_:)`` sequentially.
+    func embed(batch texts: [String]) async throws -> [[Float]]
 }
 
 public extension EmbeddingProvider {
     var executionMode: ProviderExecutionMode { .onDeviceOnly }
+
+    func embedQuery(_ text: String) async throws -> [Float] {
+        try await embed(text)
+    }
+
+    func embed(batch texts: [String]) async throws -> [[Float]] {
+        var vectors: [[Float]] = []
+        vectors.reserveCapacity(texts.count)
+        for text in texts {
+            vectors.append(try await embed(text))
+        }
+        return vectors
+    }
 }
 
 public protocol BatchEmbeddingProvider: EmbeddingProvider {

--- a/Sources/WaxVectorSearch/Embeddings/EmbeddingProvider.swift
+++ b/Sources/WaxVectorSearch/Embeddings/EmbeddingProvider.swift
@@ -31,6 +31,7 @@ public extension EmbeddingProvider {
         var vectors: [[Float]] = []
         vectors.reserveCapacity(texts.count)
         for text in texts {
+            try Task.checkCancellation()
             vectors.append(try await embed(text))
         }
         return vectors

--- a/Tests/WaxArcticTests/QueryAwareEmbeddingTests.swift
+++ b/Tests/WaxArcticTests/QueryAwareEmbeddingTests.swift
@@ -1,8 +1,68 @@
-#if canImport(CoreML)
-import CoreML
 import Foundation
 import Testing
 import WaxVectorSearch
+
+/// Query/batch defaults on `EmbeddingProvider` dispatch through `any EmbeddingProvider`.
+struct QueryAwareEmbeddingProtocolTests {
+    @Test
+    func queryOverrideDispatchesThroughAnyEmbeddingProvider() async throws {
+        let erased: any EmbeddingProvider = PrefixQueryEmbedder()
+        let text = "How does photosynthesis work?"
+        let document = try await erased.embed(text)
+        let query = try await erased.embedQuery(text)
+        #expect(document != query)
+        #expect(document.count == query.count)
+    }
+
+    @Test
+    func defaultEmbedQueryMatchesEmbed() async throws {
+        let erased: any EmbeddingProvider = PlainCountEmbedder()
+        let text = "Simple test sentence"
+        let document = try await erased.embed(text)
+        let query = try await erased.embedQuery(text)
+        #expect(document == query)
+    }
+
+    @Test
+    func defaultBatchEmbedMapsSingleEmbed() async throws {
+        let erased: any EmbeddingProvider = PlainCountEmbedder()
+        let texts = ["a", "bb", "ccc"]
+        let batch = try await erased.embed(batch: texts)
+        var mapped: [[Float]] = []
+        mapped.reserveCapacity(texts.count)
+        for text in texts {
+            mapped.append(try await erased.embed(text))
+        }
+        #expect(batch == mapped)
+    }
+}
+
+private struct PrefixQueryEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 2
+    let normalize = false
+    let identity: EmbeddingIdentity? = nil
+
+    func embed(_ text: String) async throws -> [Float] {
+        [Float(text.utf8.count), 1]
+    }
+
+    func embedQuery(_ text: String) async throws -> [Float] {
+        try await embed("query: " + text)
+    }
+}
+
+private struct PlainCountEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 2
+    let normalize = false
+    let identity: EmbeddingIdentity? = nil
+
+    func embed(_ text: String) async throws -> [Float] {
+        [Float(text.utf8.count), 0]
+    }
+}
+
+#if canImport(CoreML)
+import CoreML
 @testable import WaxVectorSearchMiniLM
 @testable import WaxVectorSearchArctic
 

--- a/Tests/WaxArcticTests/QueryAwareEmbeddingTests.swift
+++ b/Tests/WaxArcticTests/QueryAwareEmbeddingTests.swift
@@ -35,6 +35,19 @@ struct QueryAwareEmbeddingProtocolTests {
         }
         #expect(batch == mapped)
     }
+
+    @Test
+    func defaultBatchEmbedChecksCancellationBetweenItems() async {
+        let erased: any EmbeddingProvider = CancellationIgnoringEmbedder()
+        let task = Task {
+            try await erased.embed(batch: ["a", "b", "c", "d"])
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
 }
 
 private struct PrefixQueryEmbedder: EmbeddingProvider, Sendable {
@@ -58,6 +71,20 @@ private struct PlainCountEmbedder: EmbeddingProvider, Sendable {
 
     func embed(_ text: String) async throws -> [Float] {
         [Float(text.utf8.count), 0]
+    }
+}
+
+/// `embed(_:)` swallows cancellation so only the protocol default's
+/// `Task.checkCancellation()` can abort the sequential batch loop.
+private struct CancellationIgnoringEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 2
+    let normalize = false
+    let identity: EmbeddingIdentity? = nil
+
+    func embed(_ text: String) async throws -> [Float] {
+        _ = text
+        try? await Task.sleep(for: .milliseconds(50))
+        return [1, 0]
     }
 }
 

--- a/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
+++ b/Tests/WaxIntegrationTests/MemoryOrchestratorTests.swift
@@ -225,7 +225,8 @@ func memoryOrchestratorQueryAwareProviderUsesEmbedQueryOnRecall() async throws {
         )
 
         let embedder = RecordingQueryAwareEmbedder()
-        let orchestrator = try await MemoryOrchestrator(at: url, config: config, embedder: embedder)
+        let erased: any EmbeddingProvider = embedder
+        let orchestrator = try await MemoryOrchestrator(at: url, config: config, embedder: erased)
         try await orchestrator.remember("Swift concurrency uses actors and tasks.")
         try await orchestrator.flush()
 
@@ -242,6 +243,117 @@ func memoryOrchestratorQueryAwareProviderUsesEmbedQueryOnRecall() async throws {
         try await orchestrator.close()
     }
 }
+
+@Test
+func memoryOrchestratorErasedQueryOverrideUsesEmbedQueryWithoutQueryAwareConformance() async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = true
+        config.enableTextSearch = false
+        config.chunking = .tokenCount(targetTokens: 10, overlapTokens: 2)
+        config.rag = FastRAGConfig(
+            maxContextTokens: 80,
+            expansionMaxTokens: 30,
+            snippetMaxTokens: 15,
+            maxSnippets: 10,
+            searchTopK: 25,
+            searchMode: .vectorOnly
+        )
+
+        let embedder = RecordingPrefixQueryEmbedder()
+        let erased: any EmbeddingProvider = embedder
+        let orchestrator = try await MemoryOrchestrator(at: url, config: config, embedder: erased)
+        try await orchestrator.remember("Swift concurrency uses actors and tasks.")
+        try await orchestrator.flush()
+
+        let ingestEmbeds = await embedder.embedCallCount
+        #expect(ingestEmbeds == 0)
+        #expect(await embedder.embedQueryCallCount == 0)
+        #expect(await embedder.batches.count >= 1)
+
+        let ctx = try await orchestrator.recall(query: "Swift concurrency uses actors and tasks.")
+        #expect(!ctx.items.isEmpty)
+        #expect(await embedder.embedQueryCallCount == 1)
+        #expect(await embedder.embedCallCount == ingestEmbeds)
+
+        try await orchestrator.close()
+    }
+}
+
+struct IncompleteIdentityCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let identity: EmbeddingIdentity
+    let expectedNeedle: String
+
+    var testDescription: String { name }
+}
+
+@Test(arguments: [
+    IncompleteIdentityCase(
+        name: "nil model",
+        identity: EmbeddingIdentity(
+            provider: "Test",
+            model: nil,
+            dimensions: 2,
+            normalized: true
+        ),
+        expectedNeedle: "model"
+    ),
+    IncompleteIdentityCase(
+        name: "nil dimensions",
+        identity: EmbeddingIdentity(
+            provider: "Test",
+            model: "Deterministic",
+            dimensions: nil,
+            normalized: true
+        ),
+        expectedNeedle: "dimensions"
+    ),
+])
+func memoryOrchestratorIncompleteIdentityMismatchesWhenBindingHasField(
+    testCase: IncompleteIdentityCase
+) async throws {
+    try await TempFiles.withTempFile { url in
+        var config = OrchestratorConfig.default
+        config.enableVectorSearch = true
+        config.enableTextSearch = true
+        config.chunking = .tokenCount(targetTokens: 10, overlapTokens: 2)
+
+        let writer = try await MemoryOrchestrator(at: url, config: config, embedder: TestEmbedder())
+        try await writer.remember("Persist a complete embedding identity on the store.")
+        try await writer.flush()
+        try await writer.close()
+
+        let incomplete = ConfigurableIdentityEmbedder(identity: testCase.identity)
+        do {
+            _ = try await MemoryOrchestrator(at: url, config: config, embedder: incomplete)
+            Issue.record("expected memory binding mismatch for \(testCase.name)")
+        } catch let error as WaxError {
+            guard case .io(let reason) = error else {
+                Issue.record("Wrong WaxError case: \(error)")
+                return
+            }
+            #expect(reason.contains("memory binding"))
+            #expect(reason.contains(testCase.expectedNeedle))
+        } catch {
+            Issue.record("Wrong error: \(error)")
+        }
+    }
+}
+
+#if canImport(ImageIO)
+@Test
+func textBridgedMultimodalUsesBaseEmbedQueryForQueriesAndEmbedForIngest() async throws {
+    let base = RecordingPrefixQueryEmbedder()
+    let bridged = TextBridgedMultimodalEmbedder(base: base)
+    _ = try await bridged.embed(text: "image labels: receipt")
+    #expect(await base.embedCallCount == 1)
+    #expect(await base.embedQueryCallCount == 0)
+    _ = try await bridged.embedQuery(text: "coffee receipt")
+    #expect(await base.embedQueryCallCount == 1)
+    #expect(await base.embedCallCount == 1)
+}
+#endif
 
 @Test
 func memoryOrchestratorReopenVectorSearchWithoutEmbedderAllowsRecallWithEmbedding() async throws {

--- a/Tests/WaxIntegrationTests/Mocks/MockEmbedders.swift
+++ b/Tests/WaxIntegrationTests/Mocks/MockEmbedders.swift
@@ -55,6 +55,67 @@ final class WrongCountBatchEmbedder: BatchEmbeddingProvider, @unchecked Sendable
     }
 }
 
+/// Query-aware provider that does not conform to `QueryAwareEmbeddingProvider`.
+/// Used to prove `embedQuery` dispatches through `any EmbeddingProvider`.
+actor RecordingPrefixQueryEmbedder: EmbeddingProvider {
+    let dimensions: Int = 2
+    let normalize: Bool = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "Test",
+        model: "PrefixQuery",
+        dimensions: 2,
+        normalized: true
+    )
+
+    private(set) var embedCallCount = 0
+    private(set) var embedQueryCallCount = 0
+    private(set) var batches: [[String]] = []
+
+    func embed(_ text: String) async throws -> [Float] {
+        embedCallCount += 1
+        return Self.vector(for: text, query: false)
+    }
+
+    func embedQuery(_ text: String) async throws -> [Float] {
+        embedQueryCallCount += 1
+        return Self.vector(for: text, query: true)
+    }
+
+    func embed(batch texts: [String]) async throws -> [[Float]] {
+        batches.append(texts)
+        return texts.map { Self.vector(for: $0, query: false) }
+    }
+
+    private static func vector(for text: String, query: Bool) -> [Float] {
+        let a = Float(text.utf8.count % 97) / 97.0
+        let b = Float(text.unicodeScalars.count % 89) / 89.0
+        let offset: Float = query ? 0.01 : 0
+        return VectorMath.normalizeL2([a + offset, b])
+    }
+}
+
+struct ConfigurableIdentityEmbedder: EmbeddingProvider, Sendable {
+    let dimensions: Int
+    let normalize: Bool
+    let identity: EmbeddingIdentity?
+
+    init(
+        dimensions: Int = 2,
+        normalize: Bool = true,
+        identity: EmbeddingIdentity?
+    ) {
+        self.dimensions = dimensions
+        self.normalize = normalize
+        self.identity = identity
+    }
+
+    func embed(_ text: String) async throws -> [Float] {
+        let a = Float(text.utf8.count % 97) / 97.0
+        let b = Float(text.unicodeScalars.count % 89) / 89.0
+        return VectorMath.normalizeL2([a, b])
+    }
+}
+
 struct WrongDimensionTextEmbedder: EmbeddingProvider, Sendable {
     let dimensions: Int = 4
     let normalize: Bool = false


### PR DESCRIPTION
`any EmbeddingProvider` recovered batch/query-aware behavior with `as?`. A forwarding wrapper around Arctic dropped query prefixes. Incomplete `EmbeddingIdentity` wild-carded store bindings.

This ticket adds defaulted `embedQuery` / `embed(batch:)` on the base protocol, removes attach-time `as?` probes, and treats missing identity model/dims as a mismatch when the binding has those fields. Marker protocols stay. `Memory` is not generic.

Stacked on T1 (`arch/2b047d4d/T1`, #201).

**Ticket:** T4 (type-system architecture)
**Reviews:** `swift-adversarial-pr-review` (fix pass + final pass, both APPROVE)
**Proof:** `swift test --filter MemoryOrchestratorTests`

Photo/video orchestrators still call `embed(text:)` for queries (T3 exclusive file). Follow-up after T3.

Replaces #204 (closed when #201 deleted its T1 base). Rebased onto main after #201/#202/#205.

MAPR follow-ups on this head: cancel default embed(batch:) between items; drop AttachedEmbedder identity wrapper; move multimodal embedQuery default off the Deprecated MARK.