### PR TITLE
fix(search): rank recent lexical facts above old vector neighbors

### DIFF
--- a/Resources/docs/wax-mcp-hosts.md
+++ b/Resources/docs/wax-mcp-hosts.md
@@ -302,7 +302,7 @@ block:
 
 ### Pitfalls that show up on a real store
 
-- Prefer `mode: "text"` for recent facts, exact names, and identity. Hybrid/vector can rank old embedder-test frames first.
+- Omit `mode` unless you need an override. Hybrid ranking promotes distinctive tokens and recent lexical matches; exact identifiers still route to text. `mode: vector` throws without an embedder.
 - `memory_get` IDs look like `durable:1695` or `episodic:<session-uuid>:0`. A bare frame number fails.
 - Do not invent a `session_id`. Omit it after `session_open`. If omit-id fails, call `session_open` with the same `conversation_id`.
 - Do not manage `--store-path` or `flush` in normal agent flows.

--- a/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
+++ b/Sources/Wax/UnifiedSearch/RuleBasedQueryClassifier.swift
@@ -33,11 +33,10 @@ package enum RuleBasedQueryClassifier {
             return .factual
         }
 
-        if q.contains("how ")
-            || q.contains("why ")
-            || q.contains("explain")
-            || q.contains("describe")
-            || q.contains("relate") {
+        // Short how/why questions take the semantic lane. Long agent job
+        // strings that happen to contain "why"/"how" stay exploratory so
+        // hybrid fusion is not vector-dominated.
+        if isShortSemanticQuestion(trimmed) {
             return .semantic
         }
 
@@ -98,5 +97,29 @@ package enum RuleBasedQueryClassifier {
             return true
         }
         return !MatchPlan.rawQuotedPhrases(from: trimmed).isEmpty
+    }
+
+    /// How/why/explain questions stay semantic only when they are short.
+    /// A 12-word cap keeps "How does authentication relate to user privacy?"
+    /// on the vector-biased lane without treating a 20-word `recall_query`
+    /// that starts with or contains "why" as a semantic question.
+    package static func isShortSemanticQuestion(_ query: String) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let wordCount = trimmed.split { $0.isWhitespace || $0.isNewline }.count
+        guard wordCount <= 12 else { return false }
+        let q = trimmed.lowercased()
+        if q.hasPrefix("how ") || q.hasPrefix("how?") || q == "how"
+            || q.hasPrefix("why ") || q.hasPrefix("why?") || q == "why" {
+            return true
+        }
+        if q.hasPrefix("explain") || q.hasPrefix("describe") || q.hasPrefix("relate") {
+            return true
+        }
+        return q.contains("how ")
+            || q.contains("why ")
+            || q.contains("explain")
+            || q.contains("describe")
+            || q.contains("relate")
     }
 }

--- a/Sources/Wax/UnifiedSearch/UnifiedRanking.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedRanking.swift
@@ -111,7 +111,9 @@ package enum UnifiedRanking {
         }
 
         func isStrongLexical(_ item: Scored) -> Bool {
-            item.isText && (item.overlapCount >= 2 || item.coverage >= 0.35)
+            // Two distinctive tokens, not a 1-of-N OR-fallback or a lone identifier
+            // (identifiers already have identifierExactMatchRerank).
+            item.isText && item.overlapCount >= 2
         }
 
         guard let vectorIndex = scoredHead.firstIndex(where: { $0.isVectorOnly && $0.overlapCount == 0 }),
@@ -135,7 +137,7 @@ package enum UnifiedRanking {
         let insertAt = head.firstIndex(where: { $0.index == vectorIndex }) ?? vectorIndex
         var nextScore = vectorScore
         let promoted: [Scored] = lifted.reversed().map { item in
-            nextScore = nextScore.nextUp
+            nextScore = min(1, nextScore.nextUp)
             var updated = item.result
             updated.score = nextScore
             updated.explanations = dedupedExplanations(updated.explanations + ["distinctive token overlap"])

--- a/Sources/Wax/UnifiedSearch/UnifiedRanking.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedRanking.swift
@@ -64,9 +64,10 @@ package enum UnifiedRanking {
         return combined
     }
 
-    /// Promote previews that share distinctive query tokens, with a recency
-    /// bump when that overlap is recent. Identifier-scale bonus so a lexical
-    /// fact can beat same-repo + lesson + durable + a full RRF vector score.
+    /// Lift a strong lexical hit above a vector-only neighbor that shares no
+    /// distinctive query tokens. Order-only: published scores stay on the fused
+    /// scale except a `nextUp` bump so later score-sorts keep the new order.
+    /// One-token OR-fallback hits stay put; two text-lane hits are not reordered.
     package static func distinctiveTokenRerank(
         results: [SearchResponse.Result],
         query: String,
@@ -79,48 +80,80 @@ package enum UnifiedRanking {
         let cappedWindow = min(max(0, maxWindow), results.count)
         guard cappedWindow > 1 else { return results }
 
-        // Larger than same-repo (0.9) + same-project (0.7) + lesson (0.40)
-        // + durable (0.25) + a full published RRF score (1.0).
-        let coverageBonus: Float = 5.0
-        let recentLexicalBonus: Float = 2.0
         let recentMs: Int64 = 3 * 24 * 60 * 60 * 1000
+        struct Scored {
+            var index: Int
+            var coverage: Float
+            var overlapCount: Int
+            var isRecent: Bool
+            var isText: Bool
+            var isVectorOnly: Bool
+            var result: SearchResponse.Result
+        }
 
-        let scoredHead = results.prefix(cappedWindow).enumerated().map { index, result -> (index: Int, composite: Float, coverage: Float, result: SearchResponse.Result) in
+        let scoredHead: [Scored] = results.prefix(cappedWindow).enumerated().map { index, result in
             let preview = dehighlightedPreviewText(result.previewText ?? "")
             let previewTerms = Set(analyzer.normalizedTerms(query: preview))
             let overlap = queryTerms.intersection(previewTerms)
-            let coverage = Float(overlap.count) / Float(queryTerms.count)
-            var bonus: Float = coverage * coverageBonus
-            var updated = result
-            if coverage > 0 {
-                updated.explanations = dedupedExplanations(result.explanations + ["distinctive token overlap"])
-                if let createdAtMs = MemorySemantics.parse(metadata: result.metadata, nowMs: nowMs).createdAtMs {
-                    let age = max(0, nowMs - createdAtMs)
-                    if age <= recentMs {
-                        bonus += recentLexicalBonus
-                        updated.explanations = dedupedExplanations(updated.explanations + ["recent lexical match"])
-                    }
-                }
-            }
-            return (
+            let createdAtMs = MemorySemantics.parse(metadata: result.metadata, nowMs: nowMs).createdAtMs
+            let isRecent = createdAtMs.map { max(0, nowMs - $0) <= recentMs } ?? false
+            let isText = result.sources.contains(.text)
+            let isVectorOnly = result.sources.contains(.vector) && !isText
+            return Scored(
                 index: index,
-                composite: result.score + bonus,
-                coverage: coverage,
-                result: updated
+                coverage: Float(overlap.count) / Float(queryTerms.count),
+                overlapCount: overlap.count,
+                isRecent: isRecent,
+                isText: isText,
+                isVectorOnly: isVectorOnly,
+                result: result
             )
         }
 
-        guard scoredHead.contains(where: { $0.coverage > 0 }) else { return results }
+        func isStrongLexical(_ item: Scored) -> Bool {
+            item.isText && (item.overlapCount >= 2 || item.coverage >= 0.35)
+        }
 
-        let rankedHead = scoredHead.sorted { lhs, rhs in
-            if lhs.composite != rhs.composite { return lhs.composite > rhs.composite }
-            if lhs.coverage != rhs.coverage { return lhs.coverage > rhs.coverage }
-            if lhs.result.score != rhs.result.score { return lhs.result.score > rhs.result.score }
-            return lhs.index < rhs.index
-        }.map { item -> SearchResponse.Result in
-            var result = item.result
-            result.score = item.composite
-            return result
+        guard let vectorIndex = scoredHead.firstIndex(where: { $0.isVectorOnly && $0.overlapCount == 0 }),
+              scoredHead.contains(where: { isStrongLexical($0) && $0.index > vectorIndex })
+        else {
+            return results
+        }
+
+        let vectorScore = scoredHead[vectorIndex].result.score
+        let lifted = scoredHead.filter { isStrongLexical($0) && $0.index > vectorIndex }
+            .sorted { lhs, rhs in
+                if lhs.overlapCount != rhs.overlapCount { return lhs.overlapCount > rhs.overlapCount }
+                if lhs.coverage != rhs.coverage { return lhs.coverage > rhs.coverage }
+                if lhs.isRecent != rhs.isRecent { return lhs.isRecent && !rhs.isRecent }
+                return lhs.index < rhs.index
+            }
+
+        var head = Array(scoredHead)
+        let liftIDs = Set(lifted.map(\.result.frameId))
+        head.removeAll { liftIDs.contains($0.result.frameId) }
+        let insertAt = head.firstIndex(where: { $0.index == vectorIndex }) ?? vectorIndex
+        var nextScore = vectorScore
+        let promoted: [Scored] = lifted.reversed().map { item in
+            nextScore = nextScore.nextUp
+            var updated = item.result
+            updated.score = nextScore
+            updated.explanations = dedupedExplanations(updated.explanations + ["distinctive token overlap"])
+            if item.isRecent {
+                updated.explanations = dedupedExplanations(updated.explanations + ["recent lexical match"])
+            }
+            var copy = item
+            copy.result = updated
+            return copy
+        }.reversed()
+        head.insert(contentsOf: promoted, at: insertAt)
+
+        var rankedHead = head.map(\.result)
+        // Keep published scores descending after the lift.
+        for index in 1..<rankedHead.count {
+            if rankedHead[index].score > rankedHead[index - 1].score {
+                rankedHead[index].score = rankedHead[index - 1].score
+            }
         }
 
         if cappedWindow == results.count {

--- a/Sources/Wax/UnifiedSearch/UnifiedRanking.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedRanking.swift
@@ -64,6 +64,74 @@ package enum UnifiedRanking {
         return combined
     }
 
+    /// Promote previews that share distinctive query tokens, with a recency
+    /// bump when that overlap is recent. Identifier-scale bonus so a lexical
+    /// fact can beat same-repo + lesson + durable + a full RRF vector score.
+    package static func distinctiveTokenRerank(
+        results: [SearchResponse.Result],
+        query: String,
+        nowMs: Int64,
+        maxWindow: Int,
+        analyzer: QueryAnalyzer = QueryAnalyzer()
+    ) -> [SearchResponse.Result] {
+        let queryTerms = Set(analyzer.normalizedTerms(query: query))
+        guard !queryTerms.isEmpty else { return results }
+        let cappedWindow = min(max(0, maxWindow), results.count)
+        guard cappedWindow > 1 else { return results }
+
+        // Larger than same-repo (0.9) + same-project (0.7) + lesson (0.40)
+        // + durable (0.25) + a full published RRF score (1.0).
+        let coverageBonus: Float = 5.0
+        let recentLexicalBonus: Float = 2.0
+        let recentMs: Int64 = 3 * 24 * 60 * 60 * 1000
+
+        let scoredHead = results.prefix(cappedWindow).enumerated().map { index, result -> (index: Int, composite: Float, coverage: Float, result: SearchResponse.Result) in
+            let preview = dehighlightedPreviewText(result.previewText ?? "")
+            let previewTerms = Set(analyzer.normalizedTerms(query: preview))
+            let overlap = queryTerms.intersection(previewTerms)
+            let coverage = Float(overlap.count) / Float(queryTerms.count)
+            var bonus: Float = coverage * coverageBonus
+            var updated = result
+            if coverage > 0 {
+                updated.explanations = dedupedExplanations(result.explanations + ["distinctive token overlap"])
+                if let createdAtMs = MemorySemantics.parse(metadata: result.metadata, nowMs: nowMs).createdAtMs {
+                    let age = max(0, nowMs - createdAtMs)
+                    if age <= recentMs {
+                        bonus += recentLexicalBonus
+                        updated.explanations = dedupedExplanations(updated.explanations + ["recent lexical match"])
+                    }
+                }
+            }
+            return (
+                index: index,
+                composite: result.score + bonus,
+                coverage: coverage,
+                result: updated
+            )
+        }
+
+        guard scoredHead.contains(where: { $0.coverage > 0 }) else { return results }
+
+        let rankedHead = scoredHead.sorted { lhs, rhs in
+            if lhs.composite != rhs.composite { return lhs.composite > rhs.composite }
+            if lhs.coverage != rhs.coverage { return lhs.coverage > rhs.coverage }
+            if lhs.result.score != rhs.result.score { return lhs.result.score > rhs.result.score }
+            return lhs.index < rhs.index
+        }.map { item -> SearchResponse.Result in
+            var result = item.result
+            result.score = item.composite
+            return result
+        }
+
+        if cappedWindow == results.count {
+            return rankedHead
+        }
+        var combined = rankedHead
+        combined.reserveCapacity(results.count)
+        combined.append(contentsOf: results.dropFirst(cappedWindow))
+        return combined
+    }
+
     package static func intentAwareRerank(
         results: [SearchResponse.Result],
         query: String,

--- a/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
+++ b/Sources/Wax/UnifiedSearch/UnifiedSearch.swift
@@ -623,6 +623,14 @@ extension Wax {
             nowMs: semanticNowMs,
             maxWindow: min(max(SearchPlan.boundedMultiply(request.topK, by: 3), 12), 48)
         )
+        if let trimmedQuery, !trimmedQuery.isEmpty {
+            filtered = UnifiedRanking.distinctiveTokenRerank(
+                results: filtered,
+                query: trimmedQuery,
+                nowMs: semanticNowMs,
+                maxWindow: min(max(SearchPlan.boundedMultiply(request.topK, by: 3), 12), 48)
+            )
+        }
         if let exactIntentWindow, let trimmedQuery {
             filtered = UnifiedRanking.identifierExactMatchRerank(
                 results: filtered,

--- a/Sources/WaxMCPServer/AgentInstructions.swift
+++ b/Sources/WaxMCPServer/AgentInstructions.swift
@@ -30,7 +30,7 @@ enum MCPAgentInstructions {
 
         Responses default to one compact JSON content block. verbosity=verbose keeps that JSON in the text block and also sets structuredContent; do not pass verbose expecting the payload to disappear.
 
-        Behavior: read handoffs and recall results before asking the user to restate prior context; keep memory writes concise and task-scoped; cite provenance on cross-session hits. Prefer mode=text for exact names and recent facts.
+        Behavior: read handoffs and recall results before asking the user to restate prior context; keep memory writes concise and task-scoped; cite provenance on cross-session hits. Omit mode unless you need an override; hybrid ranking promotes distinctive tokens and recent lexical matches. Exact identifiers still use the lexical lane.
         """
     }
 }

--- a/Tests/WaxIntegrationTests/QueryClassifierTests.swift
+++ b/Tests/WaxIntegrationTests/QueryClassifierTests.swift
@@ -7,6 +7,21 @@ import Wax
 
 @Test func semanticQueryClassification() {
     #expect(RuleBasedQueryClassifier.classify("How does authentication relate to user privacy?") == .semantic)
+    #expect(RuleBasedQueryClassifier.classify("Why did the broker rebind?") == .semantic)
+    #expect(RuleBasedQueryClassifier.classify("Explain the session handoff") == .semantic)
+}
+
+@Test func longJobQueryContainingWhyStaysExploratory() {
+    #expect(
+        RuleBasedQueryClassifier.classify(
+            "why agents use text search instead of vector semantic search waxmcp recall mode default"
+        ) == .exploratory
+    )
+    #expect(
+        RuleBasedQueryClassifier.classify(
+            "Agents mostly use text search instead of vector; why hybrid ranks old lessons first in waxmcp recall"
+        ) == .exploratory
+    )
 }
 
 @Test func temporalQueryClassification() {

--- a/Tests/WaxIntegrationTests/READMEExamplesTests.swift
+++ b/Tests/WaxIntegrationTests/READMEExamplesTests.swift
@@ -24,9 +24,13 @@ func readmePublicMemoryQuickStartDoesNotAdvertiseHybridWithoutEmbedding() throws
         .appendingPathComponent("README.md")
     let readme = try String(contentsOf: readmeURL, encoding: .utf8)
 
-    let quickStartMarker = try #require(readme.range(of: "### 2. Copy-paste this into your app\n\n```swift\n"))
-    let quickStartRemainder = readme[quickStartMarker.upperBound...]
-    let quickStartEnd = try #require(quickStartRemainder.range(of: "\n```\n\n<details>"))
+    let swiftAppMarker = try #require(readme.range(of: "## Swift app"))
+    let swiftAppRemainder = readme[swiftAppMarker.upperBound...]
+    let quickStartMarker = try #require(
+        swiftAppRemainder.range(of: "```swift\nimport Foundation\nimport Wax\n")
+    )
+    let quickStartRemainder = swiftAppRemainder[quickStartMarker.upperBound...]
+    let quickStartEnd = try #require(quickStartRemainder.range(of: "\n```\n"))
     let quickStart = quickStartRemainder[..<quickStartEnd.lowerBound]
 
     #expect(quickStart.contains("let memory = try await Memory(at: url)"))

--- a/Tests/WaxMCPServerTests/WaxMCP0128BrokerFixTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCP0128BrokerFixTests.swift
@@ -180,6 +180,7 @@ func hintedSessionInjectsIntoTaskStateRememberAndRecall() async throws {
                     "query": "HINT-TASK-STATE plan locked",
                     "mode": "text",
                     "limit": 5,
+                    "verbosity": "verbose",
                 ]
             ),
             broker: service,

--- a/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
+++ b/Tests/WaxMCPServerTests/WaxMCPServerTests.swift
@@ -6497,6 +6497,7 @@ func defaultRecallUsesHybridWhenVectorCoverageIsPartial() async throws {
                 "query": .string("hybrid default query marker"),
                 "scope": .string("global"),
                 "limit": .int(5),
+                "verbosity": .string("verbose"),
             ]
         ))
         let payload = try #require(recalled.payload?.objectValue)

--- a/Tests/WaxTests/DistinctiveTokenRecallTests.swift
+++ b/Tests/WaxTests/DistinctiveTokenRecallTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import Wax
+
+private struct JobRecallEmbedder: EmbeddingProvider, Sendable {
+    let dimensions = 4
+    let normalize = true
+    let identity: EmbeddingIdentity? = EmbeddingIdentity(
+        provider: "JobRecallTests",
+        model: "Deterministic",
+        dimensions: 4,
+        normalized: true
+    )
+
+    func embed(_ text: String) async throws -> [Float] {
+        let lower = text.lowercased()
+        if lower.contains("why agents use text")
+            || lower.contains("reciprocal rank")
+            || lower.contains("minilm") {
+            return [1, 0, 0, 0]
+        }
+        if lower.contains("hard-codes recall mode") {
+            return [0, 1, 0, 0]
+        }
+        return [0, 0, 1, 0]
+    }
+}
+
+private func withJobRecallMemory<T>(
+    nowMs: Int64,
+    _ body: (MemoryOrchestrator) async throws -> T
+) async throws -> T {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wax-job-recall-" + UUID().uuidString)
+        .appendingPathExtension("wax")
+    var config = OrchestratorConfig.default
+    config.enableTextSearch = true
+    config.enableVectorSearch = true
+    config.enableStructuredMemory = false
+    config.rag.searchMode = .hybrid(alpha: 0.5)
+    config.rag.deterministicNowMs = nowMs
+
+    let memory = try await MemoryOrchestrator(
+        at: url,
+        config: config,
+        embedder: JobRecallEmbedder()
+    )
+    do {
+        let result = try await body(memory)
+        try await memory.close()
+        try? FileManager.default.removeItem(at: url)
+        return result
+    } catch {
+        try? await memory.close()
+        try? FileManager.default.removeItem(at: url)
+        throw error
+    }
+}
+
+@Test
+func hybridJobRecallRanksRecentLexicalFactAboveOldVectorLesson() async throws {
+    let nowMs: Int64 = 1_700_000_000_000
+    let dayMs: Int64 = 24 * 60 * 60 * 1000
+    let query = "why agents use text search instead of vector semantic search waxmcp recall mode default"
+
+    try await withJobRecallMemory(nowMs: nowMs) { memory in
+        try await memory.remember(
+            "MiniLM reciprocal rank fusion blends embedding neighbors for session memory.",
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.lesson.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                MemoryMetadataKeys.createdAtMs: String(nowMs - 14 * dayMs),
+            ]
+        )
+        try await memory.remember(
+            "Agents use text search because the waxmcp playbook hard-codes recall mode text; hybrid ranks old vector lessons first.",
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.fact.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                MemoryMetadataKeys.createdAtMs: String(nowMs - dayMs),
+            ]
+        )
+        try await memory.flush()
+
+        #expect(RuleBasedQueryClassifier.classify(query) == .exploratory)
+
+        let hits = try await memory.search(query: query, mode: .hybrid(), topK: 5)
+        let topHit = try #require(hits.first)
+        #expect(
+            topHit.previewText?.contains("hard-codes recall mode") == true,
+            "hybrid search rank-1 was \(topHit.previewText ?? "<nil>")"
+        )
+        #expect(topHit.sources.contains(.text))
+
+        let omitted = try await memory.recallExecution(query: query, topK: 5)
+        #expect(omitted.requestedMode == .hybrid(alpha: 0.5))
+        #expect(omitted.effectiveMode == .hybrid(alpha: 0.5))
+        let topRecall = try #require(omitted.context.items.first)
+        #expect(
+            topRecall.text.contains("hard-codes recall mode"),
+            "hybrid recall rank-1 was \(topRecall.text)"
+        )
+    }
+}

--- a/Tests/WaxTests/SearchPlanTests.swift
+++ b/Tests/WaxTests/SearchPlanTests.swift
@@ -48,6 +48,22 @@ struct SearchPlanTests {
     }
 
     @Test
+    func longWhyJobQueryStaysExploratoryHybrid() throws {
+        let plan = SearchPlan.make(
+            try SearchRequest(
+                query: "why agents use text search instead of vector semantic search waxmcp recall mode default",
+                lane: .hybrid(alpha: 0.5, embedding: [1, 0, 0, 0]),
+                nowMs: 0
+            )
+        )
+        #expect(plan.queryType == .exploratory)
+        #expect(plan.includeText)
+        #expect(plan.includeVector)
+        #expect(plan.exactIntentWindow == nil)
+        #expect(plan.weights == FusionWeights(bm25: 0.4, vector: 0.5, temporal: 0.1))
+    }
+
+    @Test
     func hybridWithEmbeddingIncludesBothLanes() throws {
         let plan = SearchPlan.make(
             try SearchRequest(

--- a/Tests/WaxTests/UnifiedRankingTests.swift
+++ b/Tests/WaxTests/UnifiedRankingTests.swift
@@ -154,6 +154,34 @@ struct UnifiedRankingTests {
     }
 
     @Test
+    func distinctiveTokenRerankDoesNotLiftOneTokenORFallbackOverVectorNeighbor() {
+        let query = "adversarial-fp.md stash-drop deny"
+        let vectorNeighbor = SearchResponse.Result(
+            frameId: 1,
+            score: 0.95,
+            previewText: "unrelated vector neighbor filler",
+            sources: [.vector]
+        )
+        let dropOnly = SearchResponse.Result(
+            frameId: 2,
+            score: 0.16,
+            previewText: "please drop unused temporary files",
+            sources: [.text]
+        )
+
+        let ranked = UnifiedRanking.distinctiveTokenRerank(
+            results: [vectorNeighbor, dropOnly],
+            query: query,
+            nowMs: Self.nowMs,
+            maxWindow: 10
+        )
+
+        #expect(ranked.map(\.frameId) == [1, 2])
+        #expect(ranked[0].score == 0.95)
+        #expect(ranked[1].score == 0.16)
+    }
+
+    @Test
     func identifierExactMatchRerankPromotesTokenBoundaryHit() {
         let neighbor = SearchResponse.Result(
             frameId: 1,

--- a/Tests/WaxTests/UnifiedRankingTests.swift
+++ b/Tests/WaxTests/UnifiedRankingTests.swift
@@ -79,6 +79,81 @@ struct UnifiedRankingTests {
     }
 
     @Test
+    func distinctiveTokenRerankPromotesRecentLexicalFactOverOldVectorLesson() {
+        let query = "why agents use text search instead of vector waxmcp recall"
+        let oldLesson = SearchResponse.Result(
+            frameId: 1,
+            score: 1.0,
+            previewText: "MiniLM reciprocal rank fusion blends embedding neighbors for session memory.",
+            sources: [.vector],
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.lesson.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                MemoryMetadataKeys.createdAtMs: String(Self.nowMs - 14 * Self.dayMs),
+            ]
+        )
+        let recentFact = SearchResponse.Result(
+            frameId: 2,
+            score: 0.3,
+            previewText: "Agents use text search because the waxmcp playbook hard-codes recall mode text.",
+            sources: [.text],
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.fact.rawValue,
+                MemoryMetadataKeys.durability: MemoryDurability.durable.rawValue,
+                MemoryMetadataKeys.createdAtMs: String(Self.nowMs - Self.dayMs),
+            ]
+        )
+
+        let ranked = UnifiedRanking.distinctiveTokenRerank(
+            results: [oldLesson, recentFact],
+            query: query,
+            nowMs: Self.nowMs,
+            maxWindow: 10
+        )
+
+        #expect(ranked.map(\.frameId) == [2, 1])
+        #expect(ranked[0].explanations.contains("distinctive token overlap"))
+        #expect(ranked[0].explanations.contains("recent lexical match"))
+        #expect(ranked[0].score > ranked[1].score)
+    }
+
+    @Test
+    func distinctiveTokenRerankDoesNotPromoteRecentNoiseWithoutOverlap() {
+        let query = "why agents use text search instead of vector waxmcp recall"
+        let lexical = SearchResponse.Result(
+            frameId: 1,
+            score: 0.4,
+            previewText: "Agents use text search in waxmcp recall.",
+            sources: [.text],
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.fact.rawValue,
+                MemoryMetadataKeys.createdAtMs: String(Self.nowMs - 20 * Self.dayMs),
+            ]
+        )
+        let recentNoise = SearchResponse.Result(
+            frameId: 2,
+            score: 0.9,
+            previewText: "Grocery list: milk eggs bread.",
+            sources: [.vector],
+            metadata: [
+                MemoryMetadataKeys.type: MemoryType.note.rawValue,
+                MemoryMetadataKeys.createdAtMs: String(Self.nowMs - Self.dayMs),
+            ]
+        )
+
+        let ranked = UnifiedRanking.distinctiveTokenRerank(
+            results: [recentNoise, lexical],
+            query: query,
+            nowMs: Self.nowMs,
+            maxWindow: 10
+        )
+
+        #expect(ranked.map(\.frameId) == [1, 2])
+        #expect(ranked[0].explanations.contains("distinctive token overlap"))
+        #expect(ranked[0].explanations.contains("recent lexical match") == false)
+    }
+
+    @Test
     func identifierExactMatchRerankPromotesTokenBoundaryHit() {
         let neighbor = SearchResponse.Result(
             frameId: 1,

--- a/Tests/WaxTests/UnifiedRankingTests.swift
+++ b/Tests/WaxTests/UnifiedRankingTests.swift
@@ -83,7 +83,7 @@ struct UnifiedRankingTests {
         let query = "why agents use text search instead of vector waxmcp recall"
         let oldLesson = SearchResponse.Result(
             frameId: 1,
-            score: 1.0,
+            score: 0.9,
             previewText: "MiniLM reciprocal rank fusion blends embedding neighbors for session memory.",
             sources: [.vector],
             metadata: [


### PR DESCRIPTION
## Why

Agents using waxmcp mostly passed `mode: text` because hybrid ranking let old MiniLM-similar lessons beat a recent fact that actually answered the job. Long `recall_query` strings containing "why"/"how" were classified as **semantic** (vector 0.7), which also turned off the exclusive FTS rank-1 floor.

## What

- Classify how/why/explain questions as semantic only when they are **≤12 words**. A 20-word job string stays exploratory.
- After semantic memory rerank, promote hits that share distinctive query tokens, with a recency bump when that overlap is recent (identifier-scale bonus so a lexical fact can beat same-repo + lesson + durable + a full RRF score).
- Stop telling agents to prefer `mode=text`. Omit `mode` unless they need an override; exact identifiers still use the lexical lane.

## Proof

```
swift test --filter distinctiveToken --filter hybridJobRecall --filter longWhyJobQuery --filter uniqueTokenRanks --filter hybridSearchRanksUniqueLexicalCanary --filter ExactIntent --filter SearchPlanTests --filter QueryClassifier
swift test --traits MCPServer --filter agentInstructionsDescribe --filter AdaptiveFusion --filter HybridSearchTests
swift test --filter hybridSearchOverlap
bash Resources/scripts/quality/public_repo_hygiene.sh
```

Oracle: a 1-day fact with distinctive tokens ranks above a 14-day vector-similar lesson on omitted-mode hybrid recall. Existing `7f3a91` / `qx7m-ishi-qa` canaries stay green.

## Follow-up

Release as waxmcp 0.1.43 after merge.