### PR TITLE
Collapse fragmented host registry into MCPHostRegistry

### DIFF
--- a/Sources/Wax/Broker/MCPHostRegistry.swift
+++ b/Sources/Wax/Broker/MCPHostRegistry.swift
@@ -1,0 +1,93 @@
+/// Single host vocabulary for the hook-wiring and prime surfaces.
+///
+/// `HostHookHost` (wire-hooks), `MCPPrimeHost` (prime), and
+/// `MCPPrimeAssembly.Format` (render) each named the same hosts with
+/// slightly different membership. This module owns the canonical host list
+/// and every host-varying policy; those three shapes are thin adapters over
+/// this interface.
+package enum MCPHostRegistry {
+    package enum Host: String, Sendable, CaseIterable {
+        case claude
+        case codex
+        case grok
+        case cursor
+        case opencode
+        case openclaw
+
+        /// Hosts the wire-hooks path can merge configs for.
+        package var supportsWireHooks: Bool {
+            switch self {
+            case .claude, .codex, .grok, .cursor:
+                return true
+            case .opencode, .openclaw:
+                return false
+            }
+        }
+
+        package var startEventName: String {
+            switch self {
+            case .cursor:
+                return "sessionStart"
+            case .claude, .codex, .grok, .opencode, .openclaw:
+                return "SessionStart"
+            }
+        }
+
+        package var endEventName: String {
+            switch self {
+            case .cursor:
+                return "sessionEnd"
+            case .claude, .codex, .grok, .opencode, .openclaw:
+                return "SessionEnd"
+            }
+        }
+
+        /// Only codex scopes its prime hook behind a matcher.
+        package var primeMatcher: String? {
+            switch self {
+            case .codex:
+                return "startup|resume"
+            case .claude, .grok, .cursor, .opencode, .openclaw:
+                return nil
+            }
+        }
+
+        /// Cursor prime is opt-in; every other host always primes.
+        package func includesPrime(enableCursorStartHook: Bool) -> Bool {
+            switch self {
+            case .cursor:
+                return enableCursorStartHook
+            case .claude, .codex, .grok, .opencode, .openclaw:
+                return true
+            }
+        }
+
+        /// Only cursor needs a live-injection probe on its prime entry.
+        package var requiresLiveInjectionProbeForPrime: Bool {
+            self == .cursor
+        }
+
+        /// Render shape for prime output. Hosts without a dedicated renderer
+        /// fall back to `.json` explicitly instead of a silent nil-coalesce.
+        package var primeFormat: MCPPrimeAssembly.Format {
+            MCPPrimeAssembly.Format(rawValue: rawValue) ?? .json
+        }
+
+        /// Document shape for hook-config merge. Only cursor uses the flat
+        /// versioned document; the rest share the nested-matcher shape.
+        package var usesNestedMatcherDocument: Bool {
+            self != .cursor
+        }
+    }
+
+    /// Hosts accepted by `mcp wire-hooks`, in wiring order.
+    package static var wireHookNames: [String] {
+        Host.allCases.filter(\.supportsWireHooks).map(\.rawValue)
+    }
+
+    /// Resolve a prime render format for any host string, defaulting to
+    /// `.json` for unknown names instead of scattering `?? .json` fallbacks.
+    package static func primeFormat(hostName: String) -> MCPPrimeAssembly.Format {
+        Host(rawValue: hostName)?.primeFormat ?? .json
+    }
+}

--- a/Sources/WaxCLI/HostHookAdapters.swift
+++ b/Sources/WaxCLI/HostHookAdapters.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Wax
 
 struct HostHookJSONMember: Equatable, Sendable {
     var key: String
@@ -72,12 +73,10 @@ enum HostHookAdapterRouter {
         document: HostHookJSON,
         entries: [HostHookDesiredEntry]
     ) throws -> HostHookJSON {
-        switch host {
-        case .claude, .codex, .grok:
+        if host.registry.usesNestedMatcherDocument {
             return try NestedMatcherHostAdapter.merge(document: document, entries: entries)
-        case .cursor:
-            return try CursorHostAdapter.merge(document: document, entries: entries)
         }
+        return try CursorHostAdapter.merge(document: document, entries: entries)
     }
 }
 

--- a/Sources/WaxCLI/HostHookInstaller.swift
+++ b/Sources/WaxCLI/HostHookInstaller.swift
@@ -1,10 +1,23 @@
 import Foundation
+import Wax
 
 enum HostHookHost: String, Sendable, CaseIterable {
     case claude
     case codex
     case grok
     case cursor
+}
+
+extension HostHookHost {
+    /// Thin adapter over the canonical host vocabulary.
+    var registry: MCPHostRegistry.Host {
+        switch self {
+        case .claude: return .claude
+        case .codex: return .codex
+        case .grok: return .grok
+        case .cursor: return .cursor
+        }
+    }
 }
 
 enum HostOwnershipLevel: String, Sendable {
@@ -100,7 +113,7 @@ enum HostHookError: Error, Equatable, LocalizedError {
         case .writeFailed(let message):
             return "Host hook write failed: \(message)"
         case .unsupportedHost(let host):
-            return "Unsupported host '\(host)'. Supported: claude, codex, grok, cursor."
+            return "Unsupported host '\(host)'. Supported: \(MCPHostRegistry.wireHookNames.joined(separator: ", "))."
         case .hostConfigCountMismatch:
             return "--host and --config must be paired one-to-one."
         case .validationFailed:
@@ -141,33 +154,14 @@ enum HostHookInstaller {
         policy: HostHookInstallPolicy = .default
     ) throws -> [HostHookDesiredEntry] {
         try HostHookCommand.requireAbsolute(wrapperPath)
-        let startName: String
-        let endName: String
-        switch host {
-        case .claude, .codex, .grok:
-            startName = "SessionStart"
-            endName = "SessionEnd"
-        case .cursor:
-            startName = "sessionStart"
-            endName = "sessionEnd"
-        }
+        let registry = host.registry
+        let startName = registry.startEventName
+        let endName = registry.endEventName
 
-        let matcher: String?
-        switch host {
-        case .codex:
-            matcher = "startup|resume"
-        case .claude, .grok, .cursor:
-            matcher = nil
-        }
+        let matcher = registry.primeMatcher
 
         var entries: [HostHookDesiredEntry] = []
-        let includePrime: Bool
-        switch host {
-        case .cursor:
-            includePrime = policy.enableCursorStartHook
-        case .claude, .codex, .grok:
-            includePrime = true
-        }
+        let includePrime = registry.includesPrime(enableCursorStartHook: policy.enableCursorStartHook)
 
         if includePrime {
             entries.append(
@@ -177,7 +171,7 @@ enum HostHookInstaller {
                     command: try HostHookCommand.line(wrapperPath: wrapperPath, host: host, role: .prime),
                     matcher: matcher,
                     timeoutSeconds: 2,
-                    requiresLiveInjectionProbe: host == .cursor && policy.requiresLiveInjectionProbe
+                    requiresLiveInjectionProbe: registry.requiresLiveInjectionProbeForPrime && policy.requiresLiveInjectionProbe
                 )
             )
         }
@@ -300,15 +294,13 @@ enum HostHookInstaller {
 
 enum HostHookSchema {
     static func seed(host: HostHookHost) -> HostHookJSON {
-        switch host {
-        case .cursor:
-            return .object([
-                HostHookJSONMember(key: "version", value: .number("1")),
-                HostHookJSONMember(key: "hooks", value: .object([])),
-            ])
-        case .claude, .codex, .grok:
+        if host.registry.usesNestedMatcherDocument {
             return .object([])
         }
+        return .object([
+            HostHookJSONMember(key: "version", value: .number("1")),
+            HostHookJSONMember(key: "hooks", value: .object([])),
+        ])
     }
 
     static func validate(_ document: HostHookJSON, host: HostHookHost) throws {
@@ -316,7 +308,7 @@ enum HostHookSchema {
             throw HostHookError.malformedJSON
         }
         let version = document.value(forKey: "version")
-        if host == .cursor, version == nil {
+        if !host.registry.usesNestedMatcherDocument, version == nil {
             throw HostHookError.unknownSchemaVersion("missing")
         }
         if let version {

--- a/Sources/WaxCLI/MCPPrimeCommand.swift
+++ b/Sources/WaxCLI/MCPPrimeCommand.swift
@@ -9,6 +9,18 @@ enum MCPPrimeHost: String, CaseIterable, ExpressibleByArgument {
     case cursor
     case opencode
     case openclaw
+
+    /// Thin adapter over the canonical host vocabulary.
+    var registry: MCPHostRegistry.Host {
+        switch self {
+        case .claude: return .claude
+        case .codex: return .codex
+        case .grok: return .grok
+        case .cursor: return .cursor
+        case .opencode: return .opencode
+        case .openclaw: return .openclaw
+        }
+    }
 }
 
 enum MCPPrimeOutputFormat: String, CaseIterable, ExpressibleByArgument {
@@ -19,7 +31,7 @@ enum MCPPrimeOutputFormat: String, CaseIterable, ExpressibleByArgument {
     case cursor
 
     var assemblyFormat: MCPPrimeAssembly.Format {
-        MCPPrimeAssembly.Format(rawValue: rawValue) ?? .json
+        MCPHostRegistry.primeFormat(hostName: rawValue)
     }
 }
 

--- a/Sources/WaxCLI/MCPRunHookRunner.swift
+++ b/Sources/WaxCLI/MCPRunHookRunner.swift
@@ -98,7 +98,7 @@ enum MCPRunHookRunner {
         noEmbedder: Bool,
         embedderChoice: String
     ) -> Outcome {
-        let format = MCPPrimeAssembly.Format(rawValue: host) ?? .json
+        let format = MCPHostRegistry.primeFormat(hostName: host)
         let outcome = MCPPrimeRunner.run(
             MCPPrimeRunner.Request(
                 host: host,

--- a/Tests/WaxTests/MCPHostRegistryTests.swift
+++ b/Tests/WaxTests/MCPHostRegistryTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import Wax
+
+@Suite("MCPHostRegistry")
+struct MCPHostRegistryTests {
+    @Test func canonicalHostsCoverPrimeAndWireSurfaces() {
+        #expect(MCPHostRegistry.Host.allCases.map(\.rawValue) == ["claude", "codex", "grok", "cursor", "opencode", "openclaw"])
+    }
+
+    @Test func wireHookSurfaceIsClaudeCodexGrokCursor() {
+        #expect(MCPHostRegistry.wireHookNames == ["claude", "codex", "grok", "cursor"])
+        #expect(MCPHostRegistry.Host.claude.supportsWireHooks)
+        #expect(MCPHostRegistry.Host.cursor.supportsWireHooks)
+        #expect(!MCPHostRegistry.Host.opencode.supportsWireHooks)
+        #expect(!MCPHostRegistry.Host.openclaw.supportsWireHooks)
+    }
+
+    @Test func eventNamesAreHostShaped() {
+        #expect(MCPHostRegistry.Host.claude.startEventName == "SessionStart")
+        #expect(MCPHostRegistry.Host.claude.endEventName == "SessionEnd")
+        #expect(MCPHostRegistry.Host.cursor.startEventName == "sessionStart")
+        #expect(MCPHostRegistry.Host.cursor.endEventName == "sessionEnd")
+        #expect(MCPHostRegistry.Host.opencode.startEventName == "SessionStart")
+    }
+
+    @Test func onlyCodexScopesPrimeWithMatcher() {
+        #expect(MCPHostRegistry.Host.codex.primeMatcher == "startup|resume")
+        #expect(MCPHostRegistry.Host.claude.primeMatcher == nil)
+        #expect(MCPHostRegistry.Host.grok.primeMatcher == nil)
+        #expect(MCPHostRegistry.Host.cursor.primeMatcher == nil)
+    }
+
+    @Test func cursorPrimeIsOptInOthersAlwaysPrime() {
+        #expect(MCPHostRegistry.Host.claude.includesPrime(enableCursorStartHook: false))
+        #expect(!MCPHostRegistry.Host.cursor.includesPrime(enableCursorStartHook: false))
+        #expect(MCPHostRegistry.Host.cursor.includesPrime(enableCursorStartHook: true))
+    }
+
+    @Test func primeFormatFallsBackToJSONWithoutRenderTarget() {
+        #expect(MCPHostRegistry.Host.claude.primeFormat == .claude)
+        #expect(MCPHostRegistry.Host.codex.primeFormat == .codex)
+        #expect(MCPHostRegistry.Host.grok.primeFormat == .grok)
+        #expect(MCPHostRegistry.Host.cursor.primeFormat == .cursor)
+        #expect(MCPHostRegistry.Host.opencode.primeFormat == .json)
+        #expect(MCPHostRegistry.Host.openclaw.primeFormat == .json)
+    }
+
+    @Test func unknownHostNameFallsBackToJSON() {
+        #expect(MCPHostRegistry.primeFormat(hostName: "claude") == .claude)
+        #expect(MCPHostRegistry.primeFormat(hostName: "openclaw") == .json)
+        #expect(MCPHostRegistry.primeFormat(hostName: "nope") == .json)
+    }
+
+    @Test func onlyCursorUsesFlatDocument() {
+        #expect(MCPHostRegistry.Host.claude.usesNestedMatcherDocument)
+        #expect(MCPHostRegistry.Host.codex.usesNestedMatcherDocument)
+        #expect(MCPHostRegistry.Host.grok.usesNestedMatcherDocument)
+        #expect(!MCPHostRegistry.Host.cursor.usesNestedMatcherDocument)
+    }
+}


### PR DESCRIPTION
Three host enums drifted independently: HostHookHost (wire-hooks, 4 hosts), MCPPrimeHost (prime, 6 hosts), and MCPPrimeAssembly.Format (render, 5 targets). Adding a host meant touching installer, adapters, assembly render, and CLI enums separately, with silent .json fallbacks for unknown names.

This adds one canonical host module (Sources/Wax/Broker/MCPHostRegistry) owning event names, the codex prime matcher, cursor opt-in prime, wire-hook support, render fallback, and document shape. The existing enums become thin adapters over it. Next host = one new case.

Verification:
- New MCPHostRegistryTests (8 tests) pass
- HostHookInstaller, MCPRunHook, MCPPrime, MCPPrimeAssembly, MCPCheckpoint suites green (67 tests)
- public_repo_hygiene.sh ok

Made with [Cursor](https://cursor.com)