### PR TITLE
Extract broker presentation from AgentBrokerService

### DIFF
--- a/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
+++ b/Sources/Wax/Broker/AgentBrokerService+Markdown.swift
@@ -655,4 +655,229 @@ extension AgentBrokerService {
         }
         return MemoryType(rawValue: raw)
     }
+
+    func exportMarkdownProjection(
+        outputURL: URL,
+        sessionID: UUID?,
+        project: String? = nil
+    ) async throws -> MarkdownProjectionReport {
+        try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+        let memoryDir = outputURL.appendingPathComponent("memory", isDirectory: true)
+        try FileManager.default.createDirectory(at: memoryDir, withIntermediateDirectories: true)
+        try await longTermMemory.flush()
+
+        let durableDocuments = try await longTermMemory.corpusSourceDocuments()
+            .filter { document in
+                matchesExportProject(document.metadata[MemoryMetadataKeys.project], project: project)
+            }
+            .sorted { lhs, rhs in
+                if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
+                return lhs.frameId > rhs.frameId
+            }
+        let memoryMarkdown = renderMemoryMarkdown(documents: durableDocuments)
+        let memoryMarkdownURL = outputURL.appendingPathComponent("MEMORY.md")
+        try memoryMarkdown.write(to: memoryMarkdownURL, atomically: true, encoding: .utf8)
+
+        var dailyNotesByDate: [String: [String]] = [:]
+        var handoffLines: [String] = []
+        let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
+            .filter { sessionID == nil || $0.sessionID == sessionID }
+            .filter { matchesExportProject($0.project, project: project) }
+        for manifest in manifests {
+            let events = try BrokerSessionPersistence.loadEvents(from: URL(fileURLWithPath: manifest.eventLogPath))
+            for event in events {
+                let dateKey = Self.dayString(fromMs: event.timestampMs)
+                switch event.kind {
+                case .remembered, .checkpoint, .promotionWritten, .promotionReviewed:
+                    let summary = if let summary = event.payload["summary"], !summary.isEmpty {
+                        summary
+                    } else if let contentHash = event.payload["content_hash"] {
+                        "session event \(event.kind.rawValue) [\(contentHash)]"
+                    } else {
+                        ""
+                    }
+                    if !summary.isEmpty {
+                        let marker = MarkdownProjectionMarker(
+                            managed: false,
+                            sourceKind: "daily_note_event",
+                            hash: Self.stableHash(summary),
+                            sessionID: manifest.sessionID.uuidString,
+                            sourceFrameID: event.payload["frame_id"].flatMap(UInt64.init),
+                            memoryType: event.payload["memory_type"],
+                            dateKey: dateKey
+                        )
+                        dailyNotesByDate[dateKey, default: []].append(
+                            renderManagedMarkdownLine(text: summary, marker: marker)
+                        )
+                    }
+                case .handoff:
+                    let summary = "[\(dateKey)] \(manifest.agentID)/\(manifest.runID): \(event.payload["summary"] ?? "")"
+                    let marker = MarkdownProjectionMarker(
+                        managed: false,
+                        sourceKind: "daily_note_event",
+                        hash: Self.stableHash(summary),
+                        sessionID: manifest.sessionID.uuidString,
+                        dateKey: dateKey
+                    )
+                    let line = renderManagedMarkdownLine(text: summary, marker: marker)
+                    handoffLines.append(line)
+                    dailyNotesByDate[dateKey, default: []].append(line)
+                default:
+                    break
+                }
+            }
+        }
+
+        let managedDailyNotes = durableDocuments
+            .filter { $0.metadata[MemoryMetadataKeys.sourceKind] == MarkdownProjectionKind.dailyNote.rawValue }
+            .sorted { lhs, rhs in
+                if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
+                return lhs.frameId > rhs.frameId
+        }
+        for document in managedDailyNotes {
+            let dateKey = Self.safeMarkdownDailyDateKey(
+                document.metadata[MemoryMetadataKeys.sourceDate],
+                fallbackMs: document.timestampMs
+            )
+            let marker = marker(for: document, kind: .dailyNote, dateKey: dateKey)
+            dailyNotesByDate[dateKey, default: []].append(renderManagedMarkdownLine(text: document.text, marker: marker))
+        }
+
+        var dailyNotePaths: [String] = []
+        var dailyNoteURLs = Set<URL>()
+        for dateKey in dailyNotesByDate.keys.sorted() {
+            let noteURL = memoryDir.appendingPathComponent("\(dateKey).md")
+            var bodyLines = ["# \(dateKey)", ""]
+            bodyLines.append(contentsOf: dailyNotesByDate[dateKey, default: []])
+            let body = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+            try body.write(to: noteURL, atomically: true, encoding: .utf8)
+            dailyNoteURLs.insert(noteURL.standardizedFileURL)
+            dailyNotePaths.append(noteURL.path)
+        }
+
+        let dreamsLines = try await dreamProjectionLines(sessionID: sessionID, project: project)
+        let dreamsURL = memoryDir.appendingPathComponent("DREAMS.md")
+        var dreamsPath: String?
+        if !dreamsLines.isEmpty {
+            let body = "# DREAMS\n\n" + dreamsLines.joined(separator: "\n") + "\n"
+            try body.write(to: dreamsURL, atomically: true, encoding: .utf8)
+            dreamsPath = dreamsURL.path
+        } else {
+            try removeGeneratedMarkdownFileIfPresent(at: dreamsURL, allowedSourceKinds: [MarkdownProjectionKind.dreams.rawValue])
+        }
+
+        var handoffSummaryPath: String?
+        if !handoffLines.isEmpty {
+            let handoffURL = memoryDir.appendingPathComponent("HANDOFFS.md")
+            let body = "# Handoffs\n\n" + handoffLines.joined(separator: "\n") + "\n"
+            try body.write(to: handoffURL, atomically: true, encoding: .utf8)
+            handoffSummaryPath = handoffURL.path
+        } else {
+            try removeGeneratedMarkdownFileIfPresent(at: memoryDir.appendingPathComponent("HANDOFFS.md"), allowedSourceKinds: ["daily_note_event"])
+        }
+
+        try removeStaleGeneratedDailyNotes(in: memoryDir, keeping: dailyNoteURLs)
+
+        if let sessionID, activeSessions[sessionID] != nil {
+            try await appendSessionEvent(
+                sessionID: sessionID,
+                kind: .markdownExported,
+                payload: ["output_dir": outputURL.path]
+            )
+        }
+
+        return MarkdownProjectionReport(
+            memoryMarkdownPath: memoryMarkdownURL.path,
+            dailyNotePaths: dailyNotePaths.sorted(),
+            dreamsPath: dreamsPath,
+            handoffSummaryPath: handoffSummaryPath
+        )
+    }
+
+    private func removeStaleGeneratedDailyNotes(in memoryDir: URL, keeping currentDailyNoteURLs: Set<URL>) throws {
+        guard FileManager.default.fileExists(atPath: memoryDir.path) else { return }
+        let urls = try FileManager.default.contentsOfDirectory(
+            at: memoryDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        for url in urls where url.pathExtension == "md" {
+            guard !url.lastPathComponent.hasPrefix("DREAMS"),
+                  !url.lastPathComponent.hasPrefix("HANDOFFS"),
+                  url.lastPathComponent.range(of: #"^\d{4}-\d{2}-\d{2}\.md$"#, options: .regularExpression) != nil,
+                  !currentDailyNoteURLs.contains(url.standardizedFileURL)
+            else { continue }
+            try removeGeneratedMarkdownFileIfPresent(
+                at: url,
+                allowedSourceKinds: [MarkdownProjectionKind.dailyNote.rawValue, "daily_note_event"]
+            )
+        }
+    }
+
+    private func removeGeneratedMarkdownFileIfPresent(at url: URL, allowedSourceKinds: Set<String>) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        let entries = try BrokerMarkdownSync.parseFile(at: url)
+        guard !entries.isEmpty else { return }
+        var generatedLines = Set<String>()
+        let generatedOnly = entries.allSatisfy { entry in
+            guard let marker = entry.marker else { return false }
+            guard allowedSourceKinds.contains(marker.sourceKind) else { return false }
+            guard marker.hash == Self.stableHash(entry.text) else { return false }
+            if marker.sourceKind == MarkdownProjectionKind.dreams.rawValue, entry.checked == true {
+                return false
+            }
+            generatedLines.insert(renderManagedMarkdownLine(text: entry.text, marker: marker, checked: entry.checked))
+            return true
+        }
+        guard generatedOnly else { return }
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        let hasUserContent = raw.components(separatedBy: .newlines).contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return false }
+            guard !trimmed.hasPrefix("#") else { return false }
+            return !generatedLines.contains(trimmed)
+        }
+        guard !hasUserContent else { return }
+        try FileManager.default.removeItem(at: url)
+    }
+
+    func renderMemoryMarkdown(documents: [MemoryOrchestrator.CorpusSourceDocument]) -> String {
+        var sections: [MemoryType: [String]] = [:]
+        for document in documents {
+            let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
+            guard info.durability == .durable || info.durability == .locked else { continue }
+            let type = info.type
+            let marker = marker(for: document, kind: .memory)
+            sections[type, default: []].append(renderManagedMarkdownLine(text: document.text, marker: marker))
+        }
+        let orderedTypes: [MemoryType] = [.decision, .lesson, .userPreference, .constraint, .fact, .handoff, .note, .taskState]
+        var lines = ["# MEMORY", ""]
+        for type in orderedTypes {
+            guard let entries = sections[type], !entries.isEmpty else { continue }
+            lines.append("## \(type.rawValue)")
+            lines.append(contentsOf: entries)
+            lines.append("")
+        }
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+    }
+
+    static func dayString(fromMs timestampMs: Int64) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(timestampMs) / 1000))
+    }
+
+    static func safeMarkdownDailyDateKey(_ rawValue: String?, fallbackMs: Int64) -> String {
+        guard let rawValue else {
+            return dayString(fromMs: fallbackMs)
+        }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil else {
+            return dayString(fromMs: fallbackMs)
+        }
+        return trimmed
+    }
 }

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -487,53 +487,21 @@ extension AgentBrokerService {
             sessionID: sessionID
         )
         let after = await memory.runtimeStats()
-
-        let scope = sessionID == nil ? "durable" : "session"
-        let memoryID = sessionID.map {
-            "working:\($0.uuidString):\(rememberResult.frameId)"
-        } ?? "durable:\(rememberResult.frameId)"
-        let project = metadata[MemoryMetadataKeys.project] ?? inferredScope.projectName
-        let repo = metadata[MemoryMetadataKeys.repo] ?? inferredScope.repoName
-        let unresolvedProject = project?.isEmpty != false
-        var display = "Remembered. \(rememberResult.framesAdded) frame(s) added (\(after.frameCount) total, \(after.pendingFrames) pending)."
-        if unresolvedProject {
-            display += " Project unresolved; default recall will miss this unless you pass project/repo or scope=global."
-        }
-        var payload: [String: AgentBrokerValue] = [
-            "status": .string("ok"),
-            "frame_id": .from(rememberResult.frameId),
-            "memory_id": .string(memoryID),
-            "framesAdded": .from(rememberResult.framesAdded),
-            "frameCount": .from(after.frameCount),
-            "pendingFrames": .from(after.pendingFrames),
-            "scope": .string(scope),
-            "session_id": .from(sessionID?.uuidString),
-            "memory_type": .string(metadata[MemoryMetadataKeys.type] ?? MemoryType.note.rawValue),
-            "durability": .string(metadata[MemoryMetadataKeys.durability] ?? MemoryDurability.working.rawValue),
-            "deduplicated": .bool(rememberResult.deduplicated),
-            "searchable": .bool(rememberResult.searchable),
-            "unresolved_project": .bool(unresolvedProject),
-            "display_text": .string(display),
-        ]
-        if let project, !project.isEmpty {
-            payload["project"] = .string(project)
-        }
-        if let repo, !repo.isEmpty {
-            payload["repo"] = .string(repo)
-        }
-        if unresolvedProject {
-            payload["next_action"] = .string("pass project/repo or recall with scope=global")
-        }
-        return .object(payload)
+        return RememberAssembly.payload(
+            frameId: rememberResult.frameId,
+            framesAdded: rememberResult.framesAdded,
+            frameCount: after.frameCount,
+            pendingFrames: after.pendingFrames,
+            sessionID: sessionID,
+            metadata: metadata,
+            inferredScope: inferredScope,
+            deduplicated: rememberResult.deduplicated,
+            searchable: rememberResult.searchable
+        )
     }
 
-    private static let autoSupersedeSimilarityThreshold: Float = 0.88
-    private static let autoSupersedeMaxMatches = 32
-    private static let autoSupersedeTypes: Set<MemoryType> = [
-        .decision, .lesson, .constraint, .fact,
-    ]
-
     /// Same-project Jaccard ≥ 0.88 retires prior unsuperseded durable twins. Locked stays live.
+    /// Selection policy lives in ``RememberAssembly``; this method still owns corpus I/O + supersede + flush.
     private func autoSupersedeSimilarDurableFrames(
         memory: MemoryOrchestrator,
         newFrameId: UInt64,
@@ -541,11 +509,14 @@ extension AgentBrokerService {
         metadata: [String: String],
         sessionID: UUID?
     ) async {
-        guard sessionID == nil else { return }
-        let info = MemorySemantics.parse(metadata: metadata, nowMs: Self.nowMs())
-        guard Self.autoSupersedeTypes.contains(info.type) else { return }
-        guard info.durability == .durable || info.durability == .locked else { return }
-        guard let project = info.project else { return }
+        let nowMs = Self.nowMs()
+        guard RememberAssembly.isAutoSupersedeEligible(
+            sessionID: sessionID,
+            metadata: metadata,
+            nowMs: nowMs
+        ) else {
+            return
+        }
 
         let documents: [MemoryOrchestrator.CorpusSourceDocument]
         do {
@@ -559,24 +530,30 @@ extension AgentBrokerService {
             return
         }
 
+        let frameIDs = RememberAssembly.selectSupersedeFrameIDs(
+            sessionID: sessionID,
+            newFrameId: newFrameId,
+            content: content,
+            metadata: metadata,
+            documents: documents.map {
+                RememberAssembly.Candidate(
+                    frameId: $0.frameId,
+                    text: $0.text,
+                    metadata: $0.metadata
+                )
+            },
+            nowMs: nowMs
+        )
+        guard !frameIDs.isEmpty else { return }
+
         var supersededAny = false
-        var matchCount = 0
-        for document in documents {
-            guard matchCount < Self.autoSupersedeMaxMatches else { break }
-            guard document.frameId != newFrameId else { continue }
-            let other = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
-            guard other.type == info.type else { continue }
-            guard other.project == project else { continue }
-            guard other.durability == .durable else { continue }
-            let similarity = MemorySemantics.similarity(lhs: content, rhs: document.text)
-            guard similarity >= Self.autoSupersedeSimilarityThreshold else { continue }
+        for frameID in frameIDs {
             do {
                 try await memory.wax.supersede(
-                    supersededId: document.frameId,
+                    supersededId: frameID,
                     supersedingId: newFrameId
                 )
                 supersededAny = true
-                matchCount += 1
             } catch {
                 WaxDiagnostics.logSwallowed(
                     error,
@@ -656,14 +633,14 @@ extension AgentBrokerService {
         }
         lines.append("Applied filters: \(parsedFilters.summary.debugJSONString)")
         for (index, hit) in result.hits.enumerated() {
-            let kind = Self.itemKindLabel(hit.kind)
+            let kind = RecallPresent.itemKindLabel(hit.kind)
             lines.append("\(index + 1). [\(kind)] frame=\(hit.frameID) score=\(String(format: "%.4f", hit.score)) \(hit.text)")
         }
 
         let nowMs = Self.nowMs()
         let verbose = command.verbosity == "verbose"
         let results: [AgentBrokerValue] = result.hits.enumerated().map { index, hit in
-            renderRecallHit(hit, rank: index + 1, verbose: verbose, nowMs: nowMs)
+            RecallPresent.renderRecallHit(hit, rank: index + 1, verbose: verbose, nowMs: nowMs)
         }
         if let sessionID = parsedFilters.sessionId {
             let sessionMemory = try await memory(for: sessionID)
@@ -863,7 +840,8 @@ extension AgentBrokerService {
             )
         }
 
-        let rows = hits.map(renderLayeredMemoryHit)
+        let nowMs = Self.nowMs()
+        let rows = hits.map { RecallPresent.renderLayeredMemoryHit($0, nowMs: nowMs) }
         let text = rows.isEmpty ? "No results." : rows.map(\.debugJSONString).joined(separator: "\n")
         return .object([
             "query": .string(query),
@@ -1785,145 +1763,24 @@ extension AgentBrokerService {
         }
 
         let rebound = SessionOpenDecision.rebound(returnedSessionID: sessionUUID, facts: openFacts)
-        let sharePrompt =
-            "This MCP connection remembers session_id (\(sessionID)); omit it on subsequent memory calls on this connection. Retain it for reconnects, explicit cross-session calls, and direct broker/CLI use. Host children do not get Wax tools."
-
-        // Keep the bootstrap wire shape deliberately small.  Callers that
-        // need project/repo, lease state, or the full handoff can issue the
-        // corresponding explicit read after they have the session UUID.
-        var payload: [String: AgentBrokerValue] = [
-            "session_id": .string(sessionID),
-            "rebound": .bool(rebound),
-            "share_prompt": .string(sharePrompt),
-            "handoff": try await Self.compactSessionOpenHandoff(
-                handoffPayload,
-                recallQuery: recallQuery
-            ),
-        ]
-        if let recallPayload {
-            payload["recall"] = recallPayload
-            if let warning = recallPayload.objectValue?["warning"] {
-                payload["warning"] = warning
-            }
+        let tokenizer: SessionOpenAssembly.Tokenizer
+        if handoffPayload.objectValue?["found"]?.boolValue == true {
+            let counter = try await TokenCounter.shared()
+            tokenizer = SessionOpenAssembly.Tokenizer(count: { text in await counter.count(text) })
+        } else {
+            tokenizer = .character
         }
-        return .object(payload)
-    }
-
-    private static func compactSessionOpenHandoff(
-        _ value: AgentBrokerValue,
-        recallQuery: String?
-    ) async throws -> AgentBrokerValue {
-        guard let handoff = value.objectValue,
-              handoff["found"]?.boolValue == true
-        else {
-            return value
-        }
-
-        let originalContent = handoff["content"]?.stringValue ?? ""
-        let originalTasks = handoff["pending_tasks"]?.arrayValue?.compactMap(\.stringValue) ?? []
-        let trimmedQuery = recallQuery?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let emptyBody = originalContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && originalTasks.isEmpty
-        if emptyBody {
-            return .object([
-                "found": .bool(false),
-                "relevance": .string("low"),
-                "content": .string(""),
-                "pending_tasks": .array([]),
-                "truncated": .bool(false),
-                "content_truncated": .bool(false),
-                "pending_tasks_truncated": .from(0),
-                "pending_tasks_omitted": .from(0),
-                "content_bytes": .from(0),
-                "content_tokens": .from(0),
-            ])
-        }
-        let lowRelevance = !trimmedQuery.isEmpty
-            && MemorySemantics.similarity(lhs: trimmedQuery, rhs: originalContent) < 0.15
-
-        let byteLimitedContent = utf8Prefix(
-            originalContent,
-            maxBytes: BrokerLimits.maxSessionOpenHandoffContentBytes
+        let handoff = await SessionOpenAssembly.compactHandoff(
+            handoffPayload,
+            recallQuery: recallQuery,
+            tokenizer: tokenizer
         )
-        let tokenCounter = try await TokenCounter.shared()
-        let compactContent = await Self.tokenLimitedPrefix(
-            byteLimitedContent,
-            counter: tokenCounter,
-            maxTokens: BrokerLimits.maxSessionOpenHandoffContentTokens
+        return SessionOpenAssembly.bootstrapPayload(
+            sessionID: sessionID,
+            rebound: rebound,
+            handoff: handoff,
+            recall: recallPayload
         )
-        let contentTruncated = compactContent != originalContent
-
-        let boundedTasks = originalTasks
-            .prefix(BrokerLimits.maxSessionOpenPendingTasks)
-            .map { task in
-                utf8Prefix(task, maxBytes: BrokerLimits.maxSessionOpenPendingTaskBytes)
-            }
-        let pendingTaskTruncations = zip(
-            originalTasks.prefix(BrokerLimits.maxSessionOpenPendingTasks),
-            boundedTasks
-        ).reduce(into: 0) { count, task in
-            if task.0 != task.1 { count += 1 }
-        }
-        let omittedTaskCount = max(0, originalTasks.count - boundedTasks.count)
-        let anyTruncated = contentTruncated || pendingTaskTruncations > 0 || omittedTaskCount > 0
-
-        var compact: [String: AgentBrokerValue] = [
-            "found": .bool(true),
-            "content": .string(compactContent),
-            "pending_tasks": .array(boundedTasks.map { .string($0) }),
-            "truncated": .bool(anyTruncated),
-            "content_truncated": .bool(contentTruncated),
-            "pending_tasks_truncated": .from(pendingTaskTruncations),
-            "pending_tasks_omitted": .from(omittedTaskCount),
-            "content_bytes": .from(compactContent.utf8.count),
-            "content_tokens": .from(await tokenCounter.count(compactContent)),
-        ]
-        if lowRelevance {
-            compact["relevance"] = .string("low")
-        }
-        return .object(compact)
-    }
-
-    /// Return a prefix without splitting a user-visible Unicode grapheme.
-    private static func utf8Prefix(_ text: String, maxBytes: Int) -> String {
-        guard maxBytes > 0 else { return "" }
-        var bytes = 0
-        var result = String()
-        result.reserveCapacity(min(text.utf8.count, maxBytes))
-        for character in text {
-            let characterBytes = String(character).utf8.count
-            guard bytes + characterBytes <= maxBytes else { break }
-            result.append(character)
-            bytes += characterBytes
-        }
-        return result
-    }
-
-    /// Bound `text` to `maxTokens` while remaining a grapheme prefix of `text`.
-    ///
-    /// Encode the full string once, then take a proportional character prefix
-    /// and shrink by graphemes if that prefix is still over budget. This avoids
-    /// re-tokenizing every binary-search midpoint on `TokenCounter.shared()`,
-    /// which serializes orchestrator chunking and MCP remember/recall.
-    private static func tokenLimitedPrefix(
-        _ text: String,
-        counter: TokenCounter,
-        maxTokens: Int
-    ) async -> String {
-        guard maxTokens > 0, !text.isEmpty else { return "" }
-        let fullCount = await counter.count(text)
-        if fullCount <= maxTokens { return text }
-
-        let characters = Array(text)
-        var high = max(1, min(characters.count, (maxTokens * characters.count) / fullCount))
-        var candidate = String(characters.prefix(high))
-        var candidateCount = await counter.count(candidate)
-        while candidateCount > maxTokens && high > 1 {
-            high = max(1, (high * 3) / 4)
-            candidate = String(characters.prefix(high))
-            candidateCount = await counter.count(candidate)
-        }
-        return candidateCount <= maxTokens ? candidate : ""
     }
 
     private func sessionEndPayload(
@@ -2306,14 +2163,21 @@ extension AgentBrokerService {
                 await session.memory.recordAccess(frameId: hit.frameID)
             }
         }
+        let nowMs = Self.nowMs()
         return .object([
             "query": .string(query),
             "token_budget": .from(tokenBudget),
             "used_tokens": .from(assembled.usedTokens),
             "summary": .string(assembled.summary),
-            "short_context": .array(assembled.short.map(renderCompactLayeredMemoryHit)),
-            "medium_context": .array(assembled.medium.map(renderCompactLayeredMemoryHit)),
-            "long_context": .array(assembled.long.map(renderCompactLayeredMemoryHit)),
+            "short_context": .array(assembled.short.map {
+                RecallPresent.renderCompactLayeredMemoryHit($0, nowMs: nowMs)
+            }),
+            "medium_context": .array(assembled.medium.map {
+                RecallPresent.renderCompactLayeredMemoryHit($0, nowMs: nowMs)
+            }),
+            "long_context": .array(assembled.long.map {
+                RecallPresent.renderCompactLayeredMemoryHit($0, nowMs: nowMs)
+            }),
             "compacted_text": .string(assembled.compactedText),
             "display_text": .string(assembled.compactedText),
         ])
@@ -2910,192 +2774,6 @@ extension AgentBrokerService {
         }
     }
 
-    func exportMarkdownProjection(
-        outputURL: URL,
-        sessionID: UUID?,
-        project: String? = nil
-    ) async throws -> MarkdownProjectionReport {
-        try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
-        let memoryDir = outputURL.appendingPathComponent("memory", isDirectory: true)
-        try FileManager.default.createDirectory(at: memoryDir, withIntermediateDirectories: true)
-        try await longTermMemory.flush()
-
-        let durableDocuments = try await longTermMemory.corpusSourceDocuments()
-            .filter { document in
-                matchesExportProject(document.metadata[MemoryMetadataKeys.project], project: project)
-            }
-            .sorted { lhs, rhs in
-                if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
-                return lhs.frameId > rhs.frameId
-            }
-        let memoryMarkdown = renderMemoryMarkdown(documents: durableDocuments)
-        let memoryMarkdownURL = outputURL.appendingPathComponent("MEMORY.md")
-        try memoryMarkdown.write(to: memoryMarkdownURL, atomically: true, encoding: .utf8)
-
-        var dailyNotesByDate: [String: [String]] = [:]
-        var handoffLines: [String] = []
-        let manifests = try BrokerSessionPersistence.listManifests(rootURL: sessionRootURL)
-            .filter { sessionID == nil || $0.sessionID == sessionID }
-            .filter { matchesExportProject($0.project, project: project) }
-        for manifest in manifests {
-            let events = try BrokerSessionPersistence.loadEvents(from: URL(fileURLWithPath: manifest.eventLogPath))
-            for event in events {
-                let dateKey = Self.dayString(fromMs: event.timestampMs)
-                switch event.kind {
-                case .remembered, .checkpoint, .promotionWritten, .promotionReviewed:
-                    let summary = if let summary = event.payload["summary"], !summary.isEmpty {
-                        summary
-                    } else if let contentHash = event.payload["content_hash"] {
-                        "session event \(event.kind.rawValue) [\(contentHash)]"
-                    } else {
-                        ""
-                    }
-                    if !summary.isEmpty {
-                        let marker = MarkdownProjectionMarker(
-                            managed: false,
-                            sourceKind: "daily_note_event",
-                            hash: Self.stableHash(summary),
-                            sessionID: manifest.sessionID.uuidString,
-                            sourceFrameID: event.payload["frame_id"].flatMap(UInt64.init),
-                            memoryType: event.payload["memory_type"],
-                            dateKey: dateKey
-                        )
-                        dailyNotesByDate[dateKey, default: []].append(
-                            renderManagedMarkdownLine(text: summary, marker: marker)
-                        )
-                    }
-                case .handoff:
-                    let summary = "[\(dateKey)] \(manifest.agentID)/\(manifest.runID): \(event.payload["summary"] ?? "")"
-                    let marker = MarkdownProjectionMarker(
-                        managed: false,
-                        sourceKind: "daily_note_event",
-                        hash: Self.stableHash(summary),
-                        sessionID: manifest.sessionID.uuidString,
-                        dateKey: dateKey
-                    )
-                    let line = renderManagedMarkdownLine(text: summary, marker: marker)
-                    handoffLines.append(line)
-                    dailyNotesByDate[dateKey, default: []].append(line)
-                default:
-                    break
-                }
-            }
-        }
-
-        let managedDailyNotes = durableDocuments
-            .filter { $0.metadata[MemoryMetadataKeys.sourceKind] == MarkdownProjectionKind.dailyNote.rawValue }
-            .sorted { lhs, rhs in
-                if lhs.timestampMs != rhs.timestampMs { return lhs.timestampMs > rhs.timestampMs }
-                return lhs.frameId > rhs.frameId
-        }
-        for document in managedDailyNotes {
-            let dateKey = Self.safeMarkdownDailyDateKey(
-                document.metadata[MemoryMetadataKeys.sourceDate],
-                fallbackMs: document.timestampMs
-            )
-            let marker = marker(for: document, kind: .dailyNote, dateKey: dateKey)
-            dailyNotesByDate[dateKey, default: []].append(renderManagedMarkdownLine(text: document.text, marker: marker))
-        }
-
-        var dailyNotePaths: [String] = []
-        var dailyNoteURLs = Set<URL>()
-        for dateKey in dailyNotesByDate.keys.sorted() {
-            let noteURL = memoryDir.appendingPathComponent("\(dateKey).md")
-            var bodyLines = ["# \(dateKey)", ""]
-            bodyLines.append(contentsOf: dailyNotesByDate[dateKey, default: []])
-            let body = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
-            try body.write(to: noteURL, atomically: true, encoding: .utf8)
-            dailyNoteURLs.insert(noteURL.standardizedFileURL)
-            dailyNotePaths.append(noteURL.path)
-        }
-
-        let dreamsLines = try await dreamProjectionLines(sessionID: sessionID, project: project)
-        let dreamsURL = memoryDir.appendingPathComponent("DREAMS.md")
-        var dreamsPath: String?
-        if !dreamsLines.isEmpty {
-            let body = "# DREAMS\n\n" + dreamsLines.joined(separator: "\n") + "\n"
-            try body.write(to: dreamsURL, atomically: true, encoding: .utf8)
-            dreamsPath = dreamsURL.path
-        } else {
-            try removeGeneratedMarkdownFileIfPresent(at: dreamsURL, allowedSourceKinds: [MarkdownProjectionKind.dreams.rawValue])
-        }
-
-        var handoffSummaryPath: String?
-        if !handoffLines.isEmpty {
-            let handoffURL = memoryDir.appendingPathComponent("HANDOFFS.md")
-            let body = "# Handoffs\n\n" + handoffLines.joined(separator: "\n") + "\n"
-            try body.write(to: handoffURL, atomically: true, encoding: .utf8)
-            handoffSummaryPath = handoffURL.path
-        } else {
-            try removeGeneratedMarkdownFileIfPresent(at: memoryDir.appendingPathComponent("HANDOFFS.md"), allowedSourceKinds: ["daily_note_event"])
-        }
-
-        try removeStaleGeneratedDailyNotes(in: memoryDir, keeping: dailyNoteURLs)
-
-        if let sessionID, activeSessions[sessionID] != nil {
-            try await appendSessionEvent(
-                sessionID: sessionID,
-                kind: .markdownExported,
-                payload: ["output_dir": outputURL.path]
-            )
-        }
-
-        return MarkdownProjectionReport(
-            memoryMarkdownPath: memoryMarkdownURL.path,
-            dailyNotePaths: dailyNotePaths.sorted(),
-            dreamsPath: dreamsPath,
-            handoffSummaryPath: handoffSummaryPath
-        )
-    }
-
-    private func removeStaleGeneratedDailyNotes(in memoryDir: URL, keeping currentDailyNoteURLs: Set<URL>) throws {
-        guard FileManager.default.fileExists(atPath: memoryDir.path) else { return }
-        let urls = try FileManager.default.contentsOfDirectory(
-            at: memoryDir,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        )
-        for url in urls where url.pathExtension == "md" {
-            guard !url.lastPathComponent.hasPrefix("DREAMS"),
-                  !url.lastPathComponent.hasPrefix("HANDOFFS"),
-                  url.lastPathComponent.range(of: #"^\d{4}-\d{2}-\d{2}\.md$"#, options: .regularExpression) != nil,
-                  !currentDailyNoteURLs.contains(url.standardizedFileURL)
-            else { continue }
-            try removeGeneratedMarkdownFileIfPresent(
-                at: url,
-                allowedSourceKinds: [MarkdownProjectionKind.dailyNote.rawValue, "daily_note_event"]
-            )
-        }
-    }
-
-    private func removeGeneratedMarkdownFileIfPresent(at url: URL, allowedSourceKinds: Set<String>) throws {
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        let entries = try BrokerMarkdownSync.parseFile(at: url)
-        guard !entries.isEmpty else { return }
-        var generatedLines = Set<String>()
-        let generatedOnly = entries.allSatisfy { entry in
-            guard let marker = entry.marker else { return false }
-            guard allowedSourceKinds.contains(marker.sourceKind) else { return false }
-            guard marker.hash == Self.stableHash(entry.text) else { return false }
-            if marker.sourceKind == MarkdownProjectionKind.dreams.rawValue, entry.checked == true {
-                return false
-            }
-            generatedLines.insert(renderManagedMarkdownLine(text: entry.text, marker: marker, checked: entry.checked))
-            return true
-        }
-        guard generatedOnly else { return }
-        let raw = try String(contentsOf: url, encoding: .utf8)
-        let hasUserContent = raw.components(separatedBy: .newlines).contains { line in
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return false }
-            guard !trimmed.hasPrefix("#") else { return false }
-            return !generatedLines.contains(trimmed)
-        }
-        guard !hasUserContent else { return }
-        try FileManager.default.removeItem(at: url)
-    }
-
-
     func memory(for sessionID: UUID?) async throws -> MemoryOrchestrator {
         switch try await virtualSessions.ensureLive(sessionID) {
         case .none:
@@ -3428,124 +3106,9 @@ extension AgentBrokerService {
         }
     }
 
-    static func itemKindLabel(_ kind: RAGContext.ItemKind) -> String {
-        switch kind {
-        case .expanded:
-            return "expanded"
-        case .surrogate:
-            return "surrogate"
-        case .snippet:
-            return "snippet"
-        }
-    }
-
-    func renderRecallHit(
-        _ hit: LayeredRecall.Hit,
-        rank: Int,
-        verbose: Bool,
-        nowMs: Int64
-    ) -> AgentBrokerValue {
-        var object = compactHitObject(
-            id: hit.reference,
-            text: hit.text,
-            preview: nil,
-            metadata: hit.metadata,
-            score: hit.score,
-            createdAtMs: hit.timestampMs,
-            nowMs: nowMs
-        )
-        object["rank"] = .from(rank)
-        object["kind"] = .string(Self.itemKindLabel(hit.kind))
-        object["frameId"] = .from(hit.frameID)
-        object["sources"] = .array(hit.sources.map { .string($0.rawValue) })
-        if verbose {
-            object["metadata"] = .object(hit.metadata.mapValues(AgentBrokerValue.string))
-            object["explanations"] = .array(hit.explanations.map(AgentBrokerValue.string))
-        }
-        return .object(object)
-    }
-
+    /// Thin actor wrapper for MCP/DX tests that still call presentation through the broker.
     func renderLayeredMemoryHit(_ hit: LayeredMemoryHit) -> AgentBrokerValue {
-        var object = compactHitObject(
-            id: hit.reference,
-            text: hit.text,
-            preview: hit.preview,
-            metadata: hit.metadata,
-            score: hit.score,
-            createdAtMs: hit.timestampMs,
-            nowMs: Self.nowMs()
-        )
-        object["memory_id"] = .string(hit.reference)
-        object["horizon"] = .string(hit.horizon.rawValue)
-        object["session_id"] = .from(hit.sessionID?.uuidString)
-        object["agent_id"] = .from(hit.agentID)
-        object["run_id"] = .from(hit.runID)
-        object["frame_id"] = .from(hit.frameID)
-        object["explanations"] = .array(hit.explanations.map(AgentBrokerValue.string))
-        object["metadata"] = .object(hit.metadata.mapValues(AgentBrokerValue.string))
-        return .object(object)
-    }
-
-    func renderCompactLayeredMemoryHit(_ hit: LayeredMemoryHit) -> AgentBrokerValue {
-        var object = compactHitObject(
-            id: hit.reference,
-            text: hit.text,
-            preview: hit.preview,
-            metadata: hit.metadata,
-            score: hit.score,
-            createdAtMs: hit.timestampMs,
-            nowMs: Self.nowMs()
-        )
-        object["memory_id"] = .string(hit.reference)
-        object["frame_id"] = .from(hit.frameID)
-        return .object(object)
-    }
-
-    func compactHitObject(
-        id: String,
-        text: String,
-        preview: String?,
-        metadata: [String: String],
-        score: Float,
-        createdAtMs: Int64,
-        nowMs: Int64
-    ) -> [String: AgentBrokerValue] {
-        var object: [String: AgentBrokerValue] = [
-            "id": .string(id),
-            "text": .string(text),
-            "score": .double(Double(score)),
-        ]
-        if createdAtMs > 0 {
-            object["created_at_ms"] = .int(createdAtMs)
-            object["age_days"] = .int(Self.ageDays(createdAtMs: createdAtMs, nowMs: nowMs))
-        }
-        if let preview {
-            object["preview"] = .string(preview)
-        }
-        if let project = metadata[MemoryMetadataKeys.project], !project.isEmpty {
-            object["project"] = .string(project)
-        }
-        if let repo = metadata[MemoryMetadataKeys.repo], !repo.isEmpty {
-            object["repo"] = .string(repo)
-        }
-        if let memoryType = metadata[MemoryMetadataKeys.type], !memoryType.isEmpty {
-            object["memory_type"] = .string(memoryType)
-        }
-        if let durability = metadata[MemoryMetadataKeys.durability], !durability.isEmpty {
-            object["durability"] = .string(durability)
-        }
-        if let reviewed = metadata[MemoryMetadataKeys.reviewed] {
-            object["reviewed"] = .bool(reviewed.lowercased() == "true")
-        }
-        if let confidence = metadata[MemoryMetadataKeys.confidence].flatMap(Double.init) {
-            object["confidence"] = .double(confidence)
-        }
-        return object
-    }
-
-    static func ageDays(createdAtMs: Int64, nowMs: Int64) -> Int64 {
-        guard createdAtMs > 0 else { return 0 }
-        return max(0, (nowMs - createdAtMs) / (1000 * 60 * 60 * 24))
+        RecallPresent.renderLayeredMemoryHit(hit, nowMs: Self.nowMs())
     }
 
     func corpusHitFullText(_ hit: BrokerCorpusMergeHit) async -> String {
@@ -3660,46 +3223,6 @@ extension AgentBrokerService {
         }
     }
 
-
-    func renderMemoryMarkdown(documents: [MemoryOrchestrator.CorpusSourceDocument]) -> String {
-        var sections: [MemoryType: [String]] = [:]
-        for document in documents {
-            let info = MemorySemantics.parse(metadata: document.metadata, nowMs: Self.nowMs())
-            guard info.durability == .durable || info.durability == .locked else { continue }
-            let type = info.type
-            let marker = marker(for: document, kind: .memory)
-            sections[type, default: []].append(renderManagedMarkdownLine(text: document.text, marker: marker))
-        }
-        let orderedTypes: [MemoryType] = [.decision, .lesson, .userPreference, .constraint, .fact, .handoff, .note, .taskState]
-        var lines = ["# MEMORY", ""]
-        for type in orderedTypes {
-            guard let entries = sections[type], !entries.isEmpty else { continue }
-            lines.append("## \(type.rawValue)")
-            lines.append(contentsOf: entries)
-            lines.append("")
-        }
-        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
-    }
-
-    static func dayString(fromMs timestampMs: Int64) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(timestampMs) / 1000))
-    }
-
-    static func safeMarkdownDailyDateKey(_ rawValue: String?, fallbackMs: Int64) -> String {
-        guard let rawValue else {
-            return dayString(fromMs: fallbackMs)
-        }
-        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil else {
-            return dayString(fromMs: fallbackMs)
-        }
-        return trimmed
-    }
 
     static func makeMemoryReference(frameID: UInt64) -> String {
         LayeredRecall.makeMemoryReference(frameID: frameID)

--- a/Sources/Wax/Broker/AgentBrokerService.swift
+++ b/Sources/Wax/Broker/AgentBrokerService.swift
@@ -1764,7 +1764,7 @@ extension AgentBrokerService {
 
         let rebound = SessionOpenDecision.rebound(returnedSessionID: sessionUUID, facts: openFacts)
         let tokenizer: SessionOpenAssembly.Tokenizer
-        if handoffPayload.objectValue?["found"]?.boolValue == true {
+        if SessionOpenAssembly.needsTokenizer(handoffPayload) {
             let counter = try await TokenCounter.shared()
             tokenizer = SessionOpenAssembly.Tokenizer(count: { text in await counter.count(text) })
         } else {

--- a/Sources/Wax/Broker/RecallPresent.swift
+++ b/Sources/Wax/Broker/RecallPresent.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Pure hit → `AgentBrokerValue` wire rendering for recall / memory_search / compact.
+/// Layered recall I/O and packing stay elsewhere; this only owns presentation keys.
+package enum RecallPresent {
+    package static func itemKindLabel(_ kind: RAGContext.ItemKind) -> String {
+        switch kind {
+        case .expanded:
+            return "expanded"
+        case .surrogate:
+            return "surrogate"
+        case .snippet:
+            return "snippet"
+        }
+    }
+
+    package static func ageDays(createdAtMs: Int64, nowMs: Int64) -> Int64 {
+        guard createdAtMs > 0 else { return 0 }
+        return max(0, (nowMs - createdAtMs) / (1000 * 60 * 60 * 24))
+    }
+
+    package static func compactHitObject(
+        id: String,
+        text: String,
+        preview: String?,
+        metadata: [String: String],
+        score: Float,
+        createdAtMs: Int64,
+        nowMs: Int64
+    ) -> [String: AgentBrokerValue] {
+        var object: [String: AgentBrokerValue] = [
+            "id": .string(id),
+            "text": .string(text),
+            "score": .double(Double(score)),
+        ]
+        if createdAtMs > 0 {
+            object["created_at_ms"] = .int(createdAtMs)
+            object["age_days"] = .int(ageDays(createdAtMs: createdAtMs, nowMs: nowMs))
+        }
+        if let preview {
+            object["preview"] = .string(preview)
+        }
+        if let project = metadata[MemoryMetadataKeys.project], !project.isEmpty {
+            object["project"] = .string(project)
+        }
+        if let repo = metadata[MemoryMetadataKeys.repo], !repo.isEmpty {
+            object["repo"] = .string(repo)
+        }
+        if let memoryType = metadata[MemoryMetadataKeys.type], !memoryType.isEmpty {
+            object["memory_type"] = .string(memoryType)
+        }
+        if let durability = metadata[MemoryMetadataKeys.durability], !durability.isEmpty {
+            object["durability"] = .string(durability)
+        }
+        if let reviewed = metadata[MemoryMetadataKeys.reviewed] {
+            object["reviewed"] = .bool(reviewed.lowercased() == "true")
+        }
+        if let confidence = metadata[MemoryMetadataKeys.confidence].flatMap(Double.init) {
+            object["confidence"] = .double(confidence)
+        }
+        return object
+    }
+
+    package static func renderRecallHit(
+        _ hit: LayeredRecall.Hit,
+        rank: Int,
+        verbose: Bool,
+        nowMs: Int64
+    ) -> AgentBrokerValue {
+        var object = compactHitObject(
+            id: hit.reference,
+            text: hit.text,
+            preview: nil,
+            metadata: hit.metadata,
+            score: hit.score,
+            createdAtMs: hit.timestampMs,
+            nowMs: nowMs
+        )
+        object["rank"] = .from(rank)
+        object["kind"] = .string(itemKindLabel(hit.kind))
+        object["frameId"] = .from(hit.frameID)
+        object["sources"] = .array(hit.sources.map { .string($0.rawValue) })
+        if verbose {
+            object["metadata"] = .object(hit.metadata.mapValues(AgentBrokerValue.string))
+            object["explanations"] = .array(hit.explanations.map(AgentBrokerValue.string))
+        }
+        return .object(object)
+    }
+
+    package static func renderLayeredMemoryHit(
+        _ hit: LayeredRecall.Hit,
+        nowMs: Int64
+    ) -> AgentBrokerValue {
+        var object = compactHitObject(
+            id: hit.reference,
+            text: hit.text,
+            preview: hit.preview,
+            metadata: hit.metadata,
+            score: hit.score,
+            createdAtMs: hit.timestampMs,
+            nowMs: nowMs
+        )
+        object["memory_id"] = .string(hit.reference)
+        object["horizon"] = .string(hit.horizon.rawValue)
+        object["session_id"] = .from(hit.sessionID?.uuidString)
+        object["agent_id"] = .from(hit.agentID)
+        object["run_id"] = .from(hit.runID)
+        object["frame_id"] = .from(hit.frameID)
+        object["explanations"] = .array(hit.explanations.map(AgentBrokerValue.string))
+        object["metadata"] = .object(hit.metadata.mapValues(AgentBrokerValue.string))
+        return .object(object)
+    }
+
+    package static func renderCompactLayeredMemoryHit(
+        _ hit: LayeredRecall.Hit,
+        nowMs: Int64
+    ) -> AgentBrokerValue {
+        var object = compactHitObject(
+            id: hit.reference,
+            text: hit.text,
+            preview: hit.preview,
+            metadata: hit.metadata,
+            score: hit.score,
+            createdAtMs: hit.timestampMs,
+            nowMs: nowMs
+        )
+        object["memory_id"] = .string(hit.reference)
+        object["frame_id"] = .from(hit.frameID)
+        return .object(object)
+    }
+}

--- a/Sources/Wax/Broker/RememberAssembly.swift
+++ b/Sources/Wax/Broker/RememberAssembly.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Remember response assembly and durable auto-supersede selection policy.
+/// Store I/O (`remember`, `supersede`, `flush`, session events) stays on the broker.
+package enum RememberAssembly {
+    package static let autoSupersedeSimilarityThreshold: Float = 0.88
+    package static let autoSupersedeMaxMatches = 32
+    package static let autoSupersedeTypes: Set<MemoryType> = [
+        .decision, .lesson, .constraint, .fact,
+    ]
+
+    /// Corpus row shape for pure supersede selection (no orchestrator dependency).
+    package struct Candidate: Sendable, Equatable {
+        package var frameId: UInt64
+        package var text: String
+        package var metadata: [String: String]
+
+        package init(frameId: UInt64, text: String, metadata: [String: String]) {
+            self.frameId = frameId
+            self.text = text
+            self.metadata = metadata
+        }
+    }
+
+    /// Wire payload for a completed remember. Keys stay stable for MCP/CLI clients.
+    package static func payload(
+        frameId: UInt64,
+        framesAdded: UInt64,
+        frameCount: UInt64,
+        pendingFrames: UInt64,
+        sessionID: UUID?,
+        metadata: [String: String],
+        inferredScope: MemoryScopeContext = MemoryScopeContext(),
+        deduplicated: Bool,
+        searchable: Bool
+    ) -> AgentBrokerValue {
+        let scope = sessionID == nil ? "durable" : "session"
+        let memoryID = sessionID.map {
+            "working:\($0.uuidString):\(frameId)"
+        } ?? "durable:\(frameId)"
+        let project = metadata[MemoryMetadataKeys.project] ?? inferredScope.projectName
+        let repo = metadata[MemoryMetadataKeys.repo] ?? inferredScope.repoName
+        let unresolvedProject = project?.isEmpty != false
+        var display = "Remembered. \(framesAdded) frame(s) added (\(frameCount) total, \(pendingFrames) pending)."
+        if unresolvedProject {
+            display += " Project unresolved; default recall will miss this unless you pass project/repo or scope=global."
+        }
+        var payload: [String: AgentBrokerValue] = [
+            "status": .string("ok"),
+            "frame_id": .from(frameId),
+            "memory_id": .string(memoryID),
+            "framesAdded": .from(framesAdded),
+            "frameCount": .from(frameCount),
+            "pendingFrames": .from(pendingFrames),
+            "scope": .string(scope),
+            "session_id": .from(sessionID?.uuidString),
+            "memory_type": .string(metadata[MemoryMetadataKeys.type] ?? MemoryType.note.rawValue),
+            "durability": .string(metadata[MemoryMetadataKeys.durability] ?? MemoryDurability.working.rawValue),
+            "deduplicated": .bool(deduplicated),
+            "searchable": .bool(searchable),
+            "unresolved_project": .bool(unresolvedProject),
+            "display_text": .string(display),
+        ]
+        if let project, !project.isEmpty {
+            payload["project"] = .string(project)
+        }
+        if let repo, !repo.isEmpty {
+            payload["repo"] = .string(repo)
+        }
+        if unresolvedProject {
+            payload["next_action"] = .string("pass project/repo or recall with scope=global")
+        }
+        return .object(payload)
+    }
+
+    /// Cheap gate before corpus I/O: session writes and non-policy types never scan.
+    package static func isAutoSupersedeEligible(
+        sessionID: UUID?,
+        metadata: [String: String],
+        nowMs: Int64
+    ) -> Bool {
+        guard sessionID == nil else { return false }
+        let info = MemorySemantics.parse(metadata: metadata, nowMs: nowMs)
+        guard autoSupersedeTypes.contains(info.type) else { return false }
+        guard info.durability == .durable || info.durability == .locked else { return false }
+        return info.project != nil
+    }
+
+    /// Same-project Jaccard ≥ 0.88 retires prior unsuperseded durable twins.
+    /// Locked others stay live. Returns candidate frame IDs; broker still supersedes + flushes.
+    package static func selectSupersedeFrameIDs(
+        sessionID: UUID?,
+        newFrameId: UInt64,
+        content: String,
+        metadata: [String: String],
+        documents: [Candidate],
+        nowMs: Int64
+    ) -> [UInt64] {
+        guard isAutoSupersedeEligible(sessionID: sessionID, metadata: metadata, nowMs: nowMs) else {
+            return []
+        }
+        let info = MemorySemantics.parse(metadata: metadata, nowMs: nowMs)
+        guard let project = info.project else { return [] }
+
+        var selected: [UInt64] = []
+        selected.reserveCapacity(min(documents.count, autoSupersedeMaxMatches))
+        for document in documents {
+            guard selected.count < autoSupersedeMaxMatches else { break }
+            guard document.frameId != newFrameId else { continue }
+            let other = MemorySemantics.parse(metadata: document.metadata, nowMs: nowMs)
+            guard other.type == info.type else { continue }
+            guard other.project == project else { continue }
+            guard other.durability == .durable else { continue }
+            let similarity = MemorySemantics.similarity(lhs: content, rhs: document.text)
+            guard similarity >= autoSupersedeSimilarityThreshold else { continue }
+            selected.append(document.frameId)
+        }
+        return selected
+    }
+}

--- a/Sources/Wax/Broker/SessionOpenAssembly.swift
+++ b/Sources/Wax/Broker/SessionOpenAssembly.swift
@@ -54,6 +54,19 @@ package enum SessionOpenAssembly {
         return result
     }
 
+    /// True only when compacting a found handoff that still has content or tasks.
+    /// Empty `found=true` bodies hide without a tokenizer, matching the pre-peel early return.
+    package static func needsTokenizer(_ value: AgentBrokerValue) -> Bool {
+        guard let handoff = value.objectValue,
+              handoff["found"]?.boolValue == true
+        else {
+            return false
+        }
+        let content = handoff["content"]?.stringValue ?? ""
+        let tasks = handoff["pending_tasks"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        return !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !tasks.isEmpty
+    }
+
     package static func compactHandoff(
         _ value: AgentBrokerValue,
         recallQuery: String?,
@@ -68,8 +81,7 @@ package enum SessionOpenAssembly {
         let originalContent = handoff["content"]?.stringValue ?? ""
         let originalTasks = handoff["pending_tasks"]?.arrayValue?.compactMap(\.stringValue) ?? []
         let trimmedQuery = recallQuery?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let emptyBody = originalContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && originalTasks.isEmpty
+        let emptyBody = !needsTokenizer(value)
         if emptyBody {
             return .object([
                 "found": .bool(false),

--- a/Sources/Wax/Broker/SessionOpenAssembly.swift
+++ b/Sources/Wax/Broker/SessionOpenAssembly.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// Session-open bootstrap assembly: bounded handoff projection and wire payload.
+/// Resume vs start-new stays in ``SessionOpenDecision``. Store I/O stays on the broker.
+package enum SessionOpenAssembly {
+    package struct Tokenizer: Sendable {
+        package var count: @Sendable (String) async -> Int
+
+        package init(count: @escaping @Sendable (String) async -> Int) {
+            self.count = count
+        }
+
+        /// Test adapter: one token per Character.
+        package static let character = Tokenizer(count: { $0.count })
+    }
+
+    /// Bound `text` to `maxTokens` while remaining a grapheme prefix of `text`.
+    ///
+    /// Encode the full string once, then take a proportional character prefix
+    /// and shrink by graphemes if that prefix is still over budget.
+    package static func tokenLimitedPrefix(
+        _ text: String,
+        tokenizer: Tokenizer,
+        maxTokens: Int
+    ) async -> String {
+        guard maxTokens > 0, !text.isEmpty else { return "" }
+        let fullCount = await tokenizer.count(text)
+        if fullCount <= maxTokens { return text }
+
+        let characters = Array(text)
+        var high = max(1, min(characters.count, (maxTokens * characters.count) / fullCount))
+        var candidate = String(characters.prefix(high))
+        var candidateCount = await tokenizer.count(candidate)
+        while candidateCount > maxTokens && high > 1 {
+            high = max(1, (high * 3) / 4)
+            candidate = String(characters.prefix(high))
+            candidateCount = await tokenizer.count(candidate)
+        }
+        return candidateCount <= maxTokens ? candidate : ""
+    }
+
+    /// Return a prefix without splitting a user-visible Unicode grapheme.
+    package static func utf8Prefix(_ text: String, maxBytes: Int) -> String {
+        guard maxBytes > 0 else { return "" }
+        var bytes = 0
+        var result = String()
+        result.reserveCapacity(min(text.utf8.count, maxBytes))
+        for character in text {
+            let characterBytes = String(character).utf8.count
+            guard bytes + characterBytes <= maxBytes else { break }
+            result.append(character)
+            bytes += characterBytes
+        }
+        return result
+    }
+
+    package static func compactHandoff(
+        _ value: AgentBrokerValue,
+        recallQuery: String?,
+        tokenizer: Tokenizer
+    ) async -> AgentBrokerValue {
+        guard let handoff = value.objectValue,
+              handoff["found"]?.boolValue == true
+        else {
+            return value
+        }
+
+        let originalContent = handoff["content"]?.stringValue ?? ""
+        let originalTasks = handoff["pending_tasks"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        let trimmedQuery = recallQuery?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let emptyBody = originalContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && originalTasks.isEmpty
+        if emptyBody {
+            return .object([
+                "found": .bool(false),
+                "relevance": .string("low"),
+                "content": .string(""),
+                "pending_tasks": .array([]),
+                "truncated": .bool(false),
+                "content_truncated": .bool(false),
+                "pending_tasks_truncated": .from(0),
+                "pending_tasks_omitted": .from(0),
+                "content_bytes": .from(0),
+                "content_tokens": .from(0),
+            ])
+        }
+        let lowRelevance = !trimmedQuery.isEmpty
+            && MemorySemantics.similarity(lhs: trimmedQuery, rhs: originalContent) < 0.15
+
+        let byteLimitedContent = utf8Prefix(
+            originalContent,
+            maxBytes: BrokerLimits.maxSessionOpenHandoffContentBytes
+        )
+        let compactContent = await tokenLimitedPrefix(
+            byteLimitedContent,
+            tokenizer: tokenizer,
+            maxTokens: BrokerLimits.maxSessionOpenHandoffContentTokens
+        )
+        let contentTruncated = compactContent != originalContent
+
+        let boundedTasks = originalTasks
+            .prefix(BrokerLimits.maxSessionOpenPendingTasks)
+            .map { task in
+                utf8Prefix(task, maxBytes: BrokerLimits.maxSessionOpenPendingTaskBytes)
+            }
+        let pendingTaskTruncations = zip(
+            originalTasks.prefix(BrokerLimits.maxSessionOpenPendingTasks),
+            boundedTasks
+        ).reduce(into: 0) { count, task in
+            if task.0 != task.1 { count += 1 }
+        }
+        let omittedTaskCount = max(0, originalTasks.count - boundedTasks.count)
+        let anyTruncated = contentTruncated || pendingTaskTruncations > 0 || omittedTaskCount > 0
+        let contentTokens = await tokenizer.count(compactContent)
+
+        var compact: [String: AgentBrokerValue] = [
+            "found": .bool(true),
+            "content": .string(compactContent),
+            "pending_tasks": .array(boundedTasks.map { .string($0) }),
+            "truncated": .bool(anyTruncated),
+            "content_truncated": .bool(contentTruncated),
+            "pending_tasks_truncated": .from(pendingTaskTruncations),
+            "pending_tasks_omitted": .from(omittedTaskCount),
+            "content_bytes": .from(compactContent.utf8.count),
+            "content_tokens": .from(contentTokens),
+        ]
+        if lowRelevance {
+            compact["relevance"] = .string("low")
+        }
+        return .object(compact)
+    }
+
+    package static func bootstrapPayload(
+        sessionID: String,
+        rebound: Bool,
+        handoff: AgentBrokerValue,
+        recall: AgentBrokerValue?
+    ) -> AgentBrokerValue {
+        let sharePrompt =
+            "This MCP connection remembers session_id (\(sessionID)); "
+            + "omit it on subsequent memory calls on this connection. "
+            + "Retain it for reconnects, explicit cross-session calls, "
+            + "and direct broker/CLI use. Host children do not get Wax tools."
+        var payload: [String: AgentBrokerValue] = [
+            "session_id": .string(sessionID),
+            "rebound": .bool(rebound),
+            "share_prompt": .string(sharePrompt),
+            "handoff": handoff,
+        ]
+        if let recall {
+            payload["recall"] = recall
+            if let warning = recall.objectValue?["warning"] {
+                payload["warning"] = warning
+            }
+        }
+        return .object(payload)
+    }
+}

--- a/Tests/WaxTests/RecallPresentTests.swift
+++ b/Tests/WaxTests/RecallPresentTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func recallPresentAgeDaysUsesWholeDaysAndClamps() {
+    #expect(RecallPresent.ageDays(createdAtMs: 0, nowMs: 10_000) == 0)
+    #expect(RecallPresent.ageDays(createdAtMs: -1, nowMs: 10_000) == 0)
+    let dayMs: Int64 = 1000 * 60 * 60 * 24
+    #expect(RecallPresent.ageDays(createdAtMs: 1_000, nowMs: 1_000 + (2 * dayMs) + 5) == 2)
+    #expect(RecallPresent.ageDays(createdAtMs: 5_000, nowMs: 4_000) == 0)
+}
+
+@Test
+func recallPresentItemKindLabelKeepsWireValues() {
+    #expect(RecallPresent.itemKindLabel(.expanded) == "expanded")
+    #expect(RecallPresent.itemKindLabel(.surrogate) == "surrogate")
+    #expect(RecallPresent.itemKindLabel(.snippet) == "snippet")
+}
+
+@Test
+func recallPresentCompactHitObjectOmitsFreshnessWhenTimestampUnknown() throws {
+    let object = RecallPresent.compactHitObject(
+        id: "durable:7",
+        text: "plain",
+        preview: nil,
+        metadata: [:],
+        score: 0.5,
+        createdAtMs: 0,
+        nowMs: 99
+    )
+    #expect(Set(object.keys) == ["id", "text", "score"])
+    #expect(object["id"]?.stringValue == "durable:7")
+    #expect(object["text"]?.stringValue == "plain")
+    #expect(object["score"]?.doubleValue == 0.5)
+    #expect(object["created_at_ms"] == nil)
+    #expect(object["age_days"] == nil)
+    #expect(object["preview"] == nil)
+}
+
+@Test
+func recallPresentCompactHitObjectKeepsExactOptionalWireKeys() throws {
+    let dayMs: Int64 = 1000 * 60 * 60 * 24
+    let createdAtMs: Int64 = 1_000
+    let nowMs = createdAtMs + (3 * dayMs)
+    let object = RecallPresent.compactHitObject(
+        id: "durable:9",
+        text: "full text",
+        preview: "preview text",
+        metadata: [
+            MemoryMetadataKeys.project: "Wax",
+            MemoryMetadataKeys.repo: "wax",
+            MemoryMetadataKeys.type: MemoryType.fact.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+            MemoryMetadataKeys.reviewed: "true",
+            MemoryMetadataKeys.confidence: "0.81",
+        ],
+        score: 0.91,
+        createdAtMs: createdAtMs,
+        nowMs: nowMs
+    )
+    #expect(Set(object.keys) == [
+        "id", "text", "score", "created_at_ms", "age_days", "preview",
+        "project", "repo", "memory_type", "durability", "reviewed", "confidence",
+    ])
+    #expect(object["created_at_ms"]?.intValue == createdAtMs)
+    #expect(object["age_days"]?.intValue == 3)
+    #expect(object["preview"]?.stringValue == "preview text")
+    #expect(object["project"]?.stringValue == "Wax")
+    #expect(object["repo"]?.stringValue == "wax")
+    #expect(object["memory_type"]?.stringValue == "fact")
+    #expect(object["durability"]?.stringValue == "durable")
+    #expect(object["reviewed"]?.boolValue == true)
+    #expect(object["confidence"]?.doubleValue == 0.81)
+}
+
+@Test
+func recallPresentRenderRecallHitKeepsWireShape() throws {
+    let sessionID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    let hit = LayeredRecall.Hit(
+        id: .working(sessionID: sessionID, frameID: 42),
+        score: 0.77,
+        text: "working hit text",
+        preview: "ignored preview",
+        metadata: [
+            MemoryMetadataKeys.project: "Wax",
+            MemoryMetadataKeys.type: MemoryType.note.rawValue,
+        ],
+        explanations: ["why-a", "why-b"],
+        timestampMs: 1_234,
+        kind: .expanded,
+        sources: [.text, .vector]
+    )
+    let nowMs: Int64 = 1_234 + (1000 * 60 * 60 * 24)
+    let compact = try #require(
+        RecallPresent.renderRecallHit(hit, rank: 3, verbose: false, nowMs: nowMs).objectValue
+    )
+    #expect(Set(compact.keys) == [
+        "id", "text", "score", "created_at_ms", "age_days", "project", "memory_type",
+        "rank", "kind", "frameId", "sources",
+    ])
+    #expect(compact["id"]?.stringValue == "working:\(sessionID.uuidString):42")
+    #expect(compact["rank"]?.intValue == 3)
+    #expect(compact["kind"]?.stringValue == "expanded")
+    #expect(compact["frameId"]?.intValue == 42)
+    #expect(compact["sources"]?.arrayValue?.compactMap(\.stringValue) == ["text", "vector"])
+    #expect(compact["preview"] == nil)
+    #expect(compact["metadata"] == nil)
+    #expect(compact["explanations"] == nil)
+
+    let verbose = try #require(
+        RecallPresent.renderRecallHit(hit, rank: 3, verbose: true, nowMs: nowMs).objectValue
+    )
+    #expect(verbose["metadata"]?.objectValue?[MemoryMetadataKeys.project]?.stringValue == "Wax")
+    #expect(verbose["explanations"]?.arrayValue?.compactMap(\.stringValue) == ["why-a", "why-b"])
+}
+
+@Test
+func recallPresentRenderLayeredMemoryHitKeepsWireShape() throws {
+    let sessionID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    let hit = LayeredRecall.Hit(
+        id: .episodic(sessionID: sessionID, frameID: 9),
+        agentID: "agent-a",
+        runID: "run-b",
+        score: 0.4,
+        text: "episodic text",
+        preview: "episodic preview",
+        metadata: [
+            MemoryMetadataKeys.repo: "wax",
+            MemoryMetadataKeys.durability: MemoryDurability.working.rawValue,
+        ],
+        explanations: ["lane"],
+        timestampMs: 0
+    )
+    let rendered = try #require(
+        RecallPresent.renderLayeredMemoryHit(hit, nowMs: 99).objectValue
+    )
+    #expect(Set(rendered.keys) == [
+        "id", "text", "score", "preview", "repo", "durability",
+        "memory_id", "horizon", "session_id", "agent_id", "run_id",
+        "frame_id", "explanations", "metadata",
+    ])
+    #expect(rendered["age_days"] == nil)
+    #expect(rendered["created_at_ms"] == nil)
+    #expect(rendered["memory_id"]?.stringValue == hit.reference)
+    #expect(rendered["horizon"]?.stringValue == "episodic")
+    #expect(rendered["session_id"]?.stringValue == sessionID.uuidString)
+    #expect(rendered["agent_id"]?.stringValue == "agent-a")
+    #expect(rendered["run_id"]?.stringValue == "run-b")
+    #expect(rendered["frame_id"]?.intValue == 9)
+    #expect(rendered["explanations"]?.arrayValue?.compactMap(\.stringValue) == ["lane"])
+    #expect(rendered["metadata"]?.objectValue?[MemoryMetadataKeys.repo]?.stringValue == "wax")
+}
+
+@Test
+func recallPresentRenderCompactLayeredMemoryHitKeepsWireShape() throws {
+    let hit = LayeredRecall.Hit(
+        id: .durable(frameID: 77),
+        score: 0.2,
+        text: "durable text",
+        preview: "durable preview",
+        metadata: [MemoryMetadataKeys.project: "Wax"],
+        explanations: ["ignored"],
+        timestampMs: 5_000
+    )
+    let rendered = try #require(
+        RecallPresent.renderCompactLayeredMemoryHit(hit, nowMs: 5_000).objectValue
+    )
+    #expect(Set(rendered.keys) == [
+        "id", "text", "score", "created_at_ms", "age_days", "preview", "project",
+        "memory_id", "frame_id",
+    ])
+    #expect(rendered["memory_id"]?.stringValue == "durable:77")
+    #expect(rendered["frame_id"]?.intValue == 77)
+    #expect(rendered["horizon"] == nil)
+    #expect(rendered["session_id"] == nil)
+    #expect(rendered["explanations"] == nil)
+    #expect(rendered["metadata"] == nil)
+}

--- a/Tests/WaxTests/RememberAssemblyTests.swift
+++ b/Tests/WaxTests/RememberAssemblyTests.swift
@@ -1,0 +1,258 @@
+import Foundation
+import Testing
+@testable import Wax
+
+/// 11/12 Jaccard on `MemorySemantics.similarity` (threshold is 0.88).
+private let originalDecision = "Prefer project-scoped recall and never auto-widen an empty project lane."
+private let similarDecision = "Prefer project-scoped recall and never auto-widen an empty project lane now."
+
+private func durableMetadata(
+    type: String = MemoryType.decision.rawValue,
+    durability: String = MemoryDurability.durable.rawValue,
+    project: String? = "wax",
+    repo: String? = "wax"
+) -> [String: String] {
+    var metadata: [String: String] = [
+        MemoryMetadataKeys.type: type,
+        MemoryMetadataKeys.durability: durability,
+    ]
+    if let project {
+        metadata[MemoryMetadataKeys.project] = project
+    }
+    if let repo {
+        metadata[MemoryMetadataKeys.repo] = repo
+    }
+    return metadata
+}
+
+private func candidate(
+    frameId: UInt64,
+    text: String,
+    type: String = MemoryType.decision.rawValue,
+    durability: String = MemoryDurability.durable.rawValue,
+    project: String = "wax"
+) -> RememberAssembly.Candidate {
+    RememberAssembly.Candidate(
+        frameId: frameId,
+        text: text,
+        metadata: durableMetadata(type: type, durability: durability, project: project, repo: project)
+    )
+}
+
+@Test
+func rememberAssemblyPayloadKeepsDurableWireShape() throws {
+    let payload = RememberAssembly.payload(
+        frameId: 42,
+        framesAdded: 1,
+        frameCount: 9,
+        pendingFrames: 2,
+        sessionID: nil,
+        metadata: durableMetadata(),
+        inferredScope: MemoryScopeContext(repoName: "inferred", projectName: "inferred"),
+        deduplicated: false,
+        searchable: true
+    )
+    let object = try #require(payload.objectValue)
+    #expect(Set(object.keys) == [
+        "status", "frame_id", "memory_id", "framesAdded", "frameCount", "pendingFrames",
+        "scope", "session_id", "memory_type", "durability", "deduplicated", "searchable",
+        "unresolved_project", "display_text", "project", "repo",
+    ])
+    #expect(object["status"]?.stringValue == "ok")
+    #expect(object["frame_id"]?.intValue == 42)
+    #expect(object["memory_id"]?.stringValue == "durable:42")
+    #expect(object["framesAdded"]?.intValue == 1)
+    #expect(object["frameCount"]?.intValue == 9)
+    #expect(object["pendingFrames"]?.intValue == 2)
+    #expect(object["scope"]?.stringValue == "durable")
+    #expect(object["session_id"] == AgentBrokerValue.null)
+    #expect(object["memory_type"]?.stringValue == "decision")
+    #expect(object["durability"]?.stringValue == "durable")
+    #expect(object["deduplicated"]?.boolValue == false)
+    #expect(object["searchable"]?.boolValue == true)
+    #expect(object["unresolved_project"]?.boolValue == false)
+    #expect(object["project"]?.stringValue == "wax")
+    #expect(object["repo"]?.stringValue == "wax")
+    #expect(object["display_text"]?.stringValue == "Remembered. 1 frame(s) added (9 total, 2 pending).")
+    #expect(object["next_action"] == nil)
+}
+
+@Test
+func rememberAssemblyPayloadUsesWorkingMemoryIDForSession() throws {
+    let sessionID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    let payload = RememberAssembly.payload(
+        frameId: 7,
+        framesAdded: 1,
+        frameCount: 3,
+        pendingFrames: 0,
+        sessionID: sessionID,
+        metadata: durableMetadata(type: MemoryType.note.rawValue, durability: MemoryDurability.working.rawValue),
+        inferredScope: MemoryScopeContext(),
+        deduplicated: true,
+        searchable: false
+    )
+    let object = try #require(payload.objectValue)
+    #expect(object["scope"]?.stringValue == "session")
+    #expect(object["session_id"]?.stringValue == sessionID.uuidString)
+    #expect(object["memory_id"]?.stringValue == "working:\(sessionID.uuidString):7")
+    #expect(object["memory_type"]?.stringValue == "note")
+    #expect(object["durability"]?.stringValue == "working")
+    #expect(object["deduplicated"]?.boolValue == true)
+    #expect(object["searchable"]?.boolValue == false)
+}
+
+@Test
+func rememberAssemblyPayloadMarksUnresolvedProjectAndNextAction() throws {
+    let payload = RememberAssembly.payload(
+        frameId: 1,
+        framesAdded: 1,
+        frameCount: 1,
+        pendingFrames: 0,
+        sessionID: nil,
+        metadata: durableMetadata(project: nil, repo: nil),
+        inferredScope: MemoryScopeContext(),
+        deduplicated: false,
+        searchable: true
+    )
+    let object = try #require(payload.objectValue)
+    #expect(object["unresolved_project"]?.boolValue == true)
+    #expect(object["project"] == nil)
+    #expect(object["repo"] == nil)
+    #expect(object["next_action"]?.stringValue == "pass project/repo or recall with scope=global")
+    #expect(
+        object["display_text"]?.stringValue
+            == "Remembered. 1 frame(s) added (1 total, 0 pending). Project unresolved; default recall will miss this unless you pass project/repo or scope=global."
+    )
+}
+
+@Test
+func rememberAssemblyPayloadFallsBackToInferredScope() throws {
+    let payload = RememberAssembly.payload(
+        frameId: 5,
+        framesAdded: 1,
+        frameCount: 5,
+        pendingFrames: 1,
+        sessionID: nil,
+        metadata: [
+            MemoryMetadataKeys.type: MemoryType.fact.rawValue,
+            MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+        ],
+        inferredScope: MemoryScopeContext(repoName: "from-repo", projectName: "from-cwd"),
+        deduplicated: false,
+        searchable: true
+    )
+    let object = try #require(payload.objectValue)
+    #expect(object["project"]?.stringValue == "from-cwd")
+    #expect(object["repo"]?.stringValue == "from-repo")
+    #expect(object["unresolved_project"]?.boolValue == false)
+}
+
+@Test
+func rememberAssemblySelectsSimilarSameProjectDurableTwin() {
+    let selected = RememberAssembly.selectSupersedeFrameIDs(
+        sessionID: nil,
+        newFrameId: 2,
+        content: similarDecision,
+        metadata: durableMetadata(),
+        documents: [
+            candidate(frameId: 1, text: originalDecision),
+            candidate(frameId: 2, text: similarDecision),
+        ],
+        nowMs: 0
+    )
+    #expect(selected == [1])
+}
+
+@Test
+func rememberAssemblySkipsSupersedeWhenSessionPresent() {
+    #expect(
+        RememberAssembly.isAutoSupersedeEligible(
+            sessionID: UUID(),
+            metadata: durableMetadata(),
+            nowMs: 0
+        ) == false
+    )
+    let selected = RememberAssembly.selectSupersedeFrameIDs(
+        sessionID: UUID(),
+        newFrameId: 2,
+        content: similarDecision,
+        metadata: durableMetadata(),
+        documents: [candidate(frameId: 1, text: originalDecision)],
+        nowMs: 0
+    )
+    #expect(selected.isEmpty)
+}
+
+@Test
+func rememberAssemblySkipsNonPolicyMemoryTypes() {
+    let selected = RememberAssembly.selectSupersedeFrameIDs(
+        sessionID: nil,
+        newFrameId: 2,
+        content: similarDecision,
+        metadata: durableMetadata(type: MemoryType.note.rawValue),
+        documents: [
+            candidate(frameId: 1, text: originalDecision, type: MemoryType.note.rawValue),
+        ],
+        nowMs: 0
+    )
+    #expect(selected.isEmpty)
+}
+
+@Test
+func rememberAssemblyRequiresSameProjectAndDurableOther() {
+    let crossProject = RememberAssembly.selectSupersedeFrameIDs(
+        sessionID: nil,
+        newFrameId: 2,
+        content: similarDecision,
+        metadata: durableMetadata(project: "alpha", repo: "alpha"),
+        documents: [candidate(frameId: 1, text: originalDecision, project: "beta")],
+        nowMs: 0
+    )
+    #expect(crossProject.isEmpty)
+
+    let lockedOther = RememberAssembly.selectSupersedeFrameIDs(
+        sessionID: nil,
+        newFrameId: 2,
+        content: similarDecision,
+        metadata: durableMetadata(),
+        documents: [
+            candidate(
+                frameId: 1,
+                text: originalDecision,
+                durability: MemoryDurability.locked.rawValue
+            ),
+        ],
+        nowMs: 0
+    )
+    #expect(lockedOther.isEmpty)
+}
+
+@Test
+func rememberAssemblyLockedNewStillSelectsDurableOther() {
+    let selected = RememberAssembly.selectSupersedeFrameIDs(
+        sessionID: nil,
+        newFrameId: 2,
+        content: similarDecision,
+        metadata: durableMetadata(durability: MemoryDurability.locked.rawValue),
+        documents: [candidate(frameId: 1, text: originalDecision)],
+        nowMs: 0
+    )
+    #expect(selected == [1])
+}
+
+@Test
+func rememberAssemblyCapsSupersedeMatchesAt32() {
+    let documents = (1...40).map { index in
+        candidate(frameId: UInt64(index), text: originalDecision)
+    }
+    let selected = RememberAssembly.selectSupersedeFrameIDs(
+        sessionID: nil,
+        newFrameId: 99,
+        content: similarDecision,
+        metadata: durableMetadata(),
+        documents: documents,
+        nowMs: 0
+    )
+    #expect(selected.count == RememberAssembly.autoSupersedeMaxMatches)
+    #expect(selected == Array(1...32).map(UInt64.init))
+}

--- a/Tests/WaxTests/SessionOpenAssemblyTests.swift
+++ b/Tests/WaxTests/SessionOpenAssemblyTests.swift
@@ -34,6 +34,34 @@ func sessionOpenAssemblyHidesEmptyHandoffBody() async throws {
 }
 
 @Test
+func sessionOpenAssemblyNeedsTokenizerOnlyWhenHandoffHasBody() {
+    #expect(
+        SessionOpenAssembly.needsTokenizer(.object(["found": .bool(false)])) == false
+    )
+    #expect(
+        SessionOpenAssembly.needsTokenizer(.object([
+            "found": .bool(true),
+            "content": .string("   "),
+            "pending_tasks": .array([]),
+        ])) == false
+    )
+    #expect(
+        SessionOpenAssembly.needsTokenizer(.object([
+            "found": .bool(true),
+            "content": .string("keep"),
+            "pending_tasks": .array([]),
+        ])) == true
+    )
+    #expect(
+        SessionOpenAssembly.needsTokenizer(.object([
+            "found": .bool(true),
+            "content": .string(""),
+            "pending_tasks": .array([.string("task")]),
+        ])) == true
+    )
+}
+
+@Test
 func sessionOpenAssemblyTruncatesHandoffToTokenBudget() async throws {
     let content = String(repeating: "a", count: BrokerLimits.maxSessionOpenHandoffContentTokens + 40)
     let compacted = await SessionOpenAssembly.compactHandoff(

--- a/Tests/WaxTests/SessionOpenAssemblyTests.swift
+++ b/Tests/WaxTests/SessionOpenAssemblyTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import Wax
+
+@Test
+func sessionOpenAssemblyPassesThroughMissingHandoff() async {
+    let missing = AgentBrokerValue.object(["found": .bool(false)])
+    let compacted = await SessionOpenAssembly.compactHandoff(
+        missing,
+        recallQuery: "anything",
+        tokenizer: .character
+    )
+    #expect(compacted == missing)
+}
+
+@Test
+func sessionOpenAssemblyHidesEmptyHandoffBody() async throws {
+    let empty = AgentBrokerValue.object([
+        "found": .bool(true),
+        "content": .string("   "),
+        "pending_tasks": .array([]),
+    ])
+    let compacted = await SessionOpenAssembly.compactHandoff(
+        empty,
+        recallQuery: nil,
+        tokenizer: .character
+    )
+    let object = try #require(compacted.objectValue)
+    #expect(object["found"]?.boolValue == false)
+    #expect(object["relevance"]?.stringValue == "low")
+    #expect(object["content"]?.stringValue == "")
+    #expect(object["pending_tasks"]?.arrayValue == [])
+    #expect(object["truncated"]?.boolValue == false)
+}
+
+@Test
+func sessionOpenAssemblyTruncatesHandoffToTokenBudget() async throws {
+    let content = String(repeating: "a", count: BrokerLimits.maxSessionOpenHandoffContentTokens + 40)
+    let compacted = await SessionOpenAssembly.compactHandoff(
+        .object([
+            "found": .bool(true),
+            "content": .string(content),
+            "pending_tasks": .array([]),
+        ]),
+        recallQuery: nil,
+        tokenizer: .character
+    )
+    let object = try #require(compacted.objectValue)
+    let compactContent = try #require(object["content"]?.stringValue)
+    #expect(compactContent.count == BrokerLimits.maxSessionOpenHandoffContentTokens)
+    #expect(object["content_truncated"]?.boolValue == true)
+    #expect(object["truncated"]?.boolValue == true)
+    #expect(object["content_tokens"]?.intValue == Int64(BrokerLimits.maxSessionOpenHandoffContentTokens))
+}
+
+@Test
+func sessionOpenAssemblyCapsPendingTasksAndTaskBytes() async throws {
+    let oversized = String(repeating: "t", count: BrokerLimits.maxSessionOpenPendingTaskBytes + 8)
+    let tasks = (1...5).map { "task-\($0)-\(oversized)" }
+    let compacted = await SessionOpenAssembly.compactHandoff(
+        .object([
+            "found": .bool(true),
+            "content": .string("keep"),
+            "pending_tasks": .array(tasks.map { .string($0) }),
+        ]),
+        recallQuery: nil,
+        tokenizer: .character
+    )
+    let object = try #require(compacted.objectValue)
+    let bounded = try #require(object["pending_tasks"]?.arrayValue)
+    #expect(bounded.count == BrokerLimits.maxSessionOpenPendingTasks)
+    #expect(object["pending_tasks_omitted"]?.intValue == 2)
+    #expect(object["pending_tasks_truncated"]?.intValue == Int64(BrokerLimits.maxSessionOpenPendingTasks))
+    for task in bounded {
+        let text = try #require(task.stringValue)
+        #expect(text.utf8.count <= BrokerLimits.maxSessionOpenPendingTaskBytes)
+    }
+}
+
+@Test
+func sessionOpenAssemblyMarksLowRelevanceForUnrelatedRecallQuery() async {
+    let compacted = await SessionOpenAssembly.compactHandoff(
+        .object([
+            "found": .bool(true),
+            "content": .string("ship waxmcp 0.1.41 homebrew sha"),
+            "pending_tasks": .array([]),
+        ]),
+        recallQuery: "zzzz-unrelated-query-qqqq",
+        tokenizer: .character
+    )
+    #expect(compacted.objectValue?["relevance"]?.stringValue == "low")
+}
+
+@Test
+func sessionOpenAssemblyUtf8PrefixDoesNotSplitGrapheme() {
+    let flag = "🇺🇸"
+    #expect(SessionOpenAssembly.utf8Prefix(flag, maxBytes: 1).isEmpty)
+    #expect(SessionOpenAssembly.utf8Prefix(flag + "x", maxBytes: flag.utf8.count) == flag)
+    #expect(SessionOpenAssembly.utf8Prefix("abc", maxBytes: 2) == "ab")
+}
+
+@Test
+func sessionOpenAssemblyBootstrapPayloadKeepsWireShape() throws {
+    let recall = AgentBrokerValue.object([
+        "query": .string("q"),
+        "warning": .string("hybrid fell back to text"),
+    ])
+    let payload = SessionOpenAssembly.bootstrapPayload(
+        sessionID: "SID",
+        rebound: true,
+        handoff: .object(["found": .bool(false)]),
+        recall: recall
+    )
+    let object = try #require(payload.objectValue)
+    #expect(Set(object.keys) == [
+        "session_id", "rebound", "share_prompt", "handoff", "recall", "warning",
+    ])
+    #expect(object["session_id"]?.stringValue == "SID")
+    #expect(object["rebound"]?.boolValue == true)
+    #expect(object["share_prompt"]?.stringValue?.contains("SID") == true)
+    #expect(object["warning"]?.stringValue == "hybrid fell back to text")
+}


### PR DESCRIPTION
## Summary
- Peel `session_open` handoff compact + bootstrap payload into `SessionOpenAssembly`.
- Peel remember wire payload + durable supersede selection into `RememberAssembly` (broker still owns `supersede`/`flush`).
- Peel recall/search/compact hit rendering into `RecallPresent`.
- Move `exportMarkdownProjection` and export-only helpers onto `AgentBrokerService+Markdown.swift`.
- `handle(_:)` remains the caller-facing seam. MCP/CLI wire keys unchanged.

## Test plan
- [x] `swift test --filter RememberAssemblyTests|RecallPresentTests|SessionOpenAssemblyTests` (24 passed)
- [x] `swift test --traits MCPServer --filter sessionOpen|markdownExport|brokerRememberAppendsSessionEventBeforeFlushingMemory|brokerHandoffRecordsEventBeforeCommittingHandoffFrame|brokerHandoffAppendsEventBeforeSavingHandoffManifest|brokerKnowledgeCaptureStagesMemoryBeforeGraphWrites` (38 passed)
- [ ] PR CI `production_readiness_gates.sh`

Residual: auto-supersede now caps 32 policy matches, not 32 successful `supersede`s. `sessionOpen` I/O and `corpusSearch` stay on the actor.